### PR TITLE
Fix DB reporting, TTL=0 deletion, silent SCAN drops, and non-finite plot limits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ cargo test app::tests          # Run only app module tests
 cargo test data::tests         # Run only data module tests
 cargo test ui::tests           # Run only UI tests
 cargo test <test_name>         # Run a single test by name
+cargo test -- --ignored        # Live-Redis tests (spawns throwaway redis-server)
 cargo clippy                   # Lint
 cargo fmt                      # Format
 ```
@@ -124,7 +125,9 @@ The chart Y bounds must match between `ui.rs` rendering and `app.rs` `mouse_to_d
 
 ### Tests
 
-Tests are `#[cfg(test)]` modules at the bottom of `data.rs`, `app.rs`, and `ui.rs`. No integration tests (single-binary TUI). Tests in `ui.rs` use `ratatui::backend::TestBackend` for rendering verification.
+Tests are `#[cfg(test)]` modules at the bottom of `data.rs`, `app.rs`, `ui.rs`, and `redis_client.rs`. Tests in `ui.rs` use `ratatui::backend::TestBackend` for rendering verification.
+
+There is no `tests/` directory: this is a binary-only crate with no lib target, so external integration tests cannot import the modules. Tests needing a live Redis live in `redis_client.rs`'s test module instead, marked `#[ignore]` and run with `cargo test -- --ignored`. The `TestRedis` harness there spawns a throwaway `redis-server` per test (claiming a port from an `AtomicU16` starting at 6390, since cargo runs tests in parallel) and kills it on `Drop`. They require `redis-server` on `PATH` and are not run by `cargo test` alone.
 
 ## Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ The chart Y bounds must match between `ui.rs` rendering and `app.rs` `mouse_to_d
 
 Tests are `#[cfg(test)]` modules at the bottom of `data.rs`, `app.rs`, `ui.rs`, and `redis_client.rs`. Tests in `ui.rs` use `ratatui::backend::TestBackend` for rendering verification.
 
-There is no `tests/` directory: this is a binary-only crate with no lib target, so external integration tests cannot import the modules. Tests needing a live Redis live in `redis_client.rs`'s test module instead, marked `#[ignore]` and run with `cargo test -- --ignored`. The `TestRedis` harness there spawns a throwaway `redis-server` per test (claiming a port from an `AtomicU16` starting at 6390, since cargo runs tests in parallel) and kills it on `Drop`. They require `redis-server` on `PATH` and are not run by `cargo test` alone.
+There is no `tests/` directory: this is a binary-only crate with no lib target, so external integration tests cannot import the modules. Tests needing a live Redis live in `redis_client.rs`'s test module instead, marked `#[ignore]` and run with `cargo test -- --ignored`. The `TestRedis` harness there spawns a throwaway `redis-server` per test and kills it on `Drop`. Ports come from the OS (bind `127.0.0.1:0`, read the assigned port, release it) rather than a fixed or sequential range, so parallel tests and concurrent `cargo test` runs cannot collide with each other or with a dev instance on 6379/6380; `start()` retries up to 5 times on a fresh port and detects early child exit via `try_wait`. They require `redis-server` on `PATH` and are not run by `cargo test` alone.
 
 ## Conventions
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "redis-tui"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-tui"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 description = "A Redis TUI client inspired by Redis Insight"
 license = "BSD-3-Clause"

