### PR TITLE
Reduce in-memory stream entry cap to 10

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -9,8 +9,9 @@ use std::sync::mpsc;
 pub const MAX_PLOT_SLOTS: usize = 4;
 
 /// Maximum number of stream entries kept in memory per key.
-/// Older entries are discarded when this limit is exceeded.
-pub const MAX_STREAM_ENTRIES: usize = 10_000;
+/// Only the newest entries are needed for display (last 5 shown)
+/// and plot extraction (last entry's waveform).
+pub const MAX_STREAM_ENTRIES: usize = 10;
 
 /// Colors assigned to each plot slot
 pub const PLOT_COLORS: [Color; MAX_PLOT_SLOTS] = [


### PR DESCRIPTION
## Summary
- Reduce `MAX_STREAM_ENTRIES` from 10,000 to 10 — only the last 5 entries are displayed in the value view and only the last entry's waveform is used for plotting, so keeping thousands in memory was wasteful
- Signal gen XTRIM stays at 100 entries in Redis (unchanged)

## Test plan
- [x] All 40 tests pass
- [ ] Stream value view shows "(N older entries hidden)" capped at small numbers
- [ ] Plot still updates correctly with live stream data