### PR TITLE
Fix thread safety and input freezing in plot/stream interactions

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -125,6 +125,7 @@ pub struct App {
     pub fft_computing: bool,
     pub fft_rx: Option<mpsc::Receiver<Vec<f64>>>,
     pub fft_handle: Option<std::thread::JoinHandle<()>>,
+    pub fft_dirty: bool, // true if plot_data changed while FFT was in flight
     pub fft_auto_limits: bool,
     pub fft_y_min: f64,
     pub fft_y_max: f64,
@@ -224,6 +225,7 @@ impl App {
             fft_computing: false,
             fft_rx: None,
             fft_handle: None,
+            fft_dirty: false,
             fft_auto_limits: true,
             fft_y_min: 0.0,
             fft_y_max: 1.0,
@@ -637,9 +639,11 @@ impl App {
         } else {
             self.fft_data.clear();
             self.fft_computing = false;
+            self.fft_dirty = false;
             self.fft_rx = None;
+            // Non-blocking join — avoid stalling the UI thread
             if let Some(h) = self.fft_handle.take() {
-                let _ = h.join();
+                std::thread::spawn(move || { let _ = h.join(); });
             }
         }
     }
@@ -648,17 +652,21 @@ impl App {
         if self.plot_data.is_empty() {
             self.fft_data.clear();
             self.fft_computing = false;
+            self.fft_dirty = false;
             self.fft_rx = None;
+            // Non-blocking join — avoid stalling the UI thread
             if let Some(h) = self.fft_handle.take() {
-                let _ = h.join();
+                std::thread::spawn(move || { let _ = h.join(); });
             }
             return;
         }
-        // Skip if an FFT is already in flight — the next data update after
-        // poll_fft() clears the flag will spawn a fresh computation.
+        // If an FFT is already in flight, mark dirty so poll_fft()
+        // re-triggers a computation with the latest data once it completes.
         if self.fft_computing {
+            self.fft_dirty = true;
             return;
         }
+        self.fft_dirty = false;
         let data = self.plot_data.clone();
         let (tx, rx) = mpsc::channel();
         self.fft_rx = Some(rx);
@@ -680,6 +688,10 @@ impl App {
                     self.fft_rx = None;
                     if let Some(h) = self.fft_handle.take() {
                         let _ = h.join();
+                    }
+                    // Re-trigger if data changed while we were computing
+                    if self.fft_dirty {
+                        self.compute_fft();
                     }
                 }
                 Err(mpsc::TryRecvError::Disconnected) => {

--- a/src/app.rs
+++ b/src/app.rs
@@ -499,6 +499,7 @@ impl App {
         if let Some(RedisValue::Stream(ref mut entries)) = self.current_value {
             entries.extend(new_entries);
             // Extract plot data from the last entry only (avoids cloning entire stream)
+            let mut found_plot_field = false;
             if let Some(last_entry) = entries.last() {
                 for (fname, fval) in &last_entry.fields {
                     if fname.starts_with('_') {
@@ -508,9 +509,13 @@ impl App {
                                 *v = 0.0;
                             }
                         }
+                        found_plot_field = true;
                         break;
                     }
                 }
+            }
+            if !found_plot_field {
+                self.plot_data.clear();
             }
             self.expanded_stream_entries = vec![false; entries.len()];
             if self.fft_enabled {
@@ -633,6 +638,9 @@ impl App {
             self.fft_data.clear();
             self.fft_computing = false;
             self.fft_rx = None;
+            if let Some(h) = self.fft_handle.take() {
+                let _ = h.join();
+            }
         }
     }
 
@@ -641,6 +649,9 @@ impl App {
             self.fft_data.clear();
             self.fft_computing = false;
             self.fft_rx = None;
+            if let Some(h) = self.fft_handle.take() {
+                let _ = h.join();
+            }
             return;
         }
         // Skip if an FFT is already in flight — the next data update after

--- a/src/app.rs
+++ b/src/app.rs
@@ -124,6 +124,7 @@ pub struct App {
     pub fft_data: Vec<f64>,
     pub fft_computing: bool,
     pub fft_rx: Option<mpsc::Receiver<Vec<f64>>>,
+    pub fft_handle: Option<std::thread::JoinHandle<()>>,
     pub fft_auto_limits: bool,
     pub fft_y_min: f64,
     pub fft_y_max: f64,
@@ -222,6 +223,7 @@ impl App {
             fft_data: Vec::new(),
             fft_computing: false,
             fft_rx: None,
+            fft_handle: None,
             fft_auto_limits: true,
             fft_y_min: 0.0,
             fft_y_max: 1.0,
@@ -496,9 +498,21 @@ impl App {
         // Append to existing stream value
         if let Some(RedisValue::Stream(ref mut entries)) = self.current_value {
             entries.extend(new_entries);
-            // Recompute plot from updated stream
-            let value = RedisValue::Stream(entries.clone());
-            self.update_plot_data(&value);
+            // Extract plot data from the last entry only (avoids cloning entire stream)
+            if let Some(last_entry) = entries.last() {
+                for (fname, fval) in &last_entry.fields {
+                    if fname.starts_with('_') {
+                        self.plot_data = decode_blob(fval, self.data_type, self.endianness);
+                        for v in &mut self.plot_data {
+                            if !v.is_finite() {
+                                *v = 0.0;
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
+            self.expanded_stream_entries = vec![false; entries.len()];
             if self.fft_enabled {
                 self.compute_fft();
             }
@@ -599,8 +613,9 @@ impl App {
     }
 
     pub fn recompute_plot(&mut self) {
-        if let Some(value) = &self.current_value.clone() {
-            self.update_plot_data(value);
+        if let Some(value) = self.current_value.take() {
+            self.update_plot_data(&value);
+            self.current_value = Some(value);
         }
         // Clear stale FFT data immediately so UI doesn't use mismatched data
         self.fft_data.clear();
@@ -628,14 +643,20 @@ impl App {
             self.fft_rx = None;
             return;
         }
+        // Skip if an FFT is already in flight — the next data update after
+        // poll_fft() clears the flag will spawn a fresh computation.
+        if self.fft_computing {
+            return;
+        }
         let data = self.plot_data.clone();
         let (tx, rx) = mpsc::channel();
         self.fft_rx = Some(rx);
         self.fft_computing = true;
-        std::thread::spawn(move || {
+        let handle = std::thread::spawn(move || {
             let result = compute_fft_magnitude(&data);
             let _ = tx.send(result);
         });
+        self.fft_handle = Some(handle);
     }
 
     /// Check if background FFT has completed; call this each tick.
@@ -646,10 +667,16 @@ impl App {
                     self.fft_data = data;
                     self.fft_computing = false;
                     self.fft_rx = None;
+                    if let Some(h) = self.fft_handle.take() {
+                        let _ = h.join();
+                    }
                 }
                 Err(mpsc::TryRecvError::Disconnected) => {
                     self.fft_computing = false;
                     self.fft_rx = None;
+                    if let Some(h) = self.fft_handle.take() {
+                        let _ = h.join();
+                    }
                 }
                 Err(mpsc::TryRecvError::Empty) => {} // still computing
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -480,6 +480,10 @@ fn run_app(
         app.siggen_keys = signal_generators.iter().map(|sg| sg.watching_key.clone()).collect();
 
         if !app.running {
+            // Disable mouse capture immediately so events don't queue
+            // in stdin during the blocking thread joins below.
+            let _ = io::stdout().execute(DisableMouseCapture);
+
             // Signal all threads to stop in parallel before joining
             for sg in &signal_generators {
                 sg.stop_flag.store(true, Ordering::Relaxed);

--- a/src/main.rs
+++ b/src/main.rs
@@ -452,6 +452,7 @@ fn run_app(
 
         // Drain new stream entries from all background listeners (bounded per tick)
         const MAX_DRAIN_PER_TICK: usize = 20;
+        let viewed_key = app.selected_key_name().map(|s| s.to_string());
         for listener in &stream_listeners {
             let mut total_new = 0;
             let mut drained = 0;
@@ -460,7 +461,10 @@ fn run_app(
                     Ok(entries) => {
                         total_new += entries.len();
                         app.append_slot_stream_entries(&listener.watching_key, &entries);
-                        app.append_stream_entries(entries);
+                        // Only update main view state if this listener matches the viewed key
+                        if viewed_key.as_deref() == Some(listener.watching_key.as_str()) {
+                            app.append_stream_entries(entries);
+                        }
                         drained += 1;
                     }
                     Err(_) => break,
@@ -476,16 +480,16 @@ fn run_app(
         app.siggen_keys = signal_generators.iter().map(|sg| sg.watching_key.clone()).collect();
 
         if !app.running {
-            // Join any in-flight FFT thread
-            if let Some(h) = app.fft_handle.take() {
-                let _ = h.join();
-            }
             // Signal all threads to stop in parallel before joining
             for sg in &signal_generators {
                 sg.stop_flag.store(true, Ordering::Relaxed);
             }
             for sl in &stream_listeners {
                 sl.stop_flag.store(true, Ordering::Relaxed);
+            }
+            // Join any in-flight FFT thread
+            if let Some(h) = app.fft_handle.take() {
+                let _ = h.join();
             }
             drop(signal_generators);
             drop(stream_listeners);

--- a/src/main.rs
+++ b/src/main.rs
@@ -349,10 +349,13 @@ fn run_app(
                             if let Some(k) = app.selected_key_name().map(|s| s.to_string()) {
                                 let key_url = client.url_for_key(&k).to_string();
                                 if let Some(sg) = SignalGenerator::start(&key_url, &k, app.db, config) {
-                                    // Evict oldest if at capacity
+                                    // Evict oldest if at capacity (non-blocking)
                                     if signal_generators.len() >= app::MAX_PLOT_SLOTS {
                                         let mut oldest = signal_generators.remove(0);
-                                        oldest.stop();
+                                        oldest.stop_flag.store(true, Ordering::Relaxed);
+                                        if let Some(h) = oldest.handle.take() {
+                                            std::thread::spawn(move || { let _ = h.join(); });
+                                        }
                                     }
                                     signal_generators.push(sg);
                                     app.status_message = format!("Signal gen: running on '{}' ({}/{})", k, signal_generators.len(), app::MAX_PLOT_SLOTS);
@@ -390,19 +393,25 @@ fn run_app(
                             if let Some(k) = app.selected_key_name().map(|s| s.to_string()) {
                                 // Check if already listening on this key
                                 if let Some(idx) = stream_listeners.iter().position(|sl| sl.watching_key == k) {
-                                    // Stop this specific listener
+                                    // Stop this specific listener (non-blocking)
                                     let mut sl = stream_listeners.remove(idx);
-                                    sl.stop();
+                                    sl.stop_flag.store(true, Ordering::Relaxed);
+                                    if let Some(h) = sl.handle.take() {
+                                        std::thread::spawn(move || { let _ = h.join(); });
+                                    }
                                     app.status_message = format!("Stream: stopped '{}'", k);
                                 } else {
                                     // Start new listener
                                     let lid = app.last_stream_id.clone().unwrap_or_else(|| "$".to_string());
                                     let key_url = client.url_for_key(&k).to_string();
                                     if let Some(sl) = StreamListener::start(&key_url, &k, &lid, app.db) {
-                                        // Evict oldest if at capacity
+                                        // Evict oldest if at capacity (non-blocking)
                                         if stream_listeners.len() >= app::MAX_PLOT_SLOTS {
                                             let mut oldest = stream_listeners.remove(0);
-                                            oldest.stop();
+                                            oldest.stop_flag.store(true, Ordering::Relaxed);
+                                            if let Some(h) = oldest.handle.take() {
+                                                std::thread::spawn(move || { let _ = h.join(); });
+                                            }
                                         }
                                         stream_listeners.push(sl);
                                         app.status_message = format!("Stream: listening on '{}' ({}/{})", k, stream_listeners.len(), app::MAX_PLOT_SLOTS);
@@ -416,8 +425,12 @@ fn run_app(
                             if let Some(k) = app.selected_key_name().map(|s| s.to_string()) {
                                 // Check if already generating on this key
                                 if let Some(idx) = signal_generators.iter().position(|sg| sg.watching_key == k) {
+                                    // Non-blocking stop
                                     let mut sg = signal_generators.remove(idx);
-                                    sg.stop();
+                                    sg.stop_flag.store(true, Ordering::Relaxed);
+                                    if let Some(h) = sg.handle.take() {
+                                        std::thread::spawn(move || { let _ = h.join(); });
+                                    }
                                     app.status_message = format!("Signal gen: stopped '{}'", k);
                                 } else if app.is_viewing_stream() {
                                     app.start_signal_gen_popup();
@@ -437,15 +450,21 @@ fn run_app(
         // Check for completed background FFT
         app.poll_fft();
 
-        // Drain new stream entries from all background listeners
+        // Drain new stream entries from all background listeners (bounded per tick)
+        const MAX_DRAIN_PER_TICK: usize = 20;
         for listener in &stream_listeners {
             let mut total_new = 0;
-            while let Ok(entries) = listener.rx.try_recv() {
-                total_new += entries.len();
-                // Update the plot slot for this key
-                app.append_slot_stream_entries(&listener.watching_key, &entries);
-                // Also update main app state if this is the currently viewed key
-                app.append_stream_entries(entries);
+            let mut drained = 0;
+            while drained < MAX_DRAIN_PER_TICK {
+                match listener.rx.try_recv() {
+                    Ok(entries) => {
+                        total_new += entries.len();
+                        app.append_slot_stream_entries(&listener.watching_key, &entries);
+                        app.append_stream_entries(entries);
+                        drained += 1;
+                    }
+                    Err(_) => break,
+                }
             }
             if total_new > 0 {
                 app.status_message = format!("Stream: +{} entries on '{}' (live)", total_new, listener.watching_key);
@@ -457,6 +476,17 @@ fn run_app(
         app.siggen_keys = signal_generators.iter().map(|sg| sg.watching_key.clone()).collect();
 
         if !app.running {
+            // Join any in-flight FFT thread
+            if let Some(h) = app.fft_handle.take() {
+                let _ = h.join();
+            }
+            // Signal all threads to stop in parallel before joining
+            for sg in &signal_generators {
+                sg.stop_flag.store(true, Ordering::Relaxed);
+            }
+            for sl in &stream_listeners {
+                sl.stop_flag.store(true, Ordering::Relaxed);
+            }
             drop(signal_generators);
             drop(stream_listeners);
             return Ok(());


### PR DESCRIPTION
## Summary
- **Guard FFT thread storms**: Skip spawning a new FFT thread when one is already computing (`fft_computing` flag check). Previously, 40+ threads/sec were spawned with active listeners, causing crashes.
- **Eliminate expensive clones**: `append_stream_entries` now extracts plot data from the last entry inline instead of cloning the entire stream. `recompute_plot` uses `take()`/put-back instead of `clone()`.
- **Bound channel drain**: Capped at 20 batches per listener per event loop tick, preventing input starvation when data arrives faster than processing.
- **Non-blocking thread stop**: Toggle-off and eviction of listeners/generators set the stop flag and spawn a detached join thread, so the UI never blocks waiting for XREAD timeouts.
- **FFT handle tracking**: `JoinHandle` stored in App, joined on completion and on exit. All stop flags signaled in parallel before final drop for faster shutdown.

Fixes #25, #23, #33, #39

## Test plan
- [ ] Start signal gen at 10 entries/sec with FFT enabled on multiple streams — verify no crash, stable thread count
- [ ] Toggle listeners on/off with 'l' — verify instant response, no input delay
- [ ] Run long-duration plots — verify UI stays responsive
- [ ] Exit app with active threads — verify clean shutdown, no hangs