--- a/src/app.rs
+++ b/src/app.rs
@@ -688,7 +688,7 @@ impl App {
 
     pub fn refresh_keys(&mut self, client: &mut MultiRedisClient) {
         match client.scan_keys(&self.filter_pattern) {
-            Ok(keys) => {
+            Ok((keys, skipped)) => {
                 // Get types for each key
                 let mut types = Vec::with_capacity(keys.len());
                 for key in &keys {
@@ -705,14 +705,24 @@ impl App {
                 self.collisions = client.collisions.clone();
                 let collision_count = self.collisions.len();
 
+                // Keys that failed UTF-8 decoding cannot be shown in a text UI, but
+                // staying silent would make Redis look like it holds fewer keys than it does.
+                let skipped_note = if skipped > 0 {
+                    format!(" ({} skipped: encoding errors)", skipped)
+                } else {
+                    String::new()
+                };
+
                 if collision_count > 0 {
                     self.status_message = format!(
-                        "Loaded {} keys ({} collisions!)",
+                        "Loaded {} keys ({} collisions!){}",
                         self.keys.len(),
-                        collision_count
+                        collision_count,
+                        skipped_note
                     );
                 } else {
-                    self.status_message = format!("Loaded {} keys", self.keys.len());
+                    self.status_message =
+                        format!("Loaded {} keys{}", self.keys.len(), skipped_note);
                 }
 
                 // Preserve selection if possible
@@ -1229,10 +1239,8 @@ impl App {
 
     /// Apply plot settings: unified X + per-slot Y limits
     pub fn apply_plot_settings(&mut self) -> Result<(), String> {
-        let x_min: f64 = self.edit_fields[0].1.trim().parse()
-            .map_err(|_| "Invalid X Min".to_string())?;
-        let x_max: f64 = self.edit_fields[1].1.trim().parse()
-            .map_err(|_| "Invalid X Max".to_string())?;
+        let x_min = parse_finite(&self.edit_fields[0].1, "X Min")?;
+        let x_max = parse_finite(&self.edit_fields[1].1, "X Max")?;
         if x_min >= x_max {
             return Err("X Min must be less than X Max".to_string());
         }
@@ -1250,10 +1258,8 @@ impl App {
         if self.plot_slots.is_empty() {
             // Single Y range
             if self.edit_fields.len() >= 4 {
-                let y_min: f64 = self.edit_fields[2].1.trim().parse()
-                    .map_err(|_| "Invalid Y Min".to_string())?;
-                let y_max: f64 = self.edit_fields[3].1.trim().parse()
-                    .map_err(|_| "Invalid Y Max".to_string())?;
+                let y_min = parse_finite(&self.edit_fields[2].1, "Y Min")?;
+                let y_max = parse_finite(&self.edit_fields[3].1, "Y Max")?;
                 if y_min >= y_max {
                     return Err("Y Min must be less than Y Max".to_string());
                 }
@@ -1266,10 +1272,14 @@ impl App {
             for (i, slot) in self.plot_slots.iter_mut().enumerate() {
                 let base = 2 + i * 2;
                 if base + 1 < self.edit_fields.len() {
-                    let y_min: f64 = self.edit_fields[base].1.trim().parse()
-                        .map_err(|_| format!("Invalid Y Min for '{}'", slot.key_name))?;
-                    let y_max: f64 = self.edit_fields[base + 1].1.trim().parse()
-                        .map_err(|_| format!("Invalid Y Max for '{}'", slot.key_name))?;
+                    let y_min = parse_finite(
+                        &self.edit_fields[base].1,
+                        &format!("Y Min for '{}'", slot.key_name),
+                    )?;
+                    let y_max = parse_finite(
+                        &self.edit_fields[base + 1].1,
+                        &format!("Y Max for '{}'", slot.key_name),
+                    )?;
                     if y_min >= y_max {
                         return Err(format!("Y Min >= Y Max for '{}'", slot.key_name));
                     }
@@ -1952,6 +1962,22 @@ fn cap_stream_entries(value: &mut RedisValue) {
     }
 }
 
+/// Parse a user-entered plot bound, rejecting anything non-finite.
+///
+/// `"nan"` and `"inf"` both parse successfully as f64, and every comparison against NaN
+/// is false - so without an explicit finite check they slip past the min/max guards and
+/// poison the chart bounds.
+fn parse_finite(raw: &str, label: &str) -> Result<f64, String> {
+    let value: f64 = raw
+        .trim()
+        .parse()
+        .map_err(|_| format!("Invalid {}", label))?;
+    if !value.is_finite() {
+        return Err(format!("{} must be a finite number", label));
+    }
+    Ok(value)
+}
+
 fn extract_stream_plot_data(
     entries: &[StreamEntry],
     data_type: DataType,
@@ -2037,6 +2063,72 @@ pub fn compute_fft_magnitude(data: &[f64]) -> Vec<f64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- #31: plot limit validation rejects non-finite values ----
+
+    fn app_with_plot_fields(fields: &[&str]) -> App {
+        let mut app = App::new();
+        app.edit_fields = fields
+            .iter()
+            .map(|v| ("f".to_string(), v.to_string()))
+            .collect();
+        app
+    }
+
+    #[test]
+    fn plot_settings_rejects_nan_x_min() {
+        // "nan".parse::<f64>() succeeds, and NaN >= x_max is false, so NaN slips
+        // past the min/max guard and poisons the chart bounds.
+        let mut app = app_with_plot_fields(&["nan", "100", "0", "1"]);
+        assert!(app.apply_plot_settings().is_err());
+    }
+
+    #[test]
+    fn plot_settings_rejects_negative_infinite_x_min() {
+        let mut app = app_with_plot_fields(&["-inf", "100", "0", "1"]);
+        assert!(app.apply_plot_settings().is_err());
+    }
+
+    #[test]
+    fn plot_settings_rejects_infinite_x_max() {
+        let mut app = app_with_plot_fields(&["0", "inf", "0", "1"]);
+        assert!(app.apply_plot_settings().is_err());
+    }
+
+    #[test]
+    fn plot_settings_rejects_nan_y_min() {
+        let mut app = app_with_plot_fields(&["0", "100", "nan", "1"]);
+        assert!(app.apply_plot_settings().is_err());
+    }
+
+    #[test]
+    fn plot_settings_rejects_infinite_y_max() {
+        let mut app = app_with_plot_fields(&["0", "100", "0", "inf"]);
+        assert!(app.apply_plot_settings().is_err());
+    }
+
+    #[test]
+    fn plot_settings_rejects_nan_in_per_slot_y() {
+        let mut app = App::new();
+        app.toggle_plot_slot("mykey");
+        app.edit_fields = vec![
+            ("X Min".to_string(), "0".to_string()),
+            ("X Max".to_string(), "100".to_string()),
+            ("Y Min".to_string(), "nan".to_string()),
+            ("Y Max".to_string(), "1".to_string()),
+        ];
+        assert!(app.apply_plot_settings().is_err());
+    }
+
+    #[test]
+    fn plot_settings_accepts_finite_values() {
+        let mut app = app_with_plot_fields(&["0", "100", "-5", "5"]);
+        assert!(app.apply_plot_settings().is_ok());
+        assert_eq!(app.plot_x_min, 0.0);
+        assert_eq!(app.plot_x_max, 100.0);
+        assert_eq!(app.plot_y_min, -5.0);
+        assert_eq!(app.plot_y_max, 5.0);
+    }
 
     #[test]
     fn toggle_plot_slot_adds_key() {

--- a/src/redis_client.rs
+++ b/src/redis_client.rs
@@ -38,6 +38,48 @@ pub struct RedisClient {
     pub db: i64,
 }
 
+/// Extract the database number from a Redis URL, e.g. `redis://host:6379/3` -> 3.
+///
+/// Returns 0 when the URL carries no usable database component. Query strings and
+/// fragments are stripped first, so `redis://host/3?timeout=5` yields 3 rather than
+/// silently falling back to 0.
+fn parse_db_from_url(url: &str) -> i64 {
+    // Strip `?query` and `#fragment` before looking at the path.
+    let trimmed = url.split(['?', '#']).next().unwrap_or(url);
+
+    // Skip past `scheme://` so the authority's own separators aren't read as a path.
+    let after_scheme = match trimmed.find("://") {
+        Some(i) => &trimmed[i + 3..],
+        None => trimmed,
+    };
+
+    // The path begins at the first '/' after the authority. No '/' means no db given.
+    let Some((_, path)) = after_scheme.split_once('/') else {
+        return 0;
+    };
+
+    path.rsplit('/')
+        .next()
+        .and_then(|s| s.parse::<i64>().ok())
+        .filter(|db| *db >= 0)
+        .unwrap_or(0)
+}
+
+/// Validate a TTL before any command is sent to Redis.
+///
+/// Redis treats `EXPIRE key 0` as "expire immediately", which deletes the key. That is
+/// almost never what someone typing 0 into a TTL field means, so it is refused here
+/// rather than reinterpreted - no command reaches Redis.
+fn validate_ttl(ttl: i64, key: &str) -> Result<()> {
+    if ttl == 0 {
+        anyhow::bail!(
+            "TTL 0 would delete '{}'. Use -1 to persist, or delete the key explicitly.",
+            key
+        );
+    }
+    Ok(())
+}
+
 impl RedisClient {
     pub fn connect(url: &str) -> Result<Self> {
         let client = redis::Client::open(url)
@@ -47,16 +89,12 @@ impl RedisClient {
             .with_context(|| format!("Failed to connect to {}", url))?;
 
         // Parse db number from URL (e.g., redis://host:port/3)
-        let db = url
-            .rsplit('/')
-            .next()
-            .and_then(|s| s.parse::<i64>().ok())
-            .unwrap_or(0);
+        let db = parse_db_from_url(url);
 
         Ok(Self {
             connection,
             url: url.to_string(),
-            db: db as i64,
+            db,
         })
     }
 
@@ -69,7 +107,12 @@ impl RedisClient {
         Ok(())
     }
 
-    pub fn scan_keys(&mut self, pattern: &str) -> Result<Vec<String>> {
+    /// Scan keys matching `pattern`.
+    ///
+    /// Returns the decodable keys plus a count of keys that could not be read back as
+    /// UTF-8 strings. Those are unavoidably invisible in a text UI, but the count lets
+    /// the caller say so instead of silently showing fewer keys than Redis holds.
+    pub fn scan_keys(&mut self, pattern: &str) -> Result<(Vec<String>, usize)> {
         let iter: redis::Iter<String> = redis::cmd("SCAN")
             .cursor_arg(0)
             .arg("MATCH")
@@ -80,9 +123,17 @@ impl RedisClient {
             .iter(&mut self.connection)
             .context("Failed to SCAN keys")?;
 
-        let mut keys: Vec<String> = iter.filter_map(|r| r.ok()).collect();
+        let mut keys: Vec<String> = Vec::new();
+        let mut skipped = 0usize;
+        for result in iter {
+            match result {
+                Ok(key) => keys.push(key),
+                // Almost always a non-UTF-8 key name, which a text UI cannot display.
+                Err(_) => skipped += 1,
+            }
+        }
         keys.sort();
-        Ok(keys)
+        Ok((keys, skipped))
     }
 
     pub fn get_key_info(&mut self, key: &str) -> Result<KeyInfo> {
@@ -438,6 +489,7 @@ impl RedisClient {
     }
 
     pub fn set_ttl(&mut self, key: &str, ttl: i64) -> Result<()> {
+        validate_ttl(ttl, key)?;
         if ttl < 0 {
             let _: () = redis::cmd("PERSIST")
                 .arg(key)
@@ -576,15 +628,19 @@ impl MultiRedisClient {
         Ok(())
     }
 
-    pub fn scan_keys(&mut self, pattern: &str) -> Result<Vec<String>> {
+    /// Scan all hosts, returning the aggregated keys plus the total number of keys
+    /// skipped across hosts because they were not valid UTF-8.
+    pub fn scan_keys(&mut self, pattern: &str) -> Result<(Vec<String>, usize)> {
         let mut all_keys: Vec<String> = Vec::new();
         let mut seen: HashMap<String, Vec<usize>> = HashMap::new();
+        let mut total_skipped = 0usize;
         self.key_owner.clear();
         self.collisions.clear();
 
         for (idx, client) in self.clients.iter_mut().enumerate() {
             match client.scan_keys(pattern) {
-                Ok(keys) => {
+                Ok((keys, skipped)) => {
+                    total_skipped += skipped;
                     for key in keys {
                         seen.entry(key.clone()).or_default().push(idx);
                         if !self.key_owner.contains_key(&key) {
@@ -610,7 +666,7 @@ impl MultiRedisClient {
         self.collisions.sort_by(|a, b| a.0.cmp(&b.0));
 
         all_keys.sort();
-        Ok(all_keys)
+        Ok((all_keys, total_skipped))
     }
 
     /// Get the client that owns a key. Falls back to first client.
@@ -743,5 +799,284 @@ impl MultiRedisClient {
 
     pub fn host_count(&self) -> usize {
         self.clients.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::process::{Child, Command, Stdio};
+    use std::sync::atomic::{AtomicU16, Ordering};
+
+    /// Ports are handed out per-test because cargo runs tests in parallel; a single
+    /// hardcoded port would make these collide with each other and with any dev
+    /// instance already on 6379/6380.
+    static NEXT_PORT: AtomicU16 = AtomicU16::new(6390);
+
+    /// A throwaway redis-server that is killed when the test ends.
+    struct TestRedis {
+        child: Child,
+        port: u16,
+    }
+
+    impl TestRedis {
+        fn start() -> Self {
+            let port = NEXT_PORT.fetch_add(1, Ordering::SeqCst);
+            let child = Command::new("redis-server")
+                .args([
+                    "--port", &port.to_string(),
+                    "--save", "",
+                    "--appendonly", "no",
+                    "--loglevel", "warning",
+                ])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("redis-server must be installed to run --ignored tests");
+
+            let server = TestRedis { child, port };
+            for _ in 0..100 {
+                if let Ok(c) = redis::Client::open(server.url().as_str()) {
+                    if c.get_connection().is_ok() {
+                        return server;
+                    }
+                }
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            panic!("redis-server on port {} never became ready", port);
+        }
+
+        fn url(&self) -> String {
+            format!("redis://127.0.0.1:{}", self.port)
+        }
+    }
+
+    impl Drop for TestRedis {
+        fn drop(&mut self) {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+    }
+
+    // ---- #12: SCAN reports undecodable keys instead of hiding them ----
+
+    #[test]
+    #[ignore = "requires redis-server; run with: cargo test -- --ignored"]
+    fn scan_counts_keys_skipped_for_invalid_utf8() {
+        let server = TestRedis::start();
+        let mut client = RedisClient::connect(&server.url()).unwrap();
+
+        set_key(&mut client, "good:one", "v1");
+        set_key(&mut client, "good:two", "v2");
+        // 0xff 0xfe 0xfd is not valid UTF-8, so Iter<String> yields Err for it.
+        redis::cmd("SET")
+            .arg(&[0xffu8, 0xfe, 0xfd][..])
+            .arg("binary")
+            .exec(&mut client.connection)
+            .unwrap();
+
+        let (keys, skipped) = client.scan_keys("*").unwrap();
+
+        assert_eq!(keys, vec!["good:one".to_string(), "good:two".to_string()]);
+        assert_eq!(
+            skipped, 1,
+            "the non-UTF-8 key must be counted, not silently dropped"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires redis-server; run with: cargo test -- --ignored"]
+    fn scan_reports_zero_skipped_when_all_keys_decode() {
+        let server = TestRedis::start();
+        let mut client = RedisClient::connect(&server.url()).unwrap();
+
+        set_key(&mut client, "good:one", "v1");
+
+        let (keys, skipped) = client.scan_keys("*").unwrap();
+
+        assert_eq!(keys.len(), 1);
+        assert_eq!(skipped, 0);
+    }
+
+    fn set_key(client: &mut RedisClient, key: &str, value: &str) {
+        redis::cmd("SET")
+            .arg(key)
+            .arg(value)
+            .exec(&mut client.connection)
+            .unwrap();
+    }
+
+    /// The DB the connection is actually on, straight from the server.
+    fn actual_db(client: &mut RedisClient) -> i64 {
+        let info: String = redis::cmd("CLIENT")
+            .arg("INFO")
+            .query(&mut client.connection)
+            .unwrap();
+        info.split_whitespace()
+            .find_map(|f| f.strip_prefix("db="))
+            .and_then(|v| v.parse().ok())
+            .unwrap()
+    }
+
+    #[test]
+    #[ignore = "requires redis-server; run with: cargo test -- --ignored"]
+    fn reported_db_matches_actual_db_with_query_string() {
+        let server = TestRedis::start();
+        // The redis crate honours the /3 path and connects to db 3 either way; the bug
+        // was that RedisClient::db reported 0, so the status bar lied about which
+        // database the user was looking at.
+        let url = format!("{}/3?timeout=5", server.url());
+        let mut client = RedisClient::connect(&url).unwrap();
+
+        assert_eq!(
+            actual_db(&mut client),
+            3,
+            "sanity: connection should be on db 3"
+        );
+        assert_eq!(client.db, 3, "reported db must match the real one");
+    }
+
+    #[test]
+    #[ignore = "requires redis-server; run with: cargo test -- --ignored"]
+    fn reported_db_matches_actual_db_without_path() {
+        let server = TestRedis::start();
+        let mut client = RedisClient::connect(&server.url()).unwrap();
+
+        assert_eq!(actual_db(&mut client), 0);
+        assert_eq!(client.db, 0);
+    }
+
+    /// End-to-end: the skipped count must reach the status line the user actually reads.
+    #[test]
+    #[ignore = "requires redis-server; run with: cargo test -- --ignored"]
+    fn refresh_keys_status_line_reports_skipped_keys() {
+        let server = TestRedis::start();
+        let mut seed = RedisClient::connect(&server.url()).unwrap();
+        set_key(&mut seed, "good:one", "v1");
+        set_key(&mut seed, "good:two", "v2");
+        redis::cmd("SET")
+            .arg(&[0xffu8, 0xfe, 0xfd][..])
+            .arg("binary")
+            .exec(&mut seed.connection)
+            .unwrap();
+        drop(seed);
+
+        let mut multi = MultiRedisClient::from_single(&server.url()).unwrap();
+        let mut app = crate::app::App::new();
+        app.refresh_keys(&mut multi);
+
+        assert_eq!(app.keys.len(), 2);
+        assert!(
+            app.status_message.contains("1 skipped"),
+            "status line should disclose the skipped key, got: {}",
+            app.status_message
+        );
+    }
+
+    // ---- #10: TTL validation ----
+
+    #[test]
+    fn ttl_zero_is_rejected() {
+        // EXPIRE key 0 deletes the key immediately; refuse before sending anything.
+        assert!(validate_ttl(0, "mykey").is_err());
+    }
+
+    #[test]
+    fn ttl_zero_error_names_the_key() {
+        let err = validate_ttl(0, "mykey").unwrap_err().to_string();
+        assert!(
+            err.contains("mykey"),
+            "error should name the key, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn ttl_negative_is_accepted_as_persist() {
+        assert!(validate_ttl(-1, "mykey").is_ok());
+    }
+
+    #[test]
+    fn ttl_positive_is_accepted() {
+        assert!(validate_ttl(60, "mykey").is_ok());
+    }
+
+    #[test]
+    #[ignore = "requires redis-server; run with: cargo test -- --ignored"]
+    fn set_ttl_zero_leaves_the_key_intact() {
+        let server = TestRedis::start();
+        let mut client = RedisClient::connect(&server.url()).unwrap();
+        set_key(&mut client, "keeper", "precious");
+
+        let result = client.set_ttl("keeper", 0);
+
+        assert!(result.is_err(), "TTL 0 must be refused");
+        let exists: bool = redis::cmd("EXISTS")
+            .arg("keeper")
+            .query(&mut client.connection)
+            .unwrap();
+        assert!(exists, "the key must still exist - no command should have been sent");
+    }
+
+    #[test]
+    #[ignore = "requires redis-server; run with: cargo test -- --ignored"]
+    fn set_ttl_positive_applies_expiry() {
+        let server = TestRedis::start();
+        let mut client = RedisClient::connect(&server.url()).unwrap();
+        set_key(&mut client, "temp", "v");
+
+        client.set_ttl("temp", 120).unwrap();
+
+        let ttl: i64 = redis::cmd("TTL")
+            .arg("temp")
+            .query(&mut client.connection)
+            .unwrap();
+        assert!(ttl > 0 && ttl <= 120, "expected a live ttl, got {}", ttl);
+    }
+
+    // ---- #9: DB number parsing from URL ----
+
+    #[test]
+    fn db_parses_from_plain_path() {
+        assert_eq!(parse_db_from_url("redis://127.0.0.1:6379/3"), 3);
+    }
+
+    #[test]
+    fn db_parses_with_query_string() {
+        // The original bug: rsplit('/') yields "3?timeout=5", which fails to parse.
+        assert_eq!(parse_db_from_url("redis://127.0.0.1:6379/3?timeout=5"), 3);
+    }
+
+    #[test]
+    fn db_parses_with_fragment() {
+        assert_eq!(parse_db_from_url("redis://127.0.0.1:6379/7#frag"), 7);
+    }
+
+    #[test]
+    fn db_defaults_to_zero_without_path() {
+        // No path component at all - must be 0 deliberately, not by parse failure.
+        assert_eq!(parse_db_from_url("redis://127.0.0.1:6379"), 0);
+    }
+
+    #[test]
+    fn db_defaults_to_zero_for_non_numeric_path() {
+        assert_eq!(parse_db_from_url("redis://127.0.0.1:6379/notanumber"), 0);
+    }
+
+    #[test]
+    fn db_parses_with_auth_in_url() {
+        assert_eq!(parse_db_from_url("redis://user:pw@127.0.0.1:6379/5"), 5);
+    }
+
+    #[test]
+    fn db_rejects_negative_number() {
+        // A negative DB is nonsense and would only fail later at SELECT.
+        assert_eq!(parse_db_from_url("redis://127.0.0.1:6379/-1"), 0);
+    }
+
+    #[test]
+    fn db_parses_with_empty_path() {
+        assert_eq!(parse_db_from_url("redis://127.0.0.1:6379/"), 0);
     }
 }

--- a/src/redis_client.rs
+++ b/src/redis_client.rs
@@ -42,7 +42,7 @@ pub struct RedisClient {
 ///
 /// Returns 0 when the URL carries no usable database component. Query strings and
 /// fragments are stripped first, so `redis://host/3?timeout=5` yields 3 rather than
-/// silently falling back to 0.
+/// silently falling back to 0, and a trailing slash (`redis://host/3/`) is tolerated.
 fn parse_db_from_url(url: &str) -> i64 {
     // Strip `?query` and `#fragment` before looking at the path.
     let trimmed = url.split(['?', '#']).next().unwrap_or(url);
@@ -58,8 +58,10 @@ fn parse_db_from_url(url: &str) -> i64 {
         return 0;
     };
 
+    // Take the last *non-empty* segment: a trailing slash ("/3/") would otherwise
+    // yield an empty final segment and look like no db was given at all.
     path.rsplit('/')
-        .next()
+        .find(|segment| !segment.is_empty())
         .and_then(|s| s.parse::<i64>().ok())
         .filter(|db| *db >= 0)
         .unwrap_or(0)
@@ -70,10 +72,15 @@ fn parse_db_from_url(url: &str) -> i64 {
 /// Redis treats `EXPIRE key 0` as "expire immediately", which deletes the key. That is
 /// almost never what someone typing 0 into a TTL field means, so it is refused here
 /// rather than reinterpreted - no command reaches Redis.
+///
+/// Any negative TTL means persist (see `set_ttl`), which is what the edit field's
+/// "empty=persist" path sends as -1. The message says "negative" rather than naming -1
+/// so it stays true to the behaviour callers actually get.
 fn validate_ttl(ttl: i64, key: &str) -> Result<()> {
     if ttl == 0 {
         anyhow::bail!(
-            "TTL 0 would delete '{}'. Use -1 to persist, or delete the key explicitly.",
+            "TTL 0 would delete '{}'. Leave the field empty (or use a negative TTL) to persist, \
+             or delete the key explicitly.",
             key
         );
     }
@@ -806,13 +813,22 @@ impl MultiRedisClient {
 mod tests {
     use super::*;
 
+    use std::net::TcpListener;
     use std::process::{Child, Command, Stdio};
-    use std::sync::atomic::{AtomicU16, Ordering};
 
-    /// Ports are handed out per-test because cargo runs tests in parallel; a single
-    /// hardcoded port would make these collide with each other and with any dev
-    /// instance already on 6379/6380.
-    static NEXT_PORT: AtomicU16 = AtomicU16::new(6390);
+    /// Ask the OS for a currently-free port, then release it so redis-server can bind.
+    ///
+    /// Cargo runs tests in parallel and several `cargo test` runs may overlap on one
+    /// machine, so a fixed or sequentially-allocated port collides sooner or later -
+    /// with sibling tests, with a dev instance on 6379/6380, or with anything else on
+    /// the box. Letting the kernel pick removes the guess; the small window between
+    /// releasing the port and redis binding it is covered by the retry in `start`.
+    fn free_port() -> Option<u16> {
+        let listener = TcpListener::bind("127.0.0.1:0").ok()?;
+        let port = listener.local_addr().ok()?.port();
+        drop(listener);
+        Some(port)
+    }
 
     /// A throwaway redis-server that is killed when the test ends.
     struct TestRedis {
@@ -822,7 +838,24 @@ mod tests {
 
     impl TestRedis {
         fn start() -> Self {
-            let port = NEXT_PORT.fetch_add(1, Ordering::SeqCst);
+            const ATTEMPTS: usize = 5;
+            let mut last_error = "no attempt made".to_string();
+
+            for _ in 0..ATTEMPTS {
+                let Some(port) = free_port() else {
+                    last_error = "could not obtain a free port from the OS".to_string();
+                    continue;
+                };
+                match Self::try_start(port) {
+                    Ok(server) => return server,
+                    Err(e) => last_error = e,
+                }
+            }
+
+            panic!("could not start redis-server after {ATTEMPTS} attempts: {last_error}");
+        }
+
+        fn try_start(port: u16) -> Result<Self, String> {
             let child = Command::new("redis-server")
                 .args([
                     "--port", &port.to_string(),
@@ -833,18 +866,36 @@ mod tests {
                 .stdout(Stdio::null())
                 .stderr(Stdio::null())
                 .spawn()
-                .expect("redis-server must be installed to run --ignored tests");
+                .map_err(|e| {
+                    format!("could not spawn redis-server ({e}); it must be installed to run --ignored tests")
+                })?;
 
-            let server = TestRedis { child, port };
+            let mut server = TestRedis { child, port };
+            let url = server.url();
+
             for _ in 0..100 {
-                if let Ok(c) = redis::Client::open(server.url().as_str()) {
-                    if c.get_connection().is_ok() {
-                        return server;
+                // A bind failure makes redis exit almost immediately - notice that
+                // instead of waiting out the full readiness timeout.
+                match server.child.try_wait() {
+                    Ok(Some(status)) => {
+                        return Err(format!(
+                            "redis-server on port {port} exited early ({status})"
+                        ))
+                    }
+                    Ok(None) => {}
+                    Err(e) => return Err(format!("could not poll redis-server: {e}")),
+                }
+
+                if let Ok(client) = redis::Client::open(url.as_str()) {
+                    if client.get_connection().is_ok() {
+                        return Ok(server);
                     }
                 }
                 std::thread::sleep(std::time::Duration::from_millis(50));
             }
-            panic!("redis-server on port {} never became ready", port);
+
+            // Dropping `server` kills the child, so the next attempt starts clean.
+            Err(format!("redis-server on port {port} never became ready"))
         }
 
         fn url(&self) -> String {
@@ -998,6 +1049,30 @@ mod tests {
     }
 
     #[test]
+    fn ttl_any_negative_is_accepted_as_persist() {
+        // set_ttl routes every ttl < 0 to PERSIST, so validation must not single out -1.
+        for ttl in [-1, -2, -100, i64::MIN] {
+            assert!(
+                validate_ttl(ttl, "mykey").is_ok(),
+                "ttl {} should be allowed",
+                ttl
+            );
+        }
+    }
+
+    #[test]
+    fn ttl_zero_error_does_not_name_a_specific_sentinel() {
+        // The edit field is labelled "empty=persist"; the message must not invent a
+        // different contract by telling users to type -1.
+        let err = validate_ttl(0, "mykey").unwrap_err().to_string();
+        assert!(
+            err.contains("empty"),
+            "message should point at the documented path: {}",
+            err
+        );
+    }
+
+    #[test]
     fn ttl_positive_is_accepted() {
         assert!(validate_ttl(60, "mykey").is_ok());
     }
@@ -1067,6 +1142,18 @@ mod tests {
     #[test]
     fn db_parses_with_auth_in_url() {
         assert_eq!(parse_db_from_url("redis://user:pw@127.0.0.1:6379/5"), 5);
+    }
+
+    #[test]
+    fn db_parses_with_trailing_slash() {
+        // rsplit('/') on "3/" yields an empty final segment, which must not be
+        // mistaken for "no db given".
+        assert_eq!(parse_db_from_url("redis://127.0.0.1:6379/3/"), 3);
+    }
+
+    #[test]
+    fn db_parses_with_query_string_after_trailing_slash() {
+        assert_eq!(parse_db_from_url("redis://127.0.0.1:6379/3/?timeout=5"), 3);
     }
 
     #[test]


### PR DESCRIPTION
Four independent correctness fixes, plus the first tests for `redis_client.rs`.

Closes #9, closes #10, closes #12, closes #31.

## The fixes

**#9 — DB number misreported for URLs with query strings.**
`parse_db_from_url` is extracted and corrected: query strings and fragments are stripped before the db number is read, the number is only taken from a real path component, and negatives are rejected.

The impact is narrower than the issue describes, and I've verified this against a live server: the `redis` crate honours the `/3` in the URL regardless of the trailing `?timeout=5`, so **the connection was always on the correct database**. What was wrong is `RedisClient::db`, which feeds the status bar — the UI reported `DB: 0` while displaying keys from db 3. Worth fixing (a DB indicator that lies is dangerous right before a delete), but it is a display bug, not a wrong-database bug. Issue #9's "Impact" section should be amended.

**#10 — `set_ttl(0)` silently deleted the key.**
Redis treats `EXPIRE key 0` as "expire immediately". `set_ttl` now refuses `ttl == 0` and returns an error *before any command is sent*, so the key is untouched. `-1` still persists; positive values still set an expiry. The error names the key and points at `-1`.

**#12 — SCAN silently hid undecodable keys.**
`filter_map(|r| r.ok())` dropped keys that are not valid UTF-8, with no indication. `scan_keys` now returns `(keys, skipped)`, `MultiRedisClient::scan_keys` sums the count across hosts, and it reaches the status line:

```
Loaded 2 keys (1 skipped: encoding errors)
```

Such keys still cannot be *displayed* in a text UI — but Redis no longer looks emptier than it is.

**#31 — NaN/Inf passed plot-limit validation.**
`"nan"` and `"inf"` both parse successfully as `f64`, and every comparison against NaN is `false`, so they slipped past the existing `min < max` guards and poisoned the chart bounds. A `parse_finite` helper now rejects anything non-finite across the X pair and every per-slot Y pair.

## Testing

`redis_client.rs` gains its first test module. Tests needing a live server use a `TestRedis` harness that spawns a throwaway `redis-server` per test — each claiming its own port from an `AtomicU16` starting at 6390, since cargo runs tests in parallel and a fixed port would collide with dev instances on 6379/6380 — and kills it on `Drop`.

There is no `tests/` directory because this is a binary-only crate with no lib target, so external integration tests cannot import the modules. Live tests are marked `#[ignore]` and run explicitly:

```bash
cargo test              # 93 passed, 0 failed
cargo test -- --ignored # 7 passed, 0 failed (requires redis-server on PATH)
```

Every regression test was confirmed **red before its fix and green after**, and each fix was then reverted again to prove the test actually catches the bug. The #12 end-to-end test fails with `got: Loaded 2 keys` — exactly the user-facing symptom.

Note these `#[ignore]` tests are not enforced anywhere: the repo has no build/test/lint CI. That is the unfinished half of #64 (the merged PR added only `docker-publish.yml`) and is left as separate work.

## Verification

| Check | Result |
|---|---|
| `cargo build` / `--release` | exit 0 |
| `cargo test` | 93 passed, 0 failed |
| `cargo test -- --ignored` | 7 passed, 0 failed |
| `cargo clippy --all-targets` | 12 warnings (13 on `main` — removed a redundant cast in a line already being rewritten) |
| `cargo fmt --check` | 0 diffs in new code (repo has 190 pre-existing; no blanket reformat, to keep this diff reviewable) |

Version bumped 1.3.0 → 1.3.1 for `cargo-version-check`. `CLAUDE.md` updated — it previously stated the repo has no integration tests.