### PR TITLE
Add Docker publish workflow for Harbor registry

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,1 @@
+--secret-file .secrets

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,54 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  REGISTRY: adregistry.fnal.gov
+  IMAGE: adregistry.fnal.gov/instrumentation/redis-tui
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    env:
+      HARBOR_USERNAME: ${{ secrets.HARBOR_USERNAME }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read version from Cargo.toml
+        id: version
+        run: |
+          VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to Harbor
+        if: env.HARBOR_USERNAME != ''
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_PASSWORD }}
+
+      - name: Set image tags
+        id: tags
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ -n "$ACT" ]; then
+            BRANCH=$(echo "${{ github.ref_name }}" | sed 's|/|-|g')
+            echo "tags=${{ env.IMAGE }}:latest-${BRANCH},${{ env.IMAGE }}:${VERSION}-${BRANCH}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tags=${{ env.IMAGE }}:latest,${{ env.IMAGE }}:${VERSION}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.tags.outputs.tags }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,7 +38,7 @@ jobs:
         id: tags
         run: |
           VERSION=${{ steps.version.outputs.version }}
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ -n "$ACT" ]; then
+          if [ -n "$ACT" ] || { [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.ref_name }}" != "main" ]; }; then
             BRANCH=$(echo "${{ github.ref_name }}" | sed 's|/|-|g')
             echo "tags=${{ env.IMAGE }}:latest-${BRANCH},${{ env.IMAGE }}:${VERSION}-${BRANCH}" >> "$GITHUB_OUTPUT"
           else

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .claude/settings.local.json
 memory/
 dump.rdb
+.secrets

--- a/.secrets.example
+++ b/.secrets.example
@@ -1,0 +1,2 @@
+HARBOR_USERNAME=your-harbor-username
+HARBOR_PASSWORD=your-harbor-password-or-token


### PR DESCRIPTION
Builds and pushes linux/amd64 image to adregistry.fnal.gov/instrumentation/redis-tui. Tags with latest + Cargo.toml version on push to main; branch-suffixed tags on workflow_dispatch or local act runs to avoid polluting Harbor. Includes .actrc and .secrets.example for local testing with act.

I went ahead and added CI/CD to redis-tui. It won't work until we get a username and password for the runner, or a key or whatever, and add it to the secrets, so that it can use it. It would also work if one of us put our username and password in for that.