### PR TITLE
Fix uint rendering as ASCII and improve binary display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ dependencies = [
 
 [[package]]
 name = "redis-tui"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-tui"
-version = "1.1.2"
+version = "1.1.3"
 edition = "2021"
 description = "A Redis TUI client inspired by Redis Insight"
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1076,7 +1076,12 @@ impl App {
         match &self.current_value {
             None => vec!["(no value loaded)".to_string()],
             Some(RedisValue::String(bytes)) => {
-                if is_binary(bytes) {
+                // Show as decoded binary when data type is numeric or data looks binary
+                let show_binary = match self.data_type {
+                    DataType::String | DataType::Blob => is_binary(bytes),
+                    _ => true, // numeric data type selected — always decode
+                };
+                if show_binary {
                     let mut lines = Vec::new();
                     // Show decoded values using current data type
                     lines.push(format!("── Decoded as {} ({}) ──", self.data_type, self.endianness));
@@ -1575,7 +1580,7 @@ fn format_stream_entries(entries: &[StreamEntry], data_type: DataType, endiannes
         let time_str = format_stream_id(&entry.id);
         lines.push(format!("--- {} ({}) ---", entry.id, time_str));
         for (fname, fval) in &entry.fields {
-            if fname.starts_with('_') && is_binary(fval) {
+            if fname.starts_with('_') {
                 // Binary data field - show decoded values + hex summary
                 let decoded = decode_blob(fval, data_type, endianness);
                 if !decoded.is_empty() {
@@ -1867,5 +1872,46 @@ mod tests {
         } else {
             panic!("expected Stream value");
         }
+    }
+
+    #[test]
+    fn format_stream_entries_uint8_printable_ascii() {
+        use crate::redis_client::StreamEntry;
+        use crate::data::{DataType, Endianness};
+
+        // Create stream entry with uint8 data in printable ASCII range (65-90 = 'A'-'Z')
+        let entries = vec![StreamEntry {
+            id: "1000-0".to_string(),
+            fields: vec![
+                ("_waveform".to_string(), vec![65, 66, 67, 68, 69]),
+            ],
+        }];
+        let result = format_stream_entries(&entries, DataType::UInt8, Endianness::Little);
+        let joined = result.join("\n");
+        // Should contain decoded numeric values, not ASCII text
+        assert!(joined.contains("[uint8]"), "should show data type label, got:\n{}", joined);
+        assert!(joined.contains("65"), "should contain decoded value 65, got:\n{}", joined);
+        assert!(joined.contains("hex"), "should contain hex dump, got:\n{}", joined);
+        // Should NOT contain the ASCII interpretation 'ABCDE'
+        assert!(!joined.contains("ABCDE"), "should not show ASCII text, got:\n{}", joined);
+    }
+
+    #[test]
+    fn format_stream_entries_uint16_data() {
+        use crate::redis_client::StreamEntry;
+        use crate::data::{DataType, Endianness};
+
+        // Create uint16 LE data: 256 = [0x00, 0x01], 512 = [0x00, 0x02]
+        let entries = vec![StreamEntry {
+            id: "1000-0".to_string(),
+            fields: vec![
+                ("_data".to_string(), vec![0x00, 0x01, 0x00, 0x02]),
+            ],
+        }];
+        let result = format_stream_entries(&entries, DataType::UInt16, Endianness::Little);
+        let joined = result.join("\n");
+        assert!(joined.contains("[uint16]"), "should show uint16 label, got:\n{}", joined);
+        assert!(joined.contains("256"), "should contain decoded value 256, got:\n{}", joined);
+        assert!(joined.contains("512"), "should contain decoded value 512, got:\n{}", joined);
     }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -447,4 +447,38 @@ mod tests {
         assert!((decoded[0] - 1.5).abs() < 1e-6);
         assert!((decoded[1] - (-3.25)).abs() < 1e-6);
     }
+
+    #[test]
+    fn roundtrip_int8_negative() {
+        let input = "-1, -4, -128";
+        let bytes = encode_values(input, DataType::Int8, Endianness::Little).unwrap();
+        let decoded = decode_blob(&bytes, DataType::Int8, Endianness::Little);
+        assert_eq!(decoded, vec![-1.0, -4.0, -128.0]);
+    }
+
+    #[test]
+    fn roundtrip_uint16_le() {
+        let input = "0, 255, 65535";
+        let bytes = encode_values(input, DataType::UInt16, Endianness::Little).unwrap();
+        let decoded = decode_blob(&bytes, DataType::UInt16, Endianness::Little);
+        assert_eq!(decoded, vec![0.0, 255.0, 65535.0]);
+    }
+
+    #[test]
+    fn encode_negative_near_zero_int8() {
+        // Values between -4 and 0 that reportedly crash
+        let input = "-1, -2, -3, -4";
+        let bytes = encode_values(input, DataType::Int8, Endianness::Little).unwrap();
+        assert_eq!(bytes, vec![0xFF, 0xFE, 0xFD, 0xFC]);
+        let decoded = decode_blob(&bytes, DataType::Int8, Endianness::Little);
+        assert_eq!(decoded, vec![-1.0, -2.0, -3.0, -4.0]);
+    }
+
+    #[test]
+    fn encode_negative_near_zero_int16() {
+        let input = "-1, -2, -3, -4";
+        let bytes = encode_values(input, DataType::Int16, Endianness::Little).unwrap();
+        let decoded = decode_blob(&bytes, DataType::Int16, Endianness::Little);
+        assert_eq!(decoded, vec![-1.0, -2.0, -3.0, -4.0]);
+    }
 }


### PR DESCRIPTION
## Summary
- **Fix stream binary display**: `_`-prefixed fields in stream entries now always decode as binary data regardless of `is_binary()` result. Previously, uint8/uint16 data with values in the printable ASCII range (32-127) was displayed as ASCII text instead of numeric values + hex dump.
- **Fix string value display**: String values now decode as binary when a numeric DataType is selected (uint8, int16, float32, etc.), only falling back to text display for String/Blob data types.
- **Add encoding tests**: Round-trip tests for negative int8/int16 values (including -1 through -4), uint16 encoding, and stream rendering tests verifying uint8/uint16 data displays correctly.

Fixes #1

## Test plan
- [x] 40 tests pass (6 new tests added)
- [ ] Load `stream:uint8_2000` with uint8 data type — should show numeric values + hex, not ASCII
- [ ] Load `stream:int16_1000` with int16 data type — should show decoded values
- [x] Enter negative values (-1 through -4) in binary edit mode with int8 — verify no crash