### PR TITLE
Auto-load key value on arrow navigation to fix stale edit type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ dependencies = [
 
 [[package]]
 name = "redis-tui"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-tui"
-version = "1.1.3"
+version = "1.1.4"
 edition = "2021"
 description = "A Redis TUI client inspired by Redis Insight"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -527,12 +527,14 @@ fn handle_normal_input(
             app.active_panel = app.active_panel.prev();
         }
 
-        // Key list navigation
+        // Key list navigation — auto-load value so key info stays in sync
         KeyCode::Up if app.active_panel == Panel::KeyList => {
             app.select_prev_key();
+            app.load_selected_value(client);
         }
         KeyCode::Down if app.active_panel == Panel::KeyList => {
             app.select_next_key();
+            app.load_selected_value(client);
         }
         KeyCode::Enter if app.active_panel == Panel::KeyList => {
             app.load_selected_value(client);


### PR DESCRIPTION
## Summary
Arrow key navigation in the key list only updated the selection index without loading the key's value/info. This left `current_key_info` stale, so pressing `s` to edit after navigating would use the **previous** key's type (e.g., HSet popup for a list key).

Now Up/Down auto-load the selected key's value, keeping key info in sync with the selection.

## Test plan
- [ ] Navigate to a hash key, press `s` — should show HSet fields
- [ ] Arrow down to a list key, press `s` — should show RPush field (not HSet)
- [ ] Arrow to a stream key, press `s` — should show XAdd fields
- [ ] Verify value view updates immediately on arrow navigation