### PR TITLE
Add multi-key plotting and stream listening (up to 4 keys)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -113,6 +113,8 @@ pub struct App {
     pub endianness: Endianness,
     pub plot_data: Vec<f64>,            // primary key's plot data (backward compat)
     pub plot_slots: Vec<PlotSlot>,      // multi-key plot FIFO (up to MAX_PLOT_SLOTS)
+    pub listening_keys: Vec<String>,    // keys with active stream listeners (set by main loop)
+    pub siggen_keys: Vec<String>,       // keys with active signal generators (set by main loop)
     pub plot_auto_limits: bool,
     pub plot_y_min: f64,
     pub plot_y_max: f64,
@@ -209,6 +211,8 @@ impl App {
             endianness: Endianness::Little,
             plot_data: Vec::new(),
             plot_slots: Vec::new(),
+            listening_keys: Vec::new(),
+            siggen_keys: Vec::new(),
             plot_auto_limits: true,
             plot_y_min: 0.0,
             plot_y_max: 1.0,

--- a/src/app.rs
+++ b/src/app.rs
@@ -1630,7 +1630,7 @@ fn auto_bounds(data: &[f64]) -> (f64, f64) {
 
 /// Compute FFT magnitude spectrum using rustfft (O(N log N)).
 /// Returns magnitudes for the first N/2 frequency bins (DC to Nyquist).
-fn compute_fft_magnitude(data: &[f64]) -> Vec<f64> {
+pub fn compute_fft_magnitude(data: &[f64]) -> Vec<f64> {
     let n = data.len();
     if n == 0 {
         return Vec::new();

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,8 +1,28 @@
 use crate::data::{DataType, Endianness, decode_blob, encode_values, is_binary};
 use crate::redis_client::{KeyInfo, MultiRedisClient, RedisValue, StreamEntry};
+use ratatui::style::Color;
 use ratatui::widgets::ListState;
 use rustfft::{FftPlanner, num_complex::Complex};
 use std::sync::mpsc;
+
+/// Maximum number of keys that can be plotted simultaneously
+pub const MAX_PLOT_SLOTS: usize = 4;
+
+/// Colors assigned to each plot slot
+pub const PLOT_COLORS: [Color; MAX_PLOT_SLOTS] = [
+    Color::Cyan,
+    Color::Yellow,
+    Color::Green,
+    Color::Magenta,
+];
+
+/// A slot in the multi-key plot FIFO
+#[derive(Clone)]
+pub struct PlotSlot {
+    pub key_name: String,
+    pub data: Vec<f64>,
+    pub color: Color,
+}
 
 #[derive(Debug, Clone, PartialEq)]
 #[allow(dead_code)]
@@ -91,7 +111,8 @@ pub struct App {
     // Data plot
     pub data_type: DataType,
     pub endianness: Endianness,
-    pub plot_data: Vec<f64>,
+    pub plot_data: Vec<f64>,            // primary key's plot data (backward compat)
+    pub plot_slots: Vec<PlotSlot>,      // multi-key plot FIFO (up to MAX_PLOT_SLOTS)
     pub plot_auto_limits: bool,
     pub plot_y_min: f64,
     pub plot_y_max: f64,
@@ -187,6 +208,7 @@ impl App {
             data_type: DataType::UInt8,
             endianness: Endianness::Little,
             plot_data: Vec::new(),
+            plot_slots: Vec::new(),
             plot_auto_limits: true,
             plot_y_min: 0.0,
             plot_y_max: 1.0,
@@ -247,6 +269,114 @@ impl App {
             signal_gen_focus: 0,
             signal_gen_wave_idx: 0,
             signal_gen_dtype_idx: 7, // float32 index in DataType::all()
+        }
+    }
+
+    /// Toggle a key in the plot slots. Returns true if added, false if removed.
+    pub fn toggle_plot_slot(&mut self, key_name: &str) -> bool {
+        // If already plotted, remove it
+        if let Some(idx) = self.plot_slots.iter().position(|s| s.key_name == key_name) {
+            self.plot_slots.remove(idx);
+            // Reassign colors to keep them sequential
+            for (i, slot) in self.plot_slots.iter_mut().enumerate() {
+                slot.color = PLOT_COLORS[i];
+            }
+            return false;
+        }
+        // If at capacity, evict the oldest (first) slot
+        if self.plot_slots.len() >= MAX_PLOT_SLOTS {
+            self.plot_slots.remove(0);
+            for (i, slot) in self.plot_slots.iter_mut().enumerate() {
+                slot.color = PLOT_COLORS[i];
+            }
+        }
+        // Add new slot
+        let color = PLOT_COLORS[self.plot_slots.len()];
+        self.plot_slots.push(PlotSlot {
+            key_name: key_name.to_string(),
+            data: Vec::new(),
+            color,
+        });
+        true
+    }
+
+    /// Check if a key is currently in the plot slots
+    pub fn is_key_plotted(&self, key_name: &str) -> bool {
+        self.plot_slots.iter().any(|s| s.key_name == key_name)
+    }
+
+    /// Get the color assigned to a plotted key, if any
+    pub fn plot_color_for_key(&self, key_name: &str) -> Option<Color> {
+        self.plot_slots.iter().find(|s| s.key_name == key_name).map(|s| s.color)
+    }
+
+    /// Update plot data for a specific slot by key name
+    pub fn update_slot_data(&mut self, key_name: &str, value: &RedisValue) {
+        if let Some(slot) = self.plot_slots.iter_mut().find(|s| s.key_name == key_name) {
+            slot.data = match value {
+                RedisValue::String(bytes) => {
+                    decode_blob(bytes, self.data_type, self.endianness)
+                }
+                RedisValue::Stream(entries) => {
+                    extract_stream_plot_data(entries, self.data_type, self.endianness)
+                }
+                RedisValue::List(items) => {
+                    let mut data = Vec::new();
+                    for item in items {
+                        if let Ok(s) = std::str::from_utf8(item) {
+                            if let Ok(v) = s.parse::<f64>() {
+                                data.push(v);
+                                continue;
+                            }
+                        }
+                        data.extend(decode_blob(item, self.data_type, self.endianness));
+                    }
+                    data
+                }
+                RedisValue::ZSet(pairs) => {
+                    pairs.iter().map(|(_, score)| *score).collect()
+                }
+                RedisValue::Hash(pairs) => {
+                    let mut data = Vec::new();
+                    for (_, val) in pairs {
+                        if let Ok(s) = std::str::from_utf8(val) {
+                            if let Ok(v) = s.parse::<f64>() {
+                                data.push(v);
+                                continue;
+                            }
+                        }
+                        data.extend(decode_blob(val, self.data_type, self.endianness));
+                    }
+                    data
+                }
+                _ => Vec::new(),
+            };
+            // Sanitize
+            for v in &mut slot.data {
+                if !v.is_finite() {
+                    *v = 0.0;
+                }
+            }
+        }
+    }
+
+    /// Append stream entries to a specific plot slot
+    pub fn append_slot_stream_entries(&mut self, key_name: &str, new_entries: &[StreamEntry]) {
+        if let Some(slot) = self.plot_slots.iter_mut().find(|s| s.key_name == key_name) {
+            // Re-extract plot data from the newest entry
+            if let Some(entry) = new_entries.last() {
+                for (fname, fval) in &entry.fields {
+                    if fname.starts_with('_') {
+                        slot.data = decode_blob(fval, self.data_type, self.endianness);
+                        for v in &mut slot.data {
+                            if !v.is_finite() {
+                                *v = 0.0;
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
         }
     }
 
@@ -1456,4 +1586,108 @@ fn compute_fft_magnitude(data: &[f64]) -> Vec<f64> {
         .iter()
         .map(|c| c.norm() * inv_n)
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn toggle_plot_slot_adds_key() {
+        let mut app = App::new();
+        let added = app.toggle_plot_slot("mykey");
+        assert!(added);
+        assert_eq!(app.plot_slots.len(), 1);
+        assert_eq!(app.plot_slots[0].key_name, "mykey");
+        assert_eq!(app.plot_slots[0].color, PLOT_COLORS[0]);
+    }
+
+    #[test]
+    fn toggle_plot_slot_removes_key() {
+        let mut app = App::new();
+        app.toggle_plot_slot("mykey");
+        let added = app.toggle_plot_slot("mykey");
+        assert!(!added);
+        assert!(app.plot_slots.is_empty());
+    }
+
+    #[test]
+    fn toggle_plot_slot_fifo_eviction() {
+        let mut app = App::new();
+        app.toggle_plot_slot("key1");
+        app.toggle_plot_slot("key2");
+        app.toggle_plot_slot("key3");
+        app.toggle_plot_slot("key4");
+        assert_eq!(app.plot_slots.len(), 4);
+
+        // Adding a 5th should evict "key1"
+        app.toggle_plot_slot("key5");
+        assert_eq!(app.plot_slots.len(), 4);
+        assert_eq!(app.plot_slots[0].key_name, "key2");
+        assert_eq!(app.plot_slots[3].key_name, "key5");
+    }
+
+    #[test]
+    fn toggle_plot_slot_colors_reassigned_on_remove() {
+        let mut app = App::new();
+        app.toggle_plot_slot("key1");
+        app.toggle_plot_slot("key2");
+        app.toggle_plot_slot("key3");
+
+        // Remove the middle key
+        app.toggle_plot_slot("key2");
+        assert_eq!(app.plot_slots.len(), 2);
+        assert_eq!(app.plot_slots[0].key_name, "key1");
+        assert_eq!(app.plot_slots[0].color, PLOT_COLORS[0]);
+        assert_eq!(app.plot_slots[1].key_name, "key3");
+        assert_eq!(app.plot_slots[1].color, PLOT_COLORS[1]);
+    }
+
+    #[test]
+    fn is_key_plotted() {
+        let mut app = App::new();
+        assert!(!app.is_key_plotted("mykey"));
+        app.toggle_plot_slot("mykey");
+        assert!(app.is_key_plotted("mykey"));
+    }
+
+    #[test]
+    fn plot_color_for_key_returns_correct_color() {
+        let mut app = App::new();
+        app.toggle_plot_slot("key1");
+        app.toggle_plot_slot("key2");
+        assert_eq!(app.plot_color_for_key("key1"), Some(PLOT_COLORS[0]));
+        assert_eq!(app.plot_color_for_key("key2"), Some(PLOT_COLORS[1]));
+        assert_eq!(app.plot_color_for_key("nonexistent"), None);
+    }
+
+    #[test]
+    fn update_slot_data_with_string_value() {
+        let mut app = App::new();
+        app.toggle_plot_slot("mykey");
+        let value = RedisValue::String(vec![0x01, 0x02, 0x03]);
+        app.update_slot_data("mykey", &value);
+        assert_eq!(app.plot_slots[0].data, vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn fifo_eviction_preserves_data() {
+        let mut app = App::new();
+        for i in 1..=4 {
+            let name = format!("key{}", i);
+            app.toggle_plot_slot(&name);
+            let value = RedisValue::String(vec![i as u8]);
+            app.update_slot_data(&name, &value);
+        }
+
+        // Add 5th, key1 evicted
+        app.toggle_plot_slot("key5");
+        let value = RedisValue::String(vec![5]);
+        app.update_slot_data("key5", &value);
+
+        assert_eq!(app.plot_slots[0].key_name, "key2");
+        assert_eq!(app.plot_slots[0].data, vec![2.0]);
+        assert_eq!(app.plot_slots[3].key_name, "key5");
+        assert_eq!(app.plot_slots[3].data, vec![5.0]);
+    }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -300,11 +300,6 @@ impl App {
         true
     }
 
-    /// Check if a key is currently in the plot slots
-    pub fn is_key_plotted(&self, key_name: &str) -> bool {
-        self.plot_slots.iter().any(|s| s.key_name == key_name)
-    }
-
     /// Get the color assigned to a plotted key, if any
     pub fn plot_color_for_key(&self, key_name: &str) -> Option<Color> {
         self.plot_slots.iter().find(|s| s.key_name == key_name).map(|s| s.color)
@@ -771,23 +766,6 @@ impl App {
         None
     }
 
-    pub fn start_set_plot_limits(&mut self) {
-        let (y_min, y_max) = match self.plot_focus {
-            PlotFocus::Signal => self.auto_signal_bounds(),
-            PlotFocus::FFT => self.auto_fft_bounds(),
-        };
-        let label = match self.plot_focus {
-            PlotFocus::Signal => "Signal",
-            PlotFocus::FFT => "FFT",
-        };
-        self.edit_fields = vec![
-            (format!("{} Y Min", label), format!("{:.2}", y_min)),
-            (format!("{} Y Max", label), format!("{:.2}", y_max)),
-        ];
-        self.edit_focus = 0;
-        self.input_mode = InputMode::PlotLimit;
-    }
-
     pub fn apply_plot_limits(&mut self) -> Result<(), String> {
         let y_min: f64 = self.edit_fields[0]
             .1
@@ -874,23 +852,6 @@ impl App {
             }
         }
         Ok(())
-    }
-
-    pub fn start_set_x_limits(&mut self) {
-        let (x_min, x_max) = match self.plot_focus {
-            PlotFocus::Signal => self.signal_x_bounds(),
-            PlotFocus::FFT => self.fft_x_bounds(),
-        };
-        let label = match self.plot_focus {
-            PlotFocus::Signal => "Signal",
-            PlotFocus::FFT => "FFT",
-        };
-        self.edit_fields = vec![
-            (format!("{} X Min", label), format!("{:.2}", x_min)),
-            (format!("{} X Max", label), format!("{:.2}", x_max)),
-        ];
-        self.edit_focus = 0;
-        self.input_mode = InputMode::PlotLimit;
     }
 
     pub fn apply_x_limits(&mut self) -> Result<(), String> {
@@ -1703,11 +1664,11 @@ mod tests {
     }
 
     #[test]
-    fn is_key_plotted() {
+    fn key_plotted_check_via_color() {
         let mut app = App::new();
-        assert!(!app.is_key_plotted("mykey"));
+        assert!(app.plot_color_for_key("mykey").is_none());
         app.toggle_plot_slot("mykey");
-        assert!(app.is_key_plotted("mykey"));
+        assert!(app.plot_color_for_key("mykey").is_some());
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -22,6 +22,8 @@ pub struct PlotSlot {
     pub key_name: String,
     pub data: Vec<f64>,
     pub color: Color,
+    pub y_min: Option<f64>,  // None = auto
+    pub y_max: Option<f64>,  // None = auto
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -299,6 +301,8 @@ impl App {
         self.plot_slots.push(PlotSlot {
             key_name: key_name.to_string(),
             data: Vec::new(),
+            y_min: None,
+            y_max: None,
             color,
         });
         true
@@ -665,6 +669,11 @@ impl App {
                 self.fft_x_max = 0.0;
             }
         }
+        // Clear per-slot Y limits
+        for slot in &mut self.plot_slots {
+            slot.y_min = None;
+            slot.y_max = None;
+        }
     }
 
     /// Get the x-axis bounds for the signal chart.
@@ -799,61 +808,99 @@ impl App {
         Ok(())
     }
 
-    /// Open a combined plot settings popup with X and Y limits
+    /// Open plot settings popup: unified X limits + per-slot Y limits
     pub fn start_plot_settings(&mut self) {
         let (x_min, x_max) = match self.plot_focus {
             PlotFocus::Signal => self.signal_x_bounds(),
             PlotFocus::FFT => self.fft_x_bounds(),
         };
-        let (y_min, y_max) = match self.plot_focus {
-            PlotFocus::Signal => self.auto_signal_bounds(),
-            PlotFocus::FFT => self.auto_fft_bounds(),
-        };
-        let label = match self.plot_focus {
-            PlotFocus::Signal => "Signal",
-            PlotFocus::FFT => "FFT",
-        };
-        self.edit_fields = vec![
-            (format!("{} X Min", label), format!("{:.2}", x_min)),
-            (format!("{} X Max", label), format!("{:.2}", x_max)),
-            (format!("{} Y Min", label), format!("{:.2}", y_min)),
-            (format!("{} Y Max", label), format!("{:.2}", y_max)),
+        let mut fields = vec![
+            ("X Min".to_string(), format!("{:.2}", x_min)),
+            ("X Max".to_string(), format!("{:.2}", x_max)),
         ];
+        if self.plot_slots.is_empty() {
+            // No multi-key: single Y range
+            let (y_min, y_max) = if self.plot_auto_limits {
+                self.auto_signal_bounds()
+            } else {
+                (self.plot_y_min, self.plot_y_max)
+            };
+            fields.push(("Y Min".to_string(), format!("{:.2}", y_min)));
+            fields.push(("Y Max".to_string(), format!("{:.2}", y_max)));
+        } else {
+            // Per-slot Y limits
+            for slot in &self.plot_slots {
+                let auto_min = slot.data.iter().copied()
+                    .filter(|v| v.is_finite()).fold(f64::INFINITY, f64::min);
+                let auto_max = slot.data.iter().copied()
+                    .filter(|v| v.is_finite()).fold(f64::NEG_INFINITY, f64::max);
+                let y_min = slot.y_min.unwrap_or(if auto_min.is_finite() { auto_min } else { 0.0 });
+                let y_max = slot.y_max.unwrap_or(if auto_max.is_finite() { auto_max } else { 1.0 });
+                let short_name = if slot.key_name.len() > 10 {
+                    format!("{}...", &slot.key_name[..10])
+                } else {
+                    slot.key_name.clone()
+                };
+                fields.push((format!("{} Y Min", short_name), format!("{:.2}", y_min)));
+                fields.push((format!("{} Y Max", short_name), format!("{:.2}", y_max)));
+            }
+        }
+        self.edit_fields = fields;
         self.edit_focus = 0;
         self.input_mode = InputMode::PlotLimit;
     }
 
-    /// Apply combined plot settings (X + Y limits)
+    /// Apply plot settings: unified X + per-slot Y limits
     pub fn apply_plot_settings(&mut self) -> Result<(), String> {
         let x_min: f64 = self.edit_fields[0].1.trim().parse()
             .map_err(|_| "Invalid X Min".to_string())?;
         let x_max: f64 = self.edit_fields[1].1.trim().parse()
             .map_err(|_| "Invalid X Max".to_string())?;
-        let y_min: f64 = self.edit_fields[2].1.trim().parse()
-            .map_err(|_| "Invalid Y Min".to_string())?;
-        let y_max: f64 = self.edit_fields[3].1.trim().parse()
-            .map_err(|_| "Invalid Y Max".to_string())?;
         if x_min >= x_max {
             return Err("X Min must be less than X Max".to_string());
-        }
-        if y_min >= y_max {
-            return Err("Y Min must be less than Y Max".to_string());
         }
         match self.plot_focus {
             PlotFocus::Signal => {
                 self.plot_x_min = x_min;
                 self.plot_x_max = x_max;
-                self.plot_y_min = y_min;
-                self.plot_y_max = y_max;
-                self.plot_auto_limits = false;
             }
             PlotFocus::FFT => {
                 self.fft_x_min = x_min;
                 self.fft_x_max = x_max;
-                self.fft_y_min = y_min;
-                self.fft_y_max = y_max;
-                self.fft_auto_limits = false;
             }
+        }
+
+        if self.plot_slots.is_empty() {
+            // Single Y range
+            if self.edit_fields.len() >= 4 {
+                let y_min: f64 = self.edit_fields[2].1.trim().parse()
+                    .map_err(|_| "Invalid Y Min".to_string())?;
+                let y_max: f64 = self.edit_fields[3].1.trim().parse()
+                    .map_err(|_| "Invalid Y Max".to_string())?;
+                if y_min >= y_max {
+                    return Err("Y Min must be less than Y Max".to_string());
+                }
+                self.plot_y_min = y_min;
+                self.plot_y_max = y_max;
+                self.plot_auto_limits = false;
+            }
+        } else {
+            // Per-slot Y limits (fields start at index 2, 2 fields per slot)
+            for (i, slot) in self.plot_slots.iter_mut().enumerate() {
+                let base = 2 + i * 2;
+                if base + 1 < self.edit_fields.len() {
+                    let y_min: f64 = self.edit_fields[base].1.trim().parse()
+                        .map_err(|_| format!("Invalid Y Min for '{}'", slot.key_name))?;
+                    let y_max: f64 = self.edit_fields[base + 1].1.trim().parse()
+                        .map_err(|_| format!("Invalid Y Max for '{}'", slot.key_name))?;
+                    if y_min >= y_max {
+                        return Err(format!("Y Min >= Y Max for '{}'", slot.key_name));
+                    }
+                    slot.y_min = Some(y_min);
+                    slot.y_max = Some(y_max);
+                }
+            }
+            self.plot_auto_limits = false;
         }
         Ok(())
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -817,6 +817,65 @@ impl App {
         Ok(())
     }
 
+    /// Open a combined plot settings popup with X and Y limits
+    pub fn start_plot_settings(&mut self) {
+        let (x_min, x_max) = match self.plot_focus {
+            PlotFocus::Signal => self.signal_x_bounds(),
+            PlotFocus::FFT => self.fft_x_bounds(),
+        };
+        let (y_min, y_max) = match self.plot_focus {
+            PlotFocus::Signal => self.auto_signal_bounds(),
+            PlotFocus::FFT => self.auto_fft_bounds(),
+        };
+        let label = match self.plot_focus {
+            PlotFocus::Signal => "Signal",
+            PlotFocus::FFT => "FFT",
+        };
+        self.edit_fields = vec![
+            (format!("{} X Min", label), format!("{:.2}", x_min)),
+            (format!("{} X Max", label), format!("{:.2}", x_max)),
+            (format!("{} Y Min", label), format!("{:.2}", y_min)),
+            (format!("{} Y Max", label), format!("{:.2}", y_max)),
+        ];
+        self.edit_focus = 0;
+        self.input_mode = InputMode::PlotLimit;
+    }
+
+    /// Apply combined plot settings (X + Y limits)
+    pub fn apply_plot_settings(&mut self) -> Result<(), String> {
+        let x_min: f64 = self.edit_fields[0].1.trim().parse()
+            .map_err(|_| "Invalid X Min".to_string())?;
+        let x_max: f64 = self.edit_fields[1].1.trim().parse()
+            .map_err(|_| "Invalid X Max".to_string())?;
+        let y_min: f64 = self.edit_fields[2].1.trim().parse()
+            .map_err(|_| "Invalid Y Min".to_string())?;
+        let y_max: f64 = self.edit_fields[3].1.trim().parse()
+            .map_err(|_| "Invalid Y Max".to_string())?;
+        if x_min >= x_max {
+            return Err("X Min must be less than X Max".to_string());
+        }
+        if y_min >= y_max {
+            return Err("Y Min must be less than Y Max".to_string());
+        }
+        match self.plot_focus {
+            PlotFocus::Signal => {
+                self.plot_x_min = x_min;
+                self.plot_x_max = x_max;
+                self.plot_y_min = y_min;
+                self.plot_y_max = y_max;
+                self.plot_auto_limits = false;
+            }
+            PlotFocus::FFT => {
+                self.fft_x_min = x_min;
+                self.fft_x_max = x_max;
+                self.fft_y_min = y_min;
+                self.fft_y_max = y_max;
+                self.fft_auto_limits = false;
+            }
+        }
+        Ok(())
+    }
+
     pub fn start_set_x_limits(&mut self) {
         let (x_min, x_max) = match self.plot_focus {
             PlotFocus::Signal => self.signal_x_bounds(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -530,7 +530,7 @@ fn handle_normal_input(
             app.status_message = "Plot: auto limits".to_string();
         }
         KeyCode::Char('y') => {
-            app.start_set_plot_limits();
+            // Reserved — no longer used for plot limits
         }
         KeyCode::Char('f') => {
             app.toggle_fft();
@@ -570,7 +570,7 @@ fn handle_normal_input(
             app.start_new_key();
         }
         KeyCode::Char('x') => {
-            app.start_set_x_limits();
+            app.start_plot_settings();
         }
         KeyCode::Char('z') => {
             if app.current_key_info.is_some() {
@@ -881,31 +881,22 @@ fn handle_plot_limit_input(app: &mut App, code: KeyCode) {
             }
         }
         KeyCode::Enter => {
-            let is_x_limit = app.edit_fields.first()
-                .map(|(label, _)| label.contains("X Min"))
-                .unwrap_or(false);
-            let result = if is_x_limit {
-                app.apply_x_limits()
+            // Detect if this is the combined 4-field settings popup or a legacy 2-field one
+            let result = if app.edit_fields.len() == 4 {
+                app.apply_plot_settings()
             } else {
-                app.apply_plot_limits()
+                let is_x_limit = app.edit_fields.first()
+                    .map(|(label, _)| label.contains("X Min"))
+                    .unwrap_or(false);
+                if is_x_limit {
+                    app.apply_x_limits()
+                } else {
+                    app.apply_plot_limits()
+                }
             };
             match result {
                 Ok(_) => {
-                    let (label, axis, lo, hi) = if is_x_limit {
-                        match app.plot_focus {
-                            app::PlotFocus::Signal => ("Signal", "X", app.plot_x_min, app.plot_x_max),
-                            app::PlotFocus::FFT => ("FFT", "X", app.fft_x_min, app.fft_x_max),
-                        }
-                    } else {
-                        match app.plot_focus {
-                            app::PlotFocus::Signal => ("Signal", "Y", app.plot_y_min, app.plot_y_max),
-                            app::PlotFocus::FFT => ("FFT", "Y", app.fft_y_min, app.fft_y_max),
-                        }
-                    };
-                    app.status_message = format!(
-                        "{} {} limits: {:.2} to {:.2}",
-                        label, axis, lo, hi
-                    );
+                    app.status_message = "Plot settings applied".to_string();
                     app.input_mode = InputMode::Normal;
                 }
                 Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -304,6 +304,11 @@ fn run_app(
             }
 
             if let Event::Key(key) = ev {
+                // Only handle key press events — ignore release/repeat to prevent
+                // input issues with crossterm 0.28+ terminal protocols
+                if key.kind != event::KeyEventKind::Press {
+                    continue;
+                }
                 // Stop stream listener on any navigation away
                 let prev_key = app.selected_key_name().map(|s| s.to_string());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -289,7 +289,7 @@ fn run_app(
     app.connected = client.is_connected();
 
     let mut stream_listeners: Vec<StreamListener> = Vec::new();
-    let mut signal_generator: Option<SignalGenerator> = None;
+    let mut signal_generators: Vec<SignalGenerator> = Vec::new();
 
     loop {
         terminal.draw(|frame| ui::draw(frame, &mut app))?;
@@ -309,9 +309,6 @@ fn run_app(
                 if key.kind != event::KeyEventKind::Press {
                     continue;
                 }
-                // Stop stream listener on any navigation away
-                let prev_key = app.selected_key_name().map(|s| s.to_string());
-
                 match app.input_mode {
                     InputMode::Filter => handle_filter_input(&mut app, client, key.code),
                     InputMode::Confirm => handle_confirm_input(&mut app, client, key.code),
@@ -351,9 +348,14 @@ fn run_app(
                             };
                             if let Some(k) = app.selected_key_name().map(|s| s.to_string()) {
                                 let key_url = client.url_for_key(&k).to_string();
-                                signal_generator = SignalGenerator::start(&key_url, &k, app.db, config);
-                                if signal_generator.is_some() {
-                                    app.status_message = format!("Signal gen: running on '{}'", k);
+                                if let Some(sg) = SignalGenerator::start(&key_url, &k, app.db, config) {
+                                    // Evict oldest if at capacity
+                                    if signal_generators.len() >= app::MAX_PLOT_SLOTS {
+                                        let mut oldest = signal_generators.remove(0);
+                                        oldest.stop();
+                                    }
+                                    signal_generators.push(sg);
+                                    app.status_message = format!("Signal gen: running on '{}' ({}/{})", k, signal_generators.len(), app::MAX_PLOT_SLOTS);
                                 } else {
                                     app.status_message = "Signal gen: failed to start".to_string();
                                 }
@@ -368,9 +370,9 @@ fn run_app(
                             if let Some(k) = app.selected_key_name().map(|s| s.to_string()) {
                                 let added = app.toggle_plot_slot(&k);
                                 if added {
-                                    // Load current data into the new slot
-                                    if let Some(ref value) = app.current_value {
-                                        app.update_slot_data(&k, &value.clone());
+                                    // Fetch value directly from Redis for this key
+                                    if let Ok(value) = client.get_value(&k) {
+                                        app.update_slot_data(&k, &value);
                                     }
                                     app.plot_visible = true;
                                     app.status_message = format!("Plot: added '{}' ({}/{})", k, app.plot_slots.len(), app::MAX_PLOT_SLOTS);
@@ -411,25 +413,21 @@ fn run_app(
 
                         // Toggle signal generator with 'w'
                         if key.code == KeyCode::Char('w') {
-                            if signal_generator.is_some() {
-                                if let Some(mut sg) = signal_generator.take() {
+                            if let Some(k) = app.selected_key_name().map(|s| s.to_string()) {
+                                // Check if already generating on this key
+                                if let Some(idx) = signal_generators.iter().position(|sg| sg.watching_key == k) {
+                                    let mut sg = signal_generators.remove(idx);
                                     sg.stop();
+                                    app.status_message = format!("Signal gen: stopped '{}'", k);
+                                } else if app.is_viewing_stream() {
+                                    app.start_signal_gen_popup();
+                                } else {
+                                    app.status_message = "Signal gen: select a stream key first".to_string();
                                 }
-                                app.status_message = "Signal gen: stopped".to_string();
-                            } else if app.is_viewing_stream() {
-                                app.start_signal_gen_popup();
-                            } else {
-                                app.status_message = "Signal gen: select a stream key first (Enter)".to_string();
                             }
                         }
 
-                        // Stop signal generator if user navigated to a different key
-                        let new_key = app.selected_key_name().map(|s| s.to_string());
-                        if prev_key != new_key {
-                            if let Some(mut sg) = signal_generator.take() {
-                                sg.stop();
-                            }
-                        }
+                        // No longer stop generators on key navigation — they run independently
                     }
                 }
             }
@@ -453,8 +451,12 @@ fn run_app(
             }
         }
 
+        // Sync active key indicators for UI
+        app.listening_keys = stream_listeners.iter().map(|sl| sl.watching_key.clone()).collect();
+        app.siggen_keys = signal_generators.iter().map(|sg| sg.watching_key.clone()).collect();
+
         if !app.running {
-            drop(signal_generator);
+            drop(signal_generators);
             drop(stream_listeners);
             return Ok(());
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -288,7 +288,7 @@ fn run_app(
     app.refresh_keys(client);
     app.connected = client.is_connected();
 
-    let mut stream_listener: Option<StreamListener> = None;
+    let mut stream_listeners: Vec<StreamListener> = Vec::new();
     let mut signal_generator: Option<SignalGenerator> = None;
 
     loop {
@@ -358,33 +358,47 @@ fn run_app(
                     InputMode::Normal => {
                         handle_normal_input(&mut app, client, key.code, key.modifiers);
 
-                        // Toggle plot visibility with 'p'
+                        // Toggle key in plot slots with 'p'
                         if key.code == KeyCode::Char('p') {
-                            app.plot_visible = !app.plot_visible;
-                            let state = if app.plot_visible { "shown" } else { "hidden" };
-                            app.status_message = format!("Plot: {}", state);
+                            if let Some(k) = app.selected_key_name().map(|s| s.to_string()) {
+                                let added = app.toggle_plot_slot(&k);
+                                if added {
+                                    // Load current data into the new slot
+                                    if let Some(ref value) = app.current_value {
+                                        app.update_slot_data(&k, &value.clone());
+                                    }
+                                    app.plot_visible = true;
+                                    app.status_message = format!("Plot: added '{}' ({}/{})", k, app.plot_slots.len(), app::MAX_PLOT_SLOTS);
+                                } else {
+                                    if app.plot_slots.is_empty() {
+                                        app.plot_visible = false;
+                                    }
+                                    app.status_message = format!("Plot: removed '{}'", k);
+                                }
+                            }
                         }
 
                         // Toggle stream listener with 'l'
                         if key.code == KeyCode::Char('l') && app.is_viewing_stream() {
-                            if stream_listener.is_some() {
-                                // Stop
-                                if let Some(mut sl) = stream_listener.take() {
+                            if let Some(k) = app.selected_key_name().map(|s| s.to_string()) {
+                                // Check if already listening on this key
+                                if let Some(idx) = stream_listeners.iter().position(|sl| sl.watching_key == k) {
+                                    // Stop this specific listener
+                                    let mut sl = stream_listeners.remove(idx);
                                     sl.stop();
-                                }
-                                app.status_message = "Stream: stopped".to_string();
-                            } else {
-                                // Start
-                                if let (Some(k), Some(lid)) = (
-                                    app.selected_key_name().map(|s| s.to_string()),
-                                    app.last_stream_id.clone(),
-                                ) {
+                                    app.status_message = format!("Stream: stopped '{}'", k);
+                                } else {
+                                    // Start new listener
+                                    let lid = app.last_stream_id.clone().unwrap_or_else(|| "$".to_string());
                                     let key_url = client.url_for_key(&k).to_string();
-                                    stream_listener =
-                                        StreamListener::start(&key_url, &k, &lid, app.db);
-                                    if stream_listener.is_some() {
-                                        app.status_message =
-                                            format!("Stream: listening on '{}'", k);
+                                    if let Some(sl) = StreamListener::start(&key_url, &k, &lid, app.db) {
+                                        // Evict oldest if at capacity
+                                        if stream_listeners.len() >= app::MAX_PLOT_SLOTS {
+                                            let mut oldest = stream_listeners.remove(0);
+                                            oldest.stop();
+                                        }
+                                        stream_listeners.push(sl);
+                                        app.status_message = format!("Stream: listening on '{}' ({}/{})", k, stream_listeners.len(), app::MAX_PLOT_SLOTS);
                                     }
                                 }
                             }
@@ -404,12 +418,9 @@ fn run_app(
                             }
                         }
 
-                        // Stop listener/generator if user navigated to a different key
+                        // Stop signal generator if user navigated to a different key
                         let new_key = app.selected_key_name().map(|s| s.to_string());
                         if prev_key != new_key {
-                            if let Some(mut sl) = stream_listener.take() {
-                                sl.stop();
-                            }
                             if let Some(mut sg) = signal_generator.take() {
                                 sg.stop();
                             }
@@ -422,21 +433,24 @@ fn run_app(
         // Check for completed background FFT
         app.poll_fft();
 
-        // Drain any new stream entries from the background listener
-        if let Some(ref listener) = stream_listener {
+        // Drain new stream entries from all background listeners
+        for listener in &stream_listeners {
             let mut total_new = 0;
             while let Ok(entries) = listener.rx.try_recv() {
                 total_new += entries.len();
+                // Update the plot slot for this key
+                app.append_slot_stream_entries(&listener.watching_key, &entries);
+                // Also update main app state if this is the currently viewed key
                 app.append_stream_entries(entries);
             }
             if total_new > 0 {
-                app.status_message = format!("Stream: +{} entries (live)", total_new);
+                app.status_message = format!("Stream: +{} entries on '{}' (live)", total_new, listener.watching_key);
             }
         }
 
         if !app.running {
             drop(signal_generator);
-            drop(stream_listener);
+            drop(stream_listeners);
             return Ok(());
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,6 +249,8 @@ impl SignalGenerator {
                     std::thread::sleep(Duration::from_millis(500));
                     continue;
                 }
+                // Trim stream to last 100 entries
+                let _ = client.xtrim(&thread_key, 100);
                 // Advance phase by freq cycles so next entry continues seamlessly
                 time_offset += config.frequency;
                 std::thread::sleep(sleep_dur);
@@ -306,9 +308,7 @@ fn run_app(
             if let Event::Key(key) = ev {
                 // Only handle key press events — ignore release/repeat to prevent
                 // input issues with crossterm 0.28+ terminal protocols
-                if key.kind != event::KeyEventKind::Press {
-                    continue;
-                }
+                if key.kind == event::KeyEventKind::Press {
                 match app.input_mode {
                     InputMode::Filter => handle_filter_input(&mut app, client, key.code),
                     InputMode::Confirm => handle_confirm_input(&mut app, client, key.code),
@@ -430,6 +430,7 @@ fn run_app(
                         // No longer stop generators on key navigation — they run independently
                     }
                 }
+            } // if KeyEventKind::Press
             }
         }
 

--- a/src/redis_client.rs
+++ b/src/redis_client.rs
@@ -426,6 +426,17 @@ impl RedisClient {
         Ok(())
     }
 
+    pub fn xtrim(&mut self, key: &str, maxlen: usize) -> Result<()> {
+        let _: i64 = redis::cmd("XTRIM")
+            .arg(key)
+            .arg("MAXLEN")
+            .arg("~")
+            .arg(maxlen)
+            .query(&mut self.connection)
+            .context("Failed to XTRIM")?;
+        Ok(())
+    }
+
     pub fn set_ttl(&mut self, key: &str, ttl: i64) -> Result<()> {
         if ttl < 0 {
             let _: () = redis::cmd("PERSIST")

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -349,21 +349,43 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
         .map(|(i, v)| (i as f64, *v))
         .collect();
 
-    // Build data points for each plot slot
-    let slot_points: Vec<Vec<(f64, f64)>> = app
+    // Normalize each slot's data independently to 0.0-1.0 for individual Y-axes.
+    // Each waveform is auto-scaled to its own min/max range.
+    // Legend shows key name with actual [min..max] range.
+    struct SlotRender {
+        points: Vec<(f64, f64)>,
+        y_min: f64,
+        y_max: f64,
+    }
+    let slot_renders: Vec<SlotRender> = app
         .plot_slots
         .iter()
         .map(|slot| {
-            slot.data
+            let y_min = slot.data.iter().copied()
+                .filter(|v| v.is_finite())
+                .fold(f64::INFINITY, f64::min);
+            let y_max = slot.data.iter().copied()
+                .filter(|v| v.is_finite())
+                .fold(f64::NEG_INFINITY, f64::max);
+            let range = y_max - y_min;
+            let safe_range = if !range.is_finite() || range == 0.0 { 1.0 } else { range };
+            let points = slot.data
                 .iter()
                 .enumerate()
-                .map(|(i, v)| (i as f64, *v))
-                .collect()
+                .map(|(i, v)| {
+                    let normalized = if safe_range == 1.0 && !range.is_finite() {
+                        0.5 // no valid data
+                    } else {
+                        (v - y_min) / safe_range
+                    };
+                    (i as f64, normalized)
+                })
+                .collect();
+            SlotRender { points, y_min, y_max }
         })
         .collect();
 
     let (x_lo, x_hi) = if !app.plot_slots.is_empty() {
-        // Use max data length across all slots for x bounds
         let max_len = app.plot_slots.iter()
             .map(|s| s.data.len())
             .max()
@@ -380,26 +402,12 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
         app.signal_x_bounds()
     };
 
-    let (y_lo, y_hi) = if app.plot_auto_limits {
-        if !app.plot_slots.is_empty() {
-            // Unified auto bounds across all slot data
-            let all_data: Vec<f64> = app.plot_slots.iter()
-                .flat_map(|s| s.data.iter().copied())
-                .chain(app.plot_data.iter().copied())
-                .filter(|v| v.is_finite())
-                .collect();
-            if all_data.is_empty() {
-                (0.0, 1.0)
-            } else {
-                let y_min = all_data.iter().copied().fold(f64::INFINITY, f64::min);
-                let y_max = all_data.iter().copied().fold(f64::NEG_INFINITY, f64::max);
-                let range = y_max - y_min;
-                let pad = if range == 0.0 { 1.0 } else { range * 0.1 };
-                (y_min - pad, y_max + pad)
-            }
-        } else {
-            app.auto_signal_bounds()
-        }
+    // When multiple slots: Y-axis is normalized 0.0-1.0
+    // When single/no slots: use original auto/manual bounds
+    let (y_lo, y_hi) = if !app.plot_slots.is_empty() {
+        (-0.05, 1.05) // slight padding around normalized range
+    } else if app.plot_auto_limits {
+        app.auto_signal_bounds()
     } else {
         (app.plot_y_min, app.plot_y_max)
     };
@@ -427,7 +435,7 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
 
     let marker = safe_marker(area);
 
-    // Build datasets: one per plot slot, plus primary if no slots
+    // Build datasets: one per plot slot (normalized), or primary if no slots
     let mut datasets = Vec::new();
     if app.plot_slots.is_empty() {
         // Fallback: single dataset from primary plot_data
@@ -440,12 +448,14 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
     } else {
         for (i, slot) in app.plot_slots.iter().enumerate() {
             if !slot.data.is_empty() {
+                let sr = &slot_renders[i];
+                let legend_name = format!("{} [{:.1}..{:.1}]", slot.key_name, sr.y_min, sr.y_max);
                 datasets.push(Dataset::default()
-                    .name(slot.key_name.clone())
+                    .name(legend_name)
                     .marker(marker)
                     .graph_type(GraphType::Line)
                     .style(Style::default().fg(slot.color))
-                    .data(&slot_points[i]));
+                    .data(&sr.points));
             }
         }
     }
@@ -469,7 +479,7 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
         )
         .y_axis(
             Axis::default()
-                .title("Value")
+                .title(if app.plot_slots.is_empty() { "Value" } else { "Norm" })
                 .bounds([y_lo, y_hi])
                 .labels(vec![
                     Line::from(format!("{:.2}", y_lo)),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -449,7 +449,13 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
         for (i, slot) in app.plot_slots.iter().enumerate() {
             if !slot.data.is_empty() {
                 let sr = &slot_renders[i];
-                let legend_name = format!("{} [{:.1}..{:.1}]", slot.key_name, sr.y_min, sr.y_max);
+                // Truncate key name to keep legend compact
+                let short_name = if slot.key_name.len() > 12 {
+                    format!("{}...", &slot.key_name[..12])
+                } else {
+                    slot.key_name.clone()
+                };
+                let legend_name = format!("{} [{:.0}..{:.0}]", short_name, sr.y_min, sr.y_max);
                 datasets.push(Dataset::default()
                     .name(legend_name)
                     .marker(marker)
@@ -487,7 +493,8 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
                     Line::from(format!("{:.2}", y_hi)),
                 ]),
         )
-        .legend_position(Some(ratatui::widgets::LegendPosition::TopRight));
+        .legend_position(Some(ratatui::widgets::LegendPosition::TopRight))
+        .hidden_legend_constraints((Constraint::Min(0), Constraint::Min(0)));
 
     frame.render_widget(chart, area);
 
@@ -838,12 +845,13 @@ fn draw_help_popup(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn draw_plot_limit_popup(frame: &mut Frame, app: &App, area: Rect) {
-    let popup_area = centered_rect(50, 8, area);
+    let popup_height = (app.edit_fields.len() as u16) + 5; // fields + title + blank + buttons + borders
+    let popup_area = centered_rect(50, popup_height, area);
     frame.render_widget(Clear, popup_area);
 
     let mut lines: Vec<Line> = Vec::new();
     lines.push(Line::from(Span::styled(
-        "Set Y-Axis Limits",
+        "Plot Settings",
         Style::default()
             .fg(Color::Yellow)
             .add_modifier(Modifier::BOLD),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -362,10 +362,8 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
         .map(|(i, v)| (i as f64, *v))
         .collect();
 
-    // When auto-limits: use raw values with unified Y-axis across all slots
-    // When manual/per-slot limits: normalize each slot to 0.0-1.0 using its own Y range
-    let has_per_slot_limits = app.plot_slots.iter().any(|s| s.y_min.is_some());
-    let normalize = !app.plot_slots.is_empty() && (!app.plot_auto_limits || has_per_slot_limits);
+    // When multiple keys: always normalize each slot to 0.0-1.0 for individual Y scales
+    let normalize = app.plot_slots.len() > 1;
 
     struct SlotRender {
         points: Vec<(f64, f64)>,
@@ -420,12 +418,13 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
         app.signal_x_bounds()
     };
 
-    let (y_lo, y_hi) = if !app.plot_slots.is_empty() && app.plot_auto_limits {
-        // Auto: unified bounds across all slot data (raw values)
-        let all_data: Vec<f64> = app.plot_slots.iter()
-            .flat_map(|s| s.data.iter().copied())
-            .filter(|v| v.is_finite())
-            .collect();
+    let (y_lo, y_hi) = if app.plot_slots.len() > 1 {
+        // Multi-key: always normalized 0-1, per-key Y scales rendered separately
+        (-0.05, 1.05)
+    } else if !app.plot_slots.is_empty() && app.plot_auto_limits {
+        // Single slot, auto: use its actual bounds
+        let all_data: Vec<f64> = app.plot_slots[0].data.iter().copied()
+            .filter(|v| v.is_finite()).collect();
         if all_data.is_empty() {
             (0.0, 1.0)
         } else {
@@ -435,9 +434,6 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
             let pad = if range == 0.0 { 1.0 } else { range * 0.1 };
             (y_min - pad, y_max + pad)
         }
-    } else if !app.plot_slots.is_empty() {
-        // Manual: data is normalized to 0-1
-        (-0.05, 1.05)
     } else if app.plot_auto_limits {
         app.auto_signal_bounds()
     } else {
@@ -515,16 +511,21 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
                     Line::from(format!("{:.0}", x_hi)),
                 ]),
         )
-        .y_axis(
+        .y_axis(if app.plot_slots.len() > 1 {
+            // Multi-key: hide default Y-axis labels, we'll draw per-key ones
             Axis::default()
-                .title(if app.plot_slots.is_empty() || app.plot_auto_limits { "Value" } else { "Norm" })
+                .bounds([y_lo, y_hi])
+                .labels(vec![Line::from(""), Line::from(""), Line::from("")])
+        } else {
+            Axis::default()
+                .title("Value")
                 .bounds([y_lo, y_hi])
                 .labels(vec![
                     Line::from(format!("{:.2}", y_lo)),
                     Line::from(format!("{:.2}", (y_lo + y_hi) / 2.0)),
                     Line::from(format!("{:.2}", y_hi)),
-                ]),
-        )
+                ])
+        })
         .legend_position(Some(ratatui::widgets::LegendPosition::TopRight))
         .hidden_legend_constraints((Constraint::Min(0), Constraint::Min(0)));
 
@@ -533,11 +534,54 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
     // Store chart inner area for mouse hit testing (inside borders)
     let inner = Block::default().borders(Borders::ALL).inner(area);
     // Approximate: ratatui chart uses ~7 chars for y-axis labels, 2 for x-axis
-    let chart_x = inner.x + 7;
+    let y_label_width: u16 = if app.plot_slots.len() > 1 { 1 } else { 7 };
+    let chart_x = inner.x + y_label_width;
     let chart_y = inner.y;
-    let chart_w = inner.width.saturating_sub(7);
+    let chart_w = inner.width.saturating_sub(y_label_width);
     let chart_h = inner.height.saturating_sub(2);
     app.signal_chart_area = Some((chart_x, chart_y, chart_w, chart_h));
+
+    // Draw per-key Y-axis scales when multiple keys are plotted
+    if app.plot_slots.len() > 1 && !slot_renders.is_empty() {
+        let num_slots = slot_renders.len().min(app.plot_slots.len());
+        // Each slot gets a column of Y labels on the left side
+        let label_width = 9u16; // enough for "-99999.9"
+        let buf_area = frame.area();
+
+        for (i, sr) in slot_renders.iter().enumerate().take(num_slots) {
+            let color = app.plot_slots[i].color;
+            let col_x = inner.x + (i as u16) * label_width;
+            if col_x + label_width > buf_area.width { break; }
+
+            // Top: Y max
+            if chart_y > 0 && chart_y < buf_area.height {
+                frame.render_widget(
+                    Paragraph::new(format!("{:.1}", sr.y_max))
+                        .style(Style::default().fg(color)),
+                    Rect::new(col_x, chart_y, label_width, 1),
+                );
+            }
+            // Middle: midpoint
+            let mid_y = chart_y + chart_h / 2;
+            if mid_y < buf_area.height {
+                let mid_val = (sr.y_min + sr.y_max) / 2.0;
+                frame.render_widget(
+                    Paragraph::new(format!("{:.1}", mid_val))
+                        .style(Style::default().fg(color)),
+                    Rect::new(col_x, mid_y, label_width, 1),
+                );
+            }
+            // Bottom: Y min
+            let bot_y = chart_y + chart_h.saturating_sub(1);
+            if bot_y < buf_area.height && bot_y != mid_y {
+                frame.render_widget(
+                    Paragraph::new(format!("{:.1}", sr.y_min))
+                        .style(Style::default().fg(color)),
+                    Rect::new(col_x, bot_y, label_width, 1),
+                );
+            }
+        }
+    }
 
     // Draw crosshair tick marks if hovering in signal chart
     if !app.hover_in_fft {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -363,8 +363,9 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
         .collect();
 
     // When auto-limits: use raw values with unified Y-axis across all slots
-    // When manual limits: normalize each slot independently to 0.0-1.0
-    let normalize = !app.plot_slots.is_empty() && !app.plot_auto_limits;
+    // When manual/per-slot limits: normalize each slot to 0.0-1.0 using its own Y range
+    let has_per_slot_limits = app.plot_slots.iter().any(|s| s.y_min.is_some());
+    let normalize = !app.plot_slots.is_empty() && (!app.plot_auto_limits || has_per_slot_limits);
 
     struct SlotRender {
         points: Vec<(f64, f64)>,
@@ -375,25 +376,27 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
         .plot_slots
         .iter()
         .map(|slot| {
-            let y_min = slot.data.iter().copied()
+            let auto_min = slot.data.iter().copied()
                 .filter(|v| v.is_finite())
                 .fold(f64::INFINITY, f64::min);
-            let y_max = slot.data.iter().copied()
+            let auto_max = slot.data.iter().copied()
                 .filter(|v| v.is_finite())
                 .fold(f64::NEG_INFINITY, f64::max);
+            // Use per-slot limits if set, otherwise auto
+            let y_min = slot.y_min.unwrap_or(if auto_min.is_finite() { auto_min } else { 0.0 });
+            let y_max = slot.y_max.unwrap_or(if auto_max.is_finite() { auto_max } else { 1.0 });
             let points = if normalize {
                 let range = y_max - y_min;
-                let safe_range = if !range.is_finite() || range == 0.0 { 1.0 } else { range };
+                let safe_range = if range == 0.0 { 1.0 } else { range };
                 slot.data
                     .iter()
                     .enumerate()
                     .map(|(i, v)| {
-                        let normalized = if !range.is_finite() { 0.5 } else { (v - y_min) / safe_range };
+                        let normalized = (v - y_min) / safe_range;
                         (i as f64, normalized)
                     })
                     .collect()
             } else {
-                // Raw values — auto-scale will compute unified bounds
                 slot.data.iter().enumerate().map(|(i, v)| (i as f64, *v)).collect()
             };
             SlotRender { points, y_min, y_max }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -142,12 +142,19 @@ fn draw_key_list(frame: &mut Frame, app: &mut App, area: Rect) {
             };
 
             let is_collision = collision_keys.contains(key.as_str());
+            let plot_color = app.plot_color_for_key(key);
             let mut spans = vec![
                 Span::styled(
                     format!("{:<6}", type_badge.0),
                     Style::default().fg(type_badge.1),
                 ),
             ];
+            // Show plot indicator with slot color
+            if let Some(color) = plot_color {
+                spans.push(Span::styled("\u{25CF} ", Style::default().fg(color)));
+            } else {
+                spans.push(Span::raw("  "));
+            }
             if is_collision {
                 spans.push(Span::styled("! ", Style::default().fg(Color::Yellow)));
             }
@@ -268,8 +275,9 @@ fn draw_data_plot(frame: &mut Frame, app: &mut App, area: Rect) {
         focused_limits, fft_label, log_label, focus_label
     );
 
-    if app.plot_data.is_empty() {
-        let msg = Paragraph::new("No plottable data. Select a key with binary data.")
+    let has_slot_data = app.plot_slots.iter().any(|s| !s.data.is_empty());
+    if app.plot_data.is_empty() && !has_slot_data {
+        let msg = Paragraph::new("No plottable data. Press [p] on a key to add it to the plot.")
             .style(Style::default().fg(Color::DarkGray))
             .block(
                 Block::default()
@@ -333,17 +341,65 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
         return;
     }
 
-    let data_points: Vec<(f64, f64)> = app
+    // Build data points for the primary key (backward compat)
+    let primary_points: Vec<(f64, f64)> = app
         .plot_data
         .iter()
         .enumerate()
         .map(|(i, v)| (i as f64, *v))
         .collect();
 
-    let (x_lo, x_hi) = app.signal_x_bounds();
+    // Build data points for each plot slot
+    let slot_points: Vec<Vec<(f64, f64)>> = app
+        .plot_slots
+        .iter()
+        .map(|slot| {
+            slot.data
+                .iter()
+                .enumerate()
+                .map(|(i, v)| (i as f64, *v))
+                .collect()
+        })
+        .collect();
+
+    let (x_lo, x_hi) = if !app.plot_slots.is_empty() {
+        // Use max data length across all slots for x bounds
+        let max_len = app.plot_slots.iter()
+            .map(|s| s.data.len())
+            .max()
+            .unwrap_or(0)
+            .max(app.plot_data.len());
+        if app.plot_x_max > 0.0 {
+            (app.plot_x_min, app.plot_x_max)
+        } else if max_len > crate::app::PLOT_WINDOW {
+            ((max_len - crate::app::PLOT_WINDOW) as f64, max_len as f64)
+        } else {
+            (0.0, max_len as f64)
+        }
+    } else {
+        app.signal_x_bounds()
+    };
 
     let (y_lo, y_hi) = if app.plot_auto_limits {
-        app.auto_signal_bounds()
+        if !app.plot_slots.is_empty() {
+            // Unified auto bounds across all slot data
+            let all_data: Vec<f64> = app.plot_slots.iter()
+                .flat_map(|s| s.data.iter().copied())
+                .chain(app.plot_data.iter().copied())
+                .filter(|v| v.is_finite())
+                .collect();
+            if all_data.is_empty() {
+                (0.0, 1.0)
+            } else {
+                let y_min = all_data.iter().copied().fold(f64::INFINITY, f64::min);
+                let y_max = all_data.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+                let range = y_max - y_min;
+                let pad = if range == 0.0 { 1.0 } else { range * 0.1 };
+                (y_min - pad, y_max + pad)
+            }
+        } else {
+            app.auto_signal_bounds()
+        }
     } else {
         (app.plot_y_min, app.plot_y_max)
     };
@@ -370,12 +426,29 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
     let full_title = format!("{}{} ", title, hover_suffix);
 
     let marker = safe_marker(area);
-    let datasets = vec![Dataset::default()
-        .name(format!("{} values", app.plot_data.len()))
-        .marker(marker)
-        .graph_type(GraphType::Line)
-        .style(Style::default().fg(Color::Cyan))
-        .data(&data_points)];
+
+    // Build datasets: one per plot slot, plus primary if no slots
+    let mut datasets = Vec::new();
+    if app.plot_slots.is_empty() {
+        // Fallback: single dataset from primary plot_data
+        datasets.push(Dataset::default()
+            .name(format!("{} values", app.plot_data.len()))
+            .marker(marker)
+            .graph_type(GraphType::Line)
+            .style(Style::default().fg(Color::Cyan))
+            .data(&primary_points));
+    } else {
+        for (i, slot) in app.plot_slots.iter().enumerate() {
+            if !slot.data.is_empty() {
+                datasets.push(Dataset::default()
+                    .name(slot.key_name.clone())
+                    .marker(marker)
+                    .graph_type(GraphType::Line)
+                    .style(Style::default().fg(slot.color))
+                    .data(&slot_points[i]));
+            }
+        }
+    }
 
     let chart = Chart::new(datasets)
         .block(
@@ -403,7 +476,8 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
                     Line::from(format!("{:.2}", (y_lo + y_hi) / 2.0)),
                     Line::from(format!("{:.2}", y_hi)),
                 ]),
-        );
+        )
+        .legend_position(Some(ratatui::widgets::LegendPosition::TopRight));
 
     frame.render_widget(chart, area);
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -596,47 +596,91 @@ fn draw_fft_chart(frame: &mut Frame, app: &mut App, area: Rect, _border_color: C
         return;
     }
 
+    // Compute FFT for primary data
     let display_data = app.fft_display_data();
-    let fft_points: Vec<(f64, f64)> = display_data
+    let primary_fft_points: Vec<(f64, f64)> = display_data
         .iter()
         .enumerate()
         .map(|(i, v)| (i as f64, *v))
         .collect();
 
-    let (x_lo, x_hi) = app.fft_x_bounds();
+    // Compute FFT per slot
+    let slot_fft_data: Vec<Vec<f64>> = app.plot_slots.iter().map(|slot| {
+        let mut magnitudes = crate::app::compute_fft_magnitude(&slot.data);
+        if app.fft_log_scale {
+            for v in &mut magnitudes {
+                *v = if *v > 0.0 { v.log10() } else { -10.0 };
+            }
+        }
+        magnitudes
+    }).collect();
+    let slot_fft_points: Vec<Vec<(f64, f64)>> = slot_fft_data.iter().map(|data| {
+        data.iter().enumerate().map(|(i, v)| (i as f64, *v)).collect()
+    }).collect();
+
+    // Compute unified bounds across all FFT data
+    let (x_lo, x_hi) = if !app.plot_slots.is_empty() {
+        let max_bins = slot_fft_data.iter().map(|d| d.len()).max().unwrap_or(0)
+            .max(display_data.len());
+        if app.fft_x_max > 0.0 { (app.fft_x_min, app.fft_x_max) }
+        else { (0.0, max_bins as f64) }
+    } else {
+        app.fft_x_bounds()
+    };
 
     let (y_lo, y_hi) = if app.fft_auto_limits {
-        app.auto_fft_bounds()
+        let all_fft: Vec<f64> = slot_fft_data.iter()
+            .flat_map(|d| d.iter().copied())
+            .chain(display_data.iter().copied())
+            .filter(|v| v.is_finite())
+            .collect();
+        if all_fft.is_empty() { (0.0, 1.0) }
+        else {
+            let y_min = all_fft.iter().copied().fold(f64::INFINITY, f64::min);
+            let y_max = all_fft.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+            let range = y_max - y_min;
+            let pad = if range == 0.0 { 1.0 } else { range * 0.1 };
+            (y_min - pad, y_max + pad)
+        }
     } else {
         (app.fft_y_min, app.fft_y_max)
     };
 
-    // Highlight border if this sub-plot is focused
-    let chart_border = if app.plot_focus == PlotFocus::FFT {
-        Color::Cyan
-    } else {
-        Color::DarkGray
-    };
+    let chart_border = if app.plot_focus == PlotFocus::FFT { Color::Cyan } else { Color::DarkGray };
 
     let scale_label = if app.fft_log_scale { "log" } else { "linear" };
     let hover_suffix = if app.hover_in_fft {
         if let (Some(hx), Some(hy)) = (app.hover_data_x, app.hover_data_y) {
             format!(" bin:{:.1} mag:{:.2}", hx, hy)
-        } else {
-            String::new()
-        }
-    } else {
-        String::new()
-    };
+        } else { String::new() }
+    } else { String::new() };
     let fft_title = format!(" FFT Magnitude ({}){} ", scale_label, hover_suffix);
 
     let marker = safe_marker(area);
-    let datasets = vec![Dataset::default()
-        .name(format!("{} bins", display_data.len()))
-        .marker(marker)
-        .graph_type(GraphType::Line)
-        .style(Style::default().fg(Color::Yellow))
-        .data(&fft_points)];
+    let mut datasets = Vec::new();
+
+    if app.plot_slots.is_empty() {
+        datasets.push(Dataset::default()
+            .name(format!("{} bins", display_data.len()))
+            .marker(marker)
+            .graph_type(GraphType::Line)
+            .style(Style::default().fg(Color::Yellow))
+            .data(&primary_fft_points));
+    } else {
+        for (i, slot) in app.plot_slots.iter().enumerate() {
+            if i < slot_fft_points.len() && !slot_fft_points[i].is_empty() {
+                let short_name = if slot.key_name.len() > 12 {
+                    format!("{}...", &slot.key_name[..12])
+                } else { slot.key_name.clone() };
+                datasets.push(Dataset::default()
+                    .name(short_name)
+                    .marker(marker)
+                    .graph_type(GraphType::Line)
+                    .style(Style::default().fg(slot.color))
+                    .data(&slot_fft_points[i]));
+            }
+        }
+    }
 
     let y_title = if app.fft_log_scale { "log10(Mag)" } else { "Magnitude" };
 
@@ -666,7 +710,9 @@ fn draw_fft_chart(frame: &mut Frame, app: &mut App, area: Rect, _border_color: C
                     Line::from(format!("{:.2}", (y_lo + y_hi) / 2.0)),
                     Line::from(format!("{:.2}", y_hi)),
                 ]),
-        );
+        )
+        .legend_position(Some(ratatui::widgets::LegendPosition::TopRight))
+        .hidden_legend_constraints((Constraint::Min(0), Constraint::Min(0)));
 
     frame.render_widget(chart, area);
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -143,18 +143,31 @@ fn draw_key_list(frame: &mut Frame, app: &mut App, area: Rect) {
 
             let is_collision = collision_keys.contains(key.as_str());
             let plot_color = app.plot_color_for_key(key);
+            let is_listening = app.listening_keys.iter().any(|k| k == key);
+            let is_siggen = app.siggen_keys.iter().any(|k| k == key);
             let mut spans = vec![
                 Span::styled(
                     format!("{:<6}", type_badge.0),
                     Style::default().fg(type_badge.1),
                 ),
             ];
-            // Show plot indicator with slot color
+            // Indicators: P=plotting, L=listening, W=signal gen
             if let Some(color) = plot_color {
-                spans.push(Span::styled("\u{25CF} ", Style::default().fg(color)));
+                spans.push(Span::styled("P", Style::default().fg(color)));
             } else {
-                spans.push(Span::raw("  "));
+                spans.push(Span::styled(" ", Style::default()));
             }
+            if is_listening {
+                spans.push(Span::styled("L", Style::default().fg(Color::Green)));
+            } else {
+                spans.push(Span::styled(" ", Style::default()));
+            }
+            if is_siggen {
+                spans.push(Span::styled("W", Style::default().fg(Color::Red)));
+            } else {
+                spans.push(Span::styled(" ", Style::default()));
+            }
+            spans.push(Span::raw(" "));
             if is_collision {
                 spans.push(Span::styled("! ", Style::default().fg(Color::Yellow)));
             }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -349,9 +349,10 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
         .map(|(i, v)| (i as f64, *v))
         .collect();
 
-    // Normalize each slot's data independently to 0.0-1.0 for individual Y-axes.
-    // Each waveform is auto-scaled to its own min/max range.
-    // Legend shows key name with actual [min..max] range.
+    // When auto-limits: use raw values with unified Y-axis across all slots
+    // When manual limits: normalize each slot independently to 0.0-1.0
+    let normalize = !app.plot_slots.is_empty() && !app.plot_auto_limits;
+
     struct SlotRender {
         points: Vec<(f64, f64)>,
         y_min: f64,
@@ -367,20 +368,21 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
             let y_max = slot.data.iter().copied()
                 .filter(|v| v.is_finite())
                 .fold(f64::NEG_INFINITY, f64::max);
-            let range = y_max - y_min;
-            let safe_range = if !range.is_finite() || range == 0.0 { 1.0 } else { range };
-            let points = slot.data
-                .iter()
-                .enumerate()
-                .map(|(i, v)| {
-                    let normalized = if safe_range == 1.0 && !range.is_finite() {
-                        0.5 // no valid data
-                    } else {
-                        (v - y_min) / safe_range
-                    };
-                    (i as f64, normalized)
-                })
-                .collect();
+            let points = if normalize {
+                let range = y_max - y_min;
+                let safe_range = if !range.is_finite() || range == 0.0 { 1.0 } else { range };
+                slot.data
+                    .iter()
+                    .enumerate()
+                    .map(|(i, v)| {
+                        let normalized = if !range.is_finite() { 0.5 } else { (v - y_min) / safe_range };
+                        (i as f64, normalized)
+                    })
+                    .collect()
+            } else {
+                // Raw values — auto-scale will compute unified bounds
+                slot.data.iter().enumerate().map(|(i, v)| (i as f64, *v)).collect()
+            };
             SlotRender { points, y_min, y_max }
         })
         .collect();
@@ -402,10 +404,24 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
         app.signal_x_bounds()
     };
 
-    // When multiple slots: Y-axis is normalized 0.0-1.0
-    // When single/no slots: use original auto/manual bounds
-    let (y_lo, y_hi) = if !app.plot_slots.is_empty() {
-        (-0.05, 1.05) // slight padding around normalized range
+    let (y_lo, y_hi) = if !app.plot_slots.is_empty() && app.plot_auto_limits {
+        // Auto: unified bounds across all slot data (raw values)
+        let all_data: Vec<f64> = app.plot_slots.iter()
+            .flat_map(|s| s.data.iter().copied())
+            .filter(|v| v.is_finite())
+            .collect();
+        if all_data.is_empty() {
+            (0.0, 1.0)
+        } else {
+            let y_min = all_data.iter().copied().fold(f64::INFINITY, f64::min);
+            let y_max = all_data.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+            let range = y_max - y_min;
+            let pad = if range == 0.0 { 1.0 } else { range * 0.1 };
+            (y_min - pad, y_max + pad)
+        }
+    } else if !app.plot_slots.is_empty() {
+        // Manual: data is normalized to 0-1
+        (-0.05, 1.05)
     } else if app.plot_auto_limits {
         app.auto_signal_bounds()
     } else {
@@ -485,7 +501,7 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
         )
         .y_axis(
             Axis::default()
-                .title(if app.plot_slots.is_empty() { "Value" } else { "Norm" })
+                .title(if app.plot_slots.is_empty() || app.plot_auto_limits { "Value" } else { "Norm" })
                 .bounds([y_lo, y_hi])
                 .labels(vec![
                     Line::from(format!("{:.2}", y_lo)),


### PR DESCRIPTION
## Summary

Multi-key plotting, stream listening, and signal generation — up to 4 concurrent keys.

### Multi-key plotting
- Press `p` on a key to toggle it into/out of the plot (FIFO queue, max 4)
- Each key gets a distinct colored trace (Cyan, Yellow, Green, Magenta)
- Individual Y-axis per key: colored Y scales rendered on the left side of the chart
- Data fetched directly from Redis per key
- Legend shows key name with `[min..max]` range

### Multi-key FFT
- Each plotted key gets its own colored trace in the FFT window
- Unified Y bounds across all FFT data

### Multi-key stream listening
- Press `l` to toggle per-key stream listeners (FIFO, max 4)
- Each listener runs independently on its own background thread

### Multi signal generator
- Press `w` to toggle per-key signal generators (FIFO, max 4)
- Signal gen trims streams to last 100 entries via XTRIM

### Key list indicators
- `P` (colored) = plotting, `L` (green) = listening, `W` (red) = signal gen

### Plot settings
- Press `x` for combined popup: unified X Min/Max + per-key Y Min/Max
- Press `a` to reset all to auto limits
- Tab navigates between fields

### Bug fixes
- Fix keyboard becoming unresponsive (crossterm KeyEventKind filtering)
- Fix key event filter skipping stream drain/FFT poll on release events

## Test plan
- [x] `cargo test` — 30/30 pass, zero warnings
- [ ] Manual: press `p` on 4 keys, verify 4 colored traces with individual Y scales
- [ ] Manual: enable FFT, verify per-key FFT traces
- [ ] Manual: press `l` on multiple streams, verify independent listening
- [ ] Manual: press `w` on multiple streams, verify independent signal gen with trim
- [ ] Manual: press `x`, verify per-key Y fields in popup
- [ ] Manual: verify PLW indicators in key list

Fixes #48