### PR TITLE
Add click-to-select, shift-bypass for copy, and paste support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ dependencies = [
 
 [[package]]
 name = "redis-tui"
-version = "1.1.5"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "libc"
@@ -669,7 +669,7 @@ dependencies = [
 
 [[package]]
 name = "redis-tui"
-version = "1.1.4"
+version = "1.1.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-tui"
-version = "1.1.4"
+version = "1.1.5"
 edition = "2021"
 description = "A Redis TUI client inspired by Redis Insight"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-tui"
-version = "1.1.5"
+version = "1.2.0"
 edition = "2021"
 description = "A Redis TUI client inspired by Redis Insight"
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1516,9 +1516,9 @@ impl App {
         self.signal_gen_wave_idx = 0;
         self.signal_gen_dtype_idx = 6; // float32
         self.signal_gen_fields = vec![
-            ("Cycles/Entry".to_string(), "1.0".to_string()),
+            ("Cycles/Entry".to_string(), "2.0".to_string()),
             ("Amplitude".to_string(), "1.0".to_string()),
-            ("Noise".to_string(), "0.0".to_string()),
+            ("Noise".to_string(), "0.1".to_string()),
             ("Samples/Entry".to_string(), "100".to_string()),
             ("Entries/Sec".to_string(), "10.0".to_string()),
         ];

--- a/src/app.rs
+++ b/src/app.rs
@@ -162,6 +162,7 @@ pub struct App {
 
     // Panel area rects (set during draw)
     pub key_list_area: Option<(u16, u16, u16, u16)>,     // x, y, w, h
+    pub value_view_area: Option<(u16, u16, u16, u16)>,   // x, y, w, h
     pub signal_chart_area: Option<(u16, u16, u16, u16)>, // x, y, w, h (inner)
     pub fft_chart_area: Option<(u16, u16, u16, u16)>,
 
@@ -262,6 +263,7 @@ impl App {
             hover_in_fft: false,
 
             key_list_area: None,
+            value_view_area: None,
             signal_chart_area: None,
             fft_chart_area: None,
             pending_click_load: false,

--- a/src/app.rs
+++ b/src/app.rs
@@ -897,35 +897,6 @@ impl App {
         None
     }
 
-    pub fn apply_plot_limits(&mut self) -> Result<(), String> {
-        let y_min: f64 = self.edit_fields[0]
-            .1
-            .trim()
-            .parse()
-            .map_err(|_| "Invalid Y Min".to_string())?;
-        let y_max: f64 = self.edit_fields[1]
-            .1
-            .trim()
-            .parse()
-            .map_err(|_| "Invalid Y Max".to_string())?;
-        if y_min >= y_max {
-            return Err("Y Min must be less than Y Max".to_string());
-        }
-        match self.plot_focus {
-            PlotFocus::Signal => {
-                self.plot_y_min = y_min;
-                self.plot_y_max = y_max;
-                self.plot_auto_limits = false;
-            }
-            PlotFocus::FFT => {
-                self.fft_y_min = y_min;
-                self.fft_y_max = y_max;
-                self.fft_auto_limits = false;
-            }
-        }
-        Ok(())
-    }
-
     /// Open plot settings popup: unified X limits + per-slot Y limits
     pub fn start_plot_settings(&mut self) {
         let (x_min, x_max) = match self.plot_focus {
@@ -1023,31 +994,14 @@ impl App {
         Ok(())
     }
 
+    #[allow(dead_code)]
     pub fn apply_x_limits(&mut self) -> Result<(), String> {
-        let x_min: f64 = self.edit_fields[0]
-            .1
-            .trim()
-            .parse()
-            .map_err(|_| "Invalid X Min".to_string())?;
-        let x_max: f64 = self.edit_fields[1]
-            .1
-            .trim()
-            .parse()
-            .map_err(|_| "Invalid X Max".to_string())?;
-        if x_min >= x_max {
-            return Err("X Min must be less than X Max".to_string());
-        }
-        match self.plot_focus {
-            PlotFocus::Signal => {
-                self.plot_x_min = x_min;
-                self.plot_x_max = x_max;
-            }
-            PlotFocus::FFT => {
-                self.fft_x_min = x_min;
-                self.fft_x_max = x_max;
-            }
-        }
-        Ok(())
+        self.apply_plot_settings()
+    }
+
+    #[allow(dead_code)]
+    pub fn apply_plot_limits(&mut self) -> Result<(), String> {
+        self.apply_plot_settings()
     }
 
     pub fn auto_signal_bounds(&self) -> (f64, f64) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -643,6 +643,10 @@ impl App {
     pub fn recompute_plot(&mut self) {
         if let Some(value) = self.current_value.take() {
             self.update_plot_data(&value);
+            // Also update the plot slot for the currently viewed key
+            if let Some(key) = self.selected_key_name().map(|s| s.to_string()) {
+                self.update_slot_data(&key, &value);
+            }
             self.current_value = Some(value);
         }
         // Clear stale FFT data immediately so UI doesn't use mismatched data

--- a/src/app.rs
+++ b/src/app.rs
@@ -882,7 +882,17 @@ impl App {
         if let Some((cx, cy, cw, ch)) = self.signal_chart_area {
             if col >= cx && col < cx + cw && row >= cy && row < cy + ch {
                 let (x0, x1) = self.signal_x_bounds();
-                let (y0, y1) = if self.plot_auto_limits {
+                // Match the Y bounds logic used by the chart renderer
+                let (y0, y1) = if self.plot_slots.len() > 1 {
+                    (-0.05, 1.05)
+                } else if !self.plot_slots.is_empty() {
+                    let slot = &self.plot_slots[0];
+                    if slot.y_min.is_some() && slot.y_max.is_some() {
+                        (slot.y_min.unwrap(), slot.y_max.unwrap())
+                    } else {
+                        self.auto_signal_bounds()
+                    }
+                } else if self.plot_auto_limits {
                     self.auto_signal_bounds()
                 } else {
                     (self.plot_y_min, self.plot_y_max)

--- a/src/app.rs
+++ b/src/app.rs
@@ -27,6 +27,8 @@ pub struct PlotSlot {
     pub key_name: String,
     pub data: Vec<f64>,
     pub color: Color,
+    pub data_type: DataType,
+    pub endianness: Endianness,
     pub y_min: Option<f64>,  // None = auto
     pub y_max: Option<f64>,  // None = auto
 }
@@ -318,6 +320,8 @@ impl App {
         self.plot_slots.push(PlotSlot {
             key_name: key_name.to_string(),
             data: Vec::new(),
+            data_type: self.data_type,
+            endianness: self.endianness,
             y_min: None,
             y_max: None,
             color,
@@ -330,15 +334,17 @@ impl App {
         self.plot_slots.iter().find(|s| s.key_name == key_name).map(|s| s.color)
     }
 
-    /// Update plot data for a specific slot by key name
+    /// Update plot data for a specific slot by key name, using the slot's own data type
     pub fn update_slot_data(&mut self, key_name: &str, value: &RedisValue) {
         if let Some(slot) = self.plot_slots.iter_mut().find(|s| s.key_name == key_name) {
+            let dt = slot.data_type;
+            let en = slot.endianness;
             slot.data = match value {
                 RedisValue::String(bytes) => {
-                    decode_blob(bytes, self.data_type, self.endianness)
+                    decode_blob(bytes, dt, en)
                 }
                 RedisValue::Stream(entries) => {
-                    extract_stream_plot_data(entries, self.data_type, self.endianness)
+                    extract_stream_plot_data(entries, dt, en)
                 }
                 RedisValue::List(items) => {
                     let mut data = Vec::new();
@@ -349,7 +355,7 @@ impl App {
                                 continue;
                             }
                         }
-                        data.extend(decode_blob(item, self.data_type, self.endianness));
+                        data.extend(decode_blob(item, dt, en));
                     }
                     data
                 }
@@ -365,7 +371,7 @@ impl App {
                                 continue;
                             }
                         }
-                        data.extend(decode_blob(val, self.data_type, self.endianness));
+                        data.extend(decode_blob(val, dt, en));
                     }
                     data
                 }
@@ -380,14 +386,16 @@ impl App {
         }
     }
 
-    /// Append stream entries to a specific plot slot
+    /// Append stream entries to a specific plot slot, using the slot's own data type
     pub fn append_slot_stream_entries(&mut self, key_name: &str, new_entries: &[StreamEntry]) {
         if let Some(slot) = self.plot_slots.iter_mut().find(|s| s.key_name == key_name) {
+            let dt = slot.data_type;
+            let en = slot.endianness;
             // Re-extract plot data from the newest entry
             if let Some(entry) = new_entries.last() {
                 for (fname, fval) in &entry.fields {
                     if fname.starts_with('_') {
-                        slot.data = decode_blob(fval, self.data_type, self.endianness);
+                        slot.data = decode_blob(fval, dt, en);
                         for v in &mut slot.data {
                             if !v.is_finite() {
                                 *v = 0.0;
@@ -638,6 +646,41 @@ impl App {
                 *v = 0.0;
             }
         }
+    }
+
+    /// Cycle the data type for the currently selected key's plot slot (if plotted),
+    /// otherwise cycle the global data type. Then recompute.
+    pub fn cycle_data_type(&mut self, forward: bool) {
+        let new_type = if forward { self.data_type.next() } else { self.data_type.prev() };
+        // Update the slot for the selected key if it's plotted
+        if let Some(key) = self.selected_key_name().map(|s| s.to_string()) {
+            if let Some(slot) = self.plot_slots.iter_mut().find(|s| s.key_name == key) {
+                slot.data_type = if forward { slot.data_type.next() } else { slot.data_type.prev() };
+                self.data_type = slot.data_type;
+            } else {
+                self.data_type = new_type;
+            }
+        } else {
+            self.data_type = new_type;
+        }
+        self.recompute_plot();
+    }
+
+    /// Toggle endianness for the currently selected key's plot slot (if plotted),
+    /// otherwise toggle the global endianness. Then recompute.
+    pub fn toggle_endianness(&mut self) {
+        let new_end = self.endianness.toggle();
+        if let Some(key) = self.selected_key_name().map(|s| s.to_string()) {
+            if let Some(slot) = self.plot_slots.iter_mut().find(|s| s.key_name == key) {
+                slot.endianness = slot.endianness.toggle();
+                self.endianness = slot.endianness;
+            } else {
+                self.endianness = new_end;
+            }
+        } else {
+            self.endianness = new_end;
+        }
+        self.recompute_plot();
     }
 
     pub fn recompute_plot(&mut self) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -160,9 +160,13 @@ pub struct App {
     pub hover_data_y: Option<f64>,
     pub hover_in_fft: bool,   // true if hovering in FFT chart
 
-    // Chart area rects (set during draw)
+    // Panel area rects (set during draw)
+    pub key_list_area: Option<(u16, u16, u16, u16)>,     // x, y, w, h
     pub signal_chart_area: Option<(u16, u16, u16, u16)>, // x, y, w, h (inner)
     pub fft_chart_area: Option<(u16, u16, u16, u16)>,
+
+    // Pending actions from mouse clicks (processed in main loop with client access)
+    pub pending_click_load: bool,
 
     // Connection
     pub db: i64,
@@ -257,8 +261,10 @@ impl App {
             hover_data_y: None,
             hover_in_fft: false,
 
+            key_list_area: None,
             signal_chart_area: None,
             fft_chart_area: None,
+            pending_click_load: false,
 
             db: 0,
             db_size: 0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 use app::{App, InputMode, Panel};
 use clap::Parser;
 use crossterm::{
-    event::{self, Event, KeyCode, KeyModifiers, MouseEvent, MouseEventKind, EnableMouseCapture, DisableMouseCapture},
+    event::{self, Event, KeyCode, KeyModifiers, MouseEvent, MouseEventKind, EnableMouseCapture, DisableMouseCapture, EnableBracketedPaste, DisableBracketedPaste},
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
     ExecutableCommand,
 };
@@ -120,6 +120,7 @@ fn main() -> Result<()> {
     std::panic::set_hook(Box::new(move |info| {
         if std::thread::current().id() == main_thread_id {
             let _ = disable_raw_mode();
+            let _ = io::stdout().execute(DisableBracketedPaste);
             let _ = io::stdout().execute(DisableMouseCapture);
             let _ = io::stdout().execute(LeaveAlternateScreen);
         }
@@ -134,6 +135,9 @@ fn main() -> Result<()> {
     io::stdout()
         .execute(EnableMouseCapture)
         .context("Failed to enable mouse capture")?;
+    io::stdout()
+        .execute(EnableBracketedPaste)
+        .context("Failed to enable bracketed paste")?;
     let backend = CrosstermBackend::new(io::stdout());
     let mut terminal = Terminal::new(backend).context("Failed to create terminal")?;
 
@@ -142,6 +146,9 @@ fn main() -> Result<()> {
 
     // Restore terminal
     disable_raw_mode().context("Failed to disable raw mode")?;
+    io::stdout()
+        .execute(DisableBracketedPaste)
+        .context("Failed to disable bracketed paste")?;
     io::stdout()
         .execute(DisableMouseCapture)
         .context("Failed to disable mouse capture")?;
@@ -300,9 +307,42 @@ fn run_app(
         if event::poll(Duration::from_millis(50))? {
             let ev = event::read()?;
 
-            // Handle mouse events
+            // Handle mouse events (shift-bypass: let terminal handle native selection)
             if let Event::Mouse(mouse) = ev {
-                handle_mouse_event(&mut app, mouse);
+                if !mouse.modifiers.contains(KeyModifiers::SHIFT) {
+                    handle_mouse_event(&mut app, mouse);
+                }
+            }
+
+            // Handle paste events (bracketed paste from terminal)
+            if let Event::Paste(data) = &ev {
+                match app.input_mode {
+                    InputMode::Filter => app.filter_text.push_str(data),
+                    InputMode::Edit => {
+                        if let Some((_label, value)) = app.edit_fields.get_mut(app.edit_focus) {
+                            value.push_str(data);
+                        }
+                    }
+                    InputMode::PlotLimit => {
+                        if let Some((_label, value)) = app.edit_fields.get_mut(app.edit_focus) {
+                            value.push_str(data);
+                        }
+                    }
+                    InputMode::SignalGen => {
+                        if let Some(idx) = app.signal_gen_focus.checked_sub(2) {
+                            if let Some((_label, value)) = app.signal_gen_fields.get_mut(idx) {
+                                value.push_str(data);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            // Load value after click-to-select (needs client access)
+            if app.pending_click_load {
+                app.pending_click_load = false;
+                app.load_selected_value(client);
             }
 
             if let Event::Key(key) = ev {
@@ -1018,6 +1058,19 @@ fn handle_mouse_event(app: &mut App, mouse: MouseEvent) {
             }
         }
         MouseEventKind::Down(crossterm::event::MouseButton::Left) => {
+            // Click-to-select in key list
+            if let Some((kx, ky, kw, kh)) = app.key_list_area {
+                if col >= kx && col < kx + kw && row > ky && row < ky + kh.saturating_sub(1) {
+                    let visible_idx = (row - ky - 1) as usize;
+                    let actual_idx = visible_idx + app.key_list_state.offset();
+                    if actual_idx < app.keys.len() {
+                        app.key_list_state.select(Some(actual_idx));
+                        app.active_panel = Panel::KeyList;
+                        app.pending_click_load = true;
+                    }
+                    return;
+                }
+            }
             if app.mouse_to_data(col, row).is_some() {
                 app.mouse_dragging = true;
                 app.drag_start_x = col;

--- a/src/main.rs
+++ b/src/main.rs
@@ -312,10 +312,13 @@ fn run_app(
         if event::poll(Duration::from_millis(50))? {
             let ev = event::read()?;
 
-            // Handle mouse events (shift-bypass: let terminal handle native selection)
+            // Handle mouse events (shift/alt bypass: let terminal handle native selection)
             if let Event::Mouse(mouse) = ev {
-                if mouse.modifiers.contains(KeyModifiers::SHIFT) {
+                let selecting_modifier = mouse.modifiers.contains(KeyModifiers::SHIFT)
+                    || mouse.modifiers.contains(KeyModifiers::ALT);
+                if selecting_modifier {
                     // Suppress redraws so native text selection persists
+                    // Shift = line select, Alt = block/rectangular select
                     shift_selecting = true;
                 } else if shift_selecting {
                     // While selection is active, ignore all mouse events to
@@ -329,11 +332,10 @@ fn run_app(
                 }
             }
 
-            // A non-shift key press clears shift-selection (user is done copying)
+            // A non-modifier key press clears selection (user is done copying)
             if let Event::Key(key) = ev {
                 if key.kind == event::KeyEventKind::Press
-                    && key.code != KeyCode::Modifier(event::ModifierKeyCode::LeftShift)
-                    && key.code != KeyCode::Modifier(event::ModifierKeyCode::RightShift)
+                    && !matches!(key.code, KeyCode::Modifier(_))
                 {
                     shift_selecting = false;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -315,15 +315,18 @@ fn run_app(
             // Handle mouse events (shift-bypass: let terminal handle native selection)
             if let Event::Mouse(mouse) = ev {
                 if mouse.modifiers.contains(KeyModifiers::SHIFT) {
-                    // Track shift-select state to suppress redraws
-                    match mouse.kind {
-                        MouseEventKind::Down(_) => shift_selecting = true,
-                        MouseEventKind::Up(_) => shift_selecting = false,
-                        _ => {}
-                    }
+                    // Suppress redraws so native text selection persists
+                    shift_selecting = true;
                 } else {
                     shift_selecting = false;
                     handle_mouse_event(&mut app, mouse);
+                }
+            }
+
+            // Release shift-selection when any key is pressed without shift
+            if let Event::Key(ref key) = ev {
+                if !key.modifiers.contains(KeyModifiers::SHIFT) {
+                    shift_selecting = false;
                 }
             }
 
@@ -1117,15 +1120,15 @@ fn handle_mouse_event(app: &mut App, mouse: MouseEvent) {
             app.mouse_dragging = false;
         }
         MouseEventKind::ScrollUp => {
-            // Scroll key list if mouse is over it
+            // Scroll key list viewport (without changing selection)
             if let Some((kx, ky, kw, kh)) = app.key_list_area {
                 if col >= kx && col < kx + kw && row >= ky && row < ky + kh {
-                    app.select_prev_key();
-                    app.pending_click_load = true;
+                    let offset = app.key_list_state.offset_mut();
+                    *offset = offset.saturating_sub(1);
                     return;
                 }
             }
-            // Scroll value view if mouse is over it
+            // Scroll value view
             if let Some((vx, vy, vw, vh)) = app.value_view_area {
                 if col >= vx && col < vx + vw && row >= vy && row < vy + vh {
                     app.scroll_value_up();
@@ -1144,15 +1147,18 @@ fn handle_mouse_event(app: &mut App, mouse: MouseEvent) {
             }
         }
         MouseEventKind::ScrollDown => {
-            // Scroll key list if mouse is over it
+            // Scroll key list viewport (without changing selection)
             if let Some((kx, ky, kw, kh)) = app.key_list_area {
                 if col >= kx && col < kx + kw && row >= ky && row < ky + kh {
-                    app.select_next_key();
-                    app.pending_click_load = true;
+                    let max_offset = app.keys.len().saturating_sub(1);
+                    let offset = app.key_list_state.offset_mut();
+                    if *offset < max_offset {
+                        *offset += 1;
+                    }
                     return;
                 }
             }
-            // Scroll value view if mouse is over it
+            // Scroll value view
             if let Some((vx, vy, vw, vh)) = app.value_view_area {
                 if col >= vx && col < vx + vw && row >= vy && row < vy + vh {
                     app.scroll_value_down();

--- a/src/main.rs
+++ b/src/main.rs
@@ -626,22 +626,19 @@ fn handle_normal_input(
             app.plot_focus = app::PlotFocus::FFT;
         }
 
-        // Data plot controls
+        // Data type / endianness — updates the selected key's plot slot if plotted
         KeyCode::Char('t') if app.active_panel == Panel::DataPlot => {
             if modifiers.contains(KeyModifiers::SHIFT) {
-                app.data_type = app.data_type.prev();
+                app.cycle_data_type(false);
             } else {
-                app.data_type = app.data_type.next();
+                app.cycle_data_type(true);
             }
-            app.recompute_plot();
         }
         KeyCode::Char('T') => {
-            app.data_type = app.data_type.prev();
-            app.recompute_plot();
+            app.cycle_data_type(false);
         }
         KeyCode::Char('e') => {
-            app.endianness = app.endianness.toggle();
-            app.recompute_plot();
+            app.toggle_endianness();
         }
         KeyCode::Char('a') => {
             app.set_auto_limits();
@@ -664,10 +661,9 @@ fn handle_normal_input(
             app.status_message = format!("FFT scale: {}", state);
         }
 
-        // Global data type and endianness (work from any panel)
+        // Data type from any panel
         KeyCode::Char('t') if app.active_panel != Panel::DataPlot => {
-            app.data_type = app.data_type.next();
-            app.recompute_plot();
+            app.cycle_data_type(true);
         }
 
         // Actions

--- a/src/main.rs
+++ b/src/main.rs
@@ -300,8 +300,13 @@ fn run_app(
     let mut stream_listeners: Vec<StreamListener> = Vec::new();
     let mut signal_generators: Vec<SignalGenerator> = Vec::new();
 
+    let mut shift_selecting = false;
+
     loop {
-        terminal.draw(|frame| ui::draw(frame, &mut app))?;
+        // Skip redraws while shift-selecting to preserve native text selection
+        if !shift_selecting {
+            terminal.draw(|frame| ui::draw(frame, &mut app))?;
+        }
 
         // Poll for events with short timeout
         if event::poll(Duration::from_millis(50))? {
@@ -309,7 +314,15 @@ fn run_app(
 
             // Handle mouse events (shift-bypass: let terminal handle native selection)
             if let Event::Mouse(mouse) = ev {
-                if !mouse.modifiers.contains(KeyModifiers::SHIFT) {
+                if mouse.modifiers.contains(KeyModifiers::SHIFT) {
+                    // Track shift-select state to suppress redraws
+                    match mouse.kind {
+                        MouseEventKind::Down(_) => shift_selecting = true,
+                        MouseEventKind::Up(_) => shift_selecting = false,
+                        _ => {}
+                    }
+                } else {
+                    shift_selecting = false;
                     handle_mouse_event(&mut app, mouse);
                 }
             }
@@ -1104,6 +1117,22 @@ fn handle_mouse_event(app: &mut App, mouse: MouseEvent) {
             app.mouse_dragging = false;
         }
         MouseEventKind::ScrollUp => {
+            // Scroll key list if mouse is over it
+            if let Some((kx, ky, kw, kh)) = app.key_list_area {
+                if col >= kx && col < kx + kw && row >= ky && row < ky + kh {
+                    app.select_prev_key();
+                    app.pending_click_load = true;
+                    return;
+                }
+            }
+            // Scroll value view if mouse is over it
+            if let Some((vx, vy, vw, vh)) = app.value_view_area {
+                if col >= vx && col < vx + vw && row >= vy && row < vy + vh {
+                    app.scroll_value_up();
+                    return;
+                }
+            }
+            // Zoom plot if mouse is over chart area
             if let Some((cx, cy, cw, ch)) = if app.hover_in_fft {
                 app.fft_chart_area
             } else {
@@ -1115,6 +1144,22 @@ fn handle_mouse_event(app: &mut App, mouse: MouseEvent) {
             }
         }
         MouseEventKind::ScrollDown => {
+            // Scroll key list if mouse is over it
+            if let Some((kx, ky, kw, kh)) = app.key_list_area {
+                if col >= kx && col < kx + kw && row >= ky && row < ky + kh {
+                    app.select_next_key();
+                    app.pending_click_load = true;
+                    return;
+                }
+            }
+            // Scroll value view if mouse is over it
+            if let Some((vx, vy, vw, vh)) = app.value_view_area {
+                if col >= vx && col < vx + vw && row >= vy && row < vy + vh {
+                    app.scroll_value_down();
+                    return;
+                }
+            }
+            // Zoom plot if mouse is over chart area
             if let Some((cx, cy, cw, ch)) = if app.hover_in_fft {
                 app.fft_chart_area
             } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -312,20 +312,23 @@ fn run_app(
         if event::poll(Duration::from_millis(50))? {
             let ev = event::read()?;
 
-            // Handle mouse events (shift/alt bypass: let terminal handle native selection)
+            // Handle mouse events (shift bypass: let terminal handle native selection)
+            // Shift+drag = line select, Shift+Alt+drag = block/rectangular select
             if let Event::Mouse(mouse) = ev {
-                let selecting_modifier = mouse.modifiers.contains(KeyModifiers::SHIFT)
-                    || mouse.modifiers.contains(KeyModifiers::ALT);
-                if selecting_modifier {
-                    // Suppress redraws so native text selection persists
-                    // Shift = line select, Alt = block/rectangular select
-                    shift_selecting = true;
-                } else if shift_selecting {
-                    // While selection is active, ignore all mouse events to
-                    // keep the selection visible. Only a click clears it.
-                    if matches!(mouse.kind, MouseEventKind::Down(_)) {
+                if shift_selecting {
+                    // While selection is active, consume all mouse events to
+                    // prevent redraws. Only a plain click (no modifiers) clears it.
+                    if !mouse.modifiers.contains(KeyModifiers::SHIFT)
+                        && matches!(mouse.kind, MouseEventKind::Down(_))
+                    {
                         shift_selecting = false;
                         handle_mouse_event(&mut app, mouse);
+                    }
+                    // Otherwise: swallow the event entirely (don't let terminal see it)
+                } else if mouse.modifiers.contains(KeyModifiers::SHIFT) {
+                    // Starting a new selection — only activate on drag/down
+                    if matches!(mouse.kind, MouseEventKind::Down(_) | MouseEventKind::Drag(_)) {
+                        shift_selecting = true;
                     }
                 } else {
                     handle_mouse_event(&mut app, mouse);

--- a/src/main.rs
+++ b/src/main.rs
@@ -995,19 +995,7 @@ fn handle_plot_limit_input(app: &mut App, code: KeyCode) {
             }
         }
         KeyCode::Enter => {
-            // Detect if this is the combined 4-field settings popup or a legacy 2-field one
-            let result = if app.edit_fields.len() == 4 {
-                app.apply_plot_settings()
-            } else {
-                let is_x_limit = app.edit_fields.first()
-                    .map(|(label, _)| label.contains("X Min"))
-                    .unwrap_or(false);
-                if is_x_limit {
-                    app.apply_x_limits()
-                } else {
-                    app.apply_plot_limits()
-                }
-            };
+            let result = app.apply_plot_settings();
             match result {
                 Ok(_) => {
                     app.status_message = "Plot settings applied".to_string();

--- a/src/main.rs
+++ b/src/main.rs
@@ -317,17 +317,25 @@ fn run_app(
                 if mouse.modifiers.contains(KeyModifiers::SHIFT) {
                     // Suppress redraws so native text selection persists
                     shift_selecting = true;
+                } else if shift_selecting {
+                    // Non-shift mouse event while selecting: a click elsewhere
+                    // clears the selection, but plain mouse-up/move after releasing
+                    // shift should keep the selection until an explicit action
+                    match mouse.kind {
+                        MouseEventKind::Down(_) => {
+                            shift_selecting = false;
+                            handle_mouse_event(&mut app, mouse);
+                        }
+                        _ => {} // ignore move/up/scroll — keep selection visible
+                    }
                 } else {
-                    shift_selecting = false;
                     handle_mouse_event(&mut app, mouse);
                 }
             }
 
-            // Release shift-selection when any key is pressed without shift
-            if let Event::Key(ref key) = ev {
-                if !key.modifiers.contains(KeyModifiers::SHIFT) {
-                    shift_selecting = false;
-                }
+            // Any keypress clears shift-selection (user is done copying)
+            if let Event::Key(_) = ev {
+                shift_selecting = false;
             }
 
             // Handle paste events (bracketed paste from terminal)

--- a/src/main.rs
+++ b/src/main.rs
@@ -318,15 +318,11 @@ fn run_app(
                     // Suppress redraws so native text selection persists
                     shift_selecting = true;
                 } else if shift_selecting {
-                    // Non-shift mouse event while selecting: a click elsewhere
-                    // clears the selection, but plain mouse-up/move after releasing
-                    // shift should keep the selection until an explicit action
-                    match mouse.kind {
-                        MouseEventKind::Down(_) => {
-                            shift_selecting = false;
-                            handle_mouse_event(&mut app, mouse);
-                        }
-                        _ => {} // ignore move/up/scroll — keep selection visible
+                    // While selection is active, ignore all mouse events to
+                    // keep the selection visible. Only a click clears it.
+                    if matches!(mouse.kind, MouseEventKind::Down(_)) {
+                        shift_selecting = false;
+                        handle_mouse_event(&mut app, mouse);
                     }
                 } else {
                     handle_mouse_event(&mut app, mouse);

--- a/src/main.rs
+++ b/src/main.rs
@@ -312,28 +312,35 @@ fn run_app(
         if event::poll(Duration::from_millis(50))? {
             let ev = event::read()?;
 
-            // Handle mouse events
-            // Shift disables mouse capture so the terminal handles native selection.
-            // Shift+drag = line select, Shift+Alt+drag = block/rectangular select.
+            // Handle mouse events (shift bypass: let terminal handle native selection)
+            // Shift+drag = line select, Shift+Alt+drag = block/rectangular select
             if let Event::Mouse(mouse) = ev {
-                if mouse.modifiers.contains(KeyModifiers::SHIFT) && !shift_selecting {
-                    // Entering selection mode: disable mouse capture so
-                    // the terminal handles selection natively
-                    let _ = io::stdout().execute(DisableMouseCapture);
-                    shift_selecting = true;
-                } else if !shift_selecting {
+                if shift_selecting {
+                    // While selection is active, consume all mouse events to
+                    // prevent redraws. Only a plain click (no modifiers) clears it.
+                    if !mouse.modifiers.contains(KeyModifiers::SHIFT)
+                        && matches!(mouse.kind, MouseEventKind::Down(_))
+                    {
+                        shift_selecting = false;
+                        handle_mouse_event(&mut app, mouse);
+                    }
+                    // Otherwise: swallow the event entirely (don't let terminal see it)
+                } else if mouse.modifiers.contains(KeyModifiers::SHIFT) {
+                    // Starting a new selection — only activate on drag/down
+                    if matches!(mouse.kind, MouseEventKind::Down(_) | MouseEventKind::Drag(_)) {
+                        shift_selecting = true;
+                    }
+                } else {
                     handle_mouse_event(&mut app, mouse);
                 }
             }
 
-            // Re-enable mouse capture when a non-modifier key is pressed
+            // A non-modifier key press clears selection (user is done copying)
             if let Event::Key(key) = ev {
-                if shift_selecting
-                    && key.kind == event::KeyEventKind::Press
+                if key.kind == event::KeyEventKind::Press
                     && !matches!(key.code, KeyCode::Modifier(_))
                 {
                     shift_selecting = false;
-                    let _ = io::stdout().execute(EnableMouseCapture);
                 }
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -329,9 +329,14 @@ fn run_app(
                 }
             }
 
-            // Any keypress clears shift-selection (user is done copying)
-            if let Event::Key(_) = ev {
-                shift_selecting = false;
+            // A non-shift key press clears shift-selection (user is done copying)
+            if let Event::Key(key) = ev {
+                if key.kind == event::KeyEventKind::Press
+                    && key.code != KeyCode::Modifier(event::ModifierKeyCode::LeftShift)
+                    && key.code != KeyCode::Modifier(event::ModifierKeyCode::RightShift)
+                {
+                    shift_selecting = false;
+                }
             }
 
             // Handle paste events (bracketed paste from terminal)

--- a/src/main.rs
+++ b/src/main.rs
@@ -312,35 +312,28 @@ fn run_app(
         if event::poll(Duration::from_millis(50))? {
             let ev = event::read()?;
 
-            // Handle mouse events (shift bypass: let terminal handle native selection)
-            // Shift+drag = line select, Shift+Alt+drag = block/rectangular select
+            // Handle mouse events
+            // Shift disables mouse capture so the terminal handles native selection.
+            // Shift+drag = line select, Shift+Alt+drag = block/rectangular select.
             if let Event::Mouse(mouse) = ev {
-                if shift_selecting {
-                    // While selection is active, consume all mouse events to
-                    // prevent redraws. Only a plain click (no modifiers) clears it.
-                    if !mouse.modifiers.contains(KeyModifiers::SHIFT)
-                        && matches!(mouse.kind, MouseEventKind::Down(_))
-                    {
-                        shift_selecting = false;
-                        handle_mouse_event(&mut app, mouse);
-                    }
-                    // Otherwise: swallow the event entirely (don't let terminal see it)
-                } else if mouse.modifiers.contains(KeyModifiers::SHIFT) {
-                    // Starting a new selection — only activate on drag/down
-                    if matches!(mouse.kind, MouseEventKind::Down(_) | MouseEventKind::Drag(_)) {
-                        shift_selecting = true;
-                    }
-                } else {
+                if mouse.modifiers.contains(KeyModifiers::SHIFT) && !shift_selecting {
+                    // Entering selection mode: disable mouse capture so
+                    // the terminal handles selection natively
+                    let _ = io::stdout().execute(DisableMouseCapture);
+                    shift_selecting = true;
+                } else if !shift_selecting {
                     handle_mouse_event(&mut app, mouse);
                 }
             }
 
-            // A non-modifier key press clears selection (user is done copying)
+            // Re-enable mouse capture when a non-modifier key is pressed
             if let Event::Key(key) = ev {
-                if key.kind == event::KeyEventKind::Press
+                if shift_selecting
+                    && key.kind == event::KeyEventKind::Press
                     && !matches!(key.code, KeyCode::Modifier(_))
                 {
                     shift_selecting = false;
+                    let _ = io::stdout().execute(EnableMouseCapture);
                 }
             }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -485,7 +485,7 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
                 } else {
                     slot.key_name.clone()
                 };
-                let legend_name = format!("{} [{:.0}..{:.0}]", short_name, sr.y_min, sr.y_max);
+                let legend_name = format!("{} {} [{:.0}..{:.0}]", short_name, slot.data_type, sr.y_min, sr.y_max);
                 datasets.push(Dataset::default()
                     .name(legend_name)
                     .marker(marker)

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -822,18 +822,18 @@ fn draw_help_popup(frame: &mut Frame, app: &App, area: Rect) {
     let key_style = Style::default().fg(Color::Green).add_modifier(Modifier::BOLD);
 
     let help_text = vec![
-        Line::from(Span::styled("Redis TUI — Keyboard Reference", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD))),
+        Line::from(Span::styled("Redis TUI — Controls Reference", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD))),
         Line::from(""),
         // --- Navigation ---
         Line::from(vec![Span::styled("Navigation", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))]),
         Line::from(vec![
             Span::styled("  Up/Down  ", key_style),
-            Span::raw("Navigate the key list, scroll value view, or"),
+            Span::raw("Navigate keys, scroll value view, or select"),
         ]),
-        Line::from(Span::styled("            switch between Signal/FFT plots", dim)),
+        Line::from(Span::styled("            Signal/FFT sub-plot", dim)),
         Line::from(vec![
             Span::styled("  Enter    ", key_style),
-            Span::raw("Load the selected key's value and plot its data"),
+            Span::raw("Load the selected key's value"),
         ]),
         Line::from(vec![
             Span::styled("  Tab      ", key_style),
@@ -842,6 +842,10 @@ fn draw_help_popup(frame: &mut Frame, app: &App, area: Rect) {
         Line::from(vec![
             Span::styled("  Shift+Tab", key_style),
             Span::raw("  Cycle focus in reverse"),
+        ]),
+        Line::from(vec![
+            Span::styled("  0-9      ", key_style),
+            Span::raw("Switch to Redis database 0-9"),
         ]),
         Line::from(""),
         // --- Key Operations ---
@@ -858,14 +862,13 @@ fn draw_help_popup(frame: &mut Frame, app: &App, area: Rect) {
             Span::styled("  s        ", key_style),
             Span::raw("Edit the selected key's value"),
         ]),
-        Line::from(Span::styled("            Ctrl+B toggles binary encoding mode", dim)),
         Line::from(vec![
             Span::styled("  n        ", key_style),
-            Span::raw("Create a new key (string, list, hash, set, stream)"),
+            Span::raw("Create a new key (←/→ to choose type)"),
         ]),
         Line::from(vec![
             Span::styled("  d        ", key_style),
-            Span::raw("Delete the selected key (with confirmation)"),
+            Span::raw("Delete the selected key (y/n to confirm)"),
         ]),
         Line::from(vec![
             Span::styled("  R        ", key_style),
@@ -873,51 +876,74 @@ fn draw_help_popup(frame: &mut Frame, app: &App, area: Rect) {
         ]),
         Line::from(vec![
             Span::styled("  z        ", key_style),
-            Span::raw("Set TTL (expiry) on the selected key in seconds"),
+            Span::raw("Set TTL on the selected key (-1 to persist)"),
+        ]),
+        Line::from(""),
+        // --- Edit Mode ---
+        Line::from(vec![Span::styled("Edit Mode", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))]),
+        Line::from(vec![
+            Span::styled("  Tab      ", key_style),
+            Span::raw("Next field"),
         ]),
         Line::from(vec![
-            Span::styled("  0-9      ", key_style),
-            Span::raw("Switch to Redis database 0-9"),
+            Span::styled("  Shift+Tab", key_style),
+            Span::raw("  Previous field"),
         ]),
+        Line::from(vec![
+            Span::styled("  Enter    ", key_style),
+            Span::raw("Submit (multi-entry types stay open)"),
+        ]),
+        Line::from(vec![
+            Span::styled("  Esc      ", key_style),
+            Span::raw("Cancel / close edit popup"),
+        ]),
+        Line::from(vec![
+            Span::styled("  Ctrl+B   ", key_style),
+            Span::raw("Toggle binary encoding mode"),
+        ]),
+        Line::from(vec![
+            Span::styled("  Ctrl+T   ", key_style),
+            Span::raw("Cycle binary data type (Int8..Float64)"),
+        ]),
+        Line::from(vec![
+            Span::styled("  Ctrl+E   ", key_style),
+            Span::raw("Toggle endianness (LE/BE)"),
+        ]),
+        Line::from(Span::styled("            Paste supported in all input fields", dim)),
         Line::from(""),
         // --- Streams ---
         Line::from(vec![Span::styled("Streams", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))]),
         Line::from(vec![
             Span::styled("  l        ", key_style),
-            Span::raw("Start/stop live stream listener (XREAD)"),
+            Span::raw("Toggle live stream listener (up to 4 keys)"),
         ]),
-        Line::from(Span::styled("            Blocks on the selected stream key for new entries", dim)),
         Line::from(vec![
             Span::styled("  w        ", key_style),
-            Span::raw("Open signal generator config (for stream keys)"),
+            Span::raw("Toggle signal generator (sine/square/saw/tri)"),
         ]),
-        Line::from(Span::styled("            Generates sine/square/saw waves into the stream", dim)),
+        Line::from(Span::styled("            ←/→ to select wave type and data type", dim)),
         Line::from(""),
         // --- Data Plot ---
         Line::from(vec![Span::styled("Data Plot", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))]),
         Line::from(vec![
             Span::styled("  p        ", key_style),
-            Span::raw("Show/hide the plot panel (hidden by default)"),
+            Span::raw("Toggle key in plot (up to 4, FIFO eviction)"),
         ]),
         Line::from(vec![
             Span::styled("  t / T    ", key_style),
-            Span::raw("Cycle data type: Int8..Float64, String, Blob"),
+            Span::raw("Cycle data type forward / backward"),
         ]),
         Line::from(vec![
             Span::styled("  e        ", key_style),
-            Span::raw("Toggle byte order: Little-Endian ↔ Big-Endian"),
+            Span::raw("Toggle endianness: Little ↔ Big"),
         ]),
         Line::from(vec![
             Span::styled("  a        ", key_style),
-            Span::raw("Auto-fit axis limits to data range"),
+            Span::raw("Auto-fit axis limits to data"),
         ]),
         Line::from(vec![
             Span::styled("  x        ", key_style),
-            Span::raw("Set manual X-axis limits on the focused plot"),
-        ]),
-        Line::from(vec![
-            Span::styled("  y        ", key_style),
-            Span::raw("Set manual Y-axis limits on the focused plot"),
+            Span::raw("Set plot axis limits (X + per-key Y)"),
         ]),
         Line::from(vec![
             Span::styled("  f        ", key_style),
@@ -925,19 +951,27 @@ fn draw_help_popup(frame: &mut Frame, app: &App, area: Rect) {
         ]),
         Line::from(vec![
             Span::styled("  g        ", key_style),
-            Span::raw("Toggle FFT Y-axis: linear ↔ log₁₀ scale"),
+            Span::raw("Toggle FFT scale: linear ↔ log"),
         ]),
-        Line::from(Span::styled("            Use Up/Down to switch focus between Signal and FFT", dim)),
         Line::from(""),
         // --- Mouse ---
-        Line::from(vec![Span::styled("Mouse (Plot)", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))]),
+        Line::from(vec![Span::styled("Mouse", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))]),
         Line::from(vec![
-            Span::styled("  Scroll   ", key_style),
-            Span::raw("Zoom in/out on the plot under the cursor"),
+            Span::styled("  Click    ", key_style),
+            Span::raw("Select a key in the key list"),
         ]),
         Line::from(vec![
+            Span::styled("  Scroll   ", key_style),
+            Span::raw("Key list / value view: scroll content"),
+        ]),
+        Line::from(Span::styled("            Data plot: zoom in/out at cursor", dim)),
+        Line::from(vec![
             Span::styled("  Drag     ", key_style),
-            Span::raw("Pan the plot view (X and Y axes)"),
+            Span::raw("Pan the plot (X and Y axes)"),
+        ]),
+        Line::from(vec![
+            Span::styled("  Shift    ", key_style),
+            Span::raw("Hold for native text selection + right-click copy"),
         ]),
         Line::from(""),
         // --- General ---
@@ -948,7 +982,7 @@ fn draw_help_popup(frame: &mut Frame, app: &App, area: Rect) {
         ]),
         Line::from(vec![
             Span::styled("  q / Esc  ", key_style),
-            Span::raw("Quit the application (or close a popup)"),
+            Span::raw("Quit (or close popup)"),
         ]),
     ];
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -423,18 +423,24 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
     let (y_lo, y_hi) = if app.plot_slots.len() > 1 {
         // Multi-key: always normalized 0-1, per-key Y scales rendered separately
         (-0.05, 1.05)
-    } else if !app.plot_slots.is_empty() && app.plot_auto_limits {
-        // Single slot, auto: use its actual bounds
-        let all_data: Vec<f64> = app.plot_slots[0].data.iter().copied()
-            .filter(|v| v.is_finite()).collect();
-        if all_data.is_empty() {
-            (0.0, 1.0)
+    } else if !app.plot_slots.is_empty() {
+        let slot = &app.plot_slots[0];
+        if slot.y_min.is_some() && slot.y_max.is_some() {
+            // Manual per-slot limits
+            (slot.y_min.unwrap(), slot.y_max.unwrap())
         } else {
-            let y_min = all_data.iter().copied().fold(f64::INFINITY, f64::min);
-            let y_max = all_data.iter().copied().fold(f64::NEG_INFINITY, f64::max);
-            let range = y_max - y_min;
-            let pad = if range == 0.0 { 1.0 } else { range * 0.1 };
-            (y_min - pad, y_max + pad)
+            // Auto: use actual data bounds
+            let all_data: Vec<f64> = slot.data.iter().copied()
+                .filter(|v| v.is_finite()).collect();
+            if all_data.is_empty() {
+                (0.0, 1.0)
+            } else {
+                let y_min = all_data.iter().copied().fold(f64::INFINITY, f64::min);
+                let y_max = all_data.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+                let range = y_max - y_min;
+                let pad = if range == 0.0 { 1.0 } else { range * 0.1 };
+                (y_min - pad, y_max + pad)
+            }
         }
     } else if app.plot_auto_limits {
         app.auto_signal_bounds()

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -457,10 +457,28 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
         border_color
     };
 
-    // Build title with hover coords
+    // Build title with hover coords — show Y value for each plotted key
     let hover_suffix = if !app.hover_in_fft {
-        if let (Some(hx), Some(hy)) = (app.hover_data_x, app.hover_data_y) {
-            format!(" x:{:.1} y:{:.2}", hx, hy)
+        if let Some(hx) = app.hover_data_x {
+            let x_idx = hx.round() as usize;
+            if !app.plot_slots.is_empty() {
+                let mut parts = vec![format!(" x:{:.0}", hx)];
+                for slot in &app.plot_slots {
+                    if let Some(&val) = slot.data.get(x_idx) {
+                        let short = if slot.key_name.len() > 8 {
+                            format!("{}...", &slot.key_name[..8])
+                        } else {
+                            slot.key_name.clone()
+                        };
+                        parts.push(format!("{}:{:.2}", short, val));
+                    }
+                }
+                parts.join(" ")
+            } else if let Some(hy) = app.hover_data_y {
+                format!(" x:{:.1} y:{:.2}", hx, hy)
+            } else {
+                String::new()
+            }
         } else {
             String::new()
         }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -113,6 +113,7 @@ fn draw_body(frame: &mut Frame, app: &mut App, area: Rect) {
 }
 
 fn draw_key_list(frame: &mut Frame, app: &mut App, area: Rect) {
+    app.key_list_area = Some((area.x, area.y, area.width, area.height));
     let border_color = if app.active_panel == Panel::KeyList {
         BORDER_ACTIVE
     } else {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -196,7 +196,8 @@ fn draw_key_list(frame: &mut Frame, app: &mut App, area: Rect) {
     frame.render_stateful_widget(list, area, &mut app.key_list_state);
 }
 
-fn draw_value_view(frame: &mut Frame, app: &App, area: Rect) {
+fn draw_value_view(frame: &mut Frame, app: &mut App, area: Rect) {
+    app.value_view_area = Some((area.x, area.y, area.width, area.height));
     let border_color = if app.active_panel == Panel::ValueView {
         BORDER_ACTIVE
     } else {


### PR DESCRIPTION
## Summary
- **Click-to-select**: Left-click on a key in the key list to select and load it instantly
- **Shift-bypass**: Hold Shift to let the terminal handle native text selection and right-click copy — works in any pane (key list, value view, data plot)
- **Paste support**: Bracketed paste enabled — paste text from clipboard into filter, edit, plot settings, and signal gen input fields

## Test plan
- [x] All 40 tests pass
- [ ] Click on keys in key list — selects and loads value
- [ ] Shift + click-drag in value view — native terminal text selection
- [ ] Shift + right-click — terminal copy/paste context menu
- [ ] Copy text externally, paste into edit/filter fields — text inserted