### PR TITLE
Add CI workflow for build, test, and lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,21 @@
 name: CI
 
 on:
+  # Scoped to main deliberately. Firing on every branch push as well meant a PR
+  # branch triggered both `push` and `pull_request`, running the whole job twice;
+  # de-duplicating them via `concurrency` fixed the waste but left the cancelled
+  # run reported as a failed check, which showed the PR as UNSTABLE with nothing
+  # actually wrong. Branch work is covered by the `pull_request` run, and main is
+  # covered here after merge.
   push:
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:
 
-# A push to a PR branch triggers both `push` and `pull_request`, and those two
-# events report different refs for the same branch - `refs/heads/<branch>` versus
-# `refs/pull/<n>/merge` - so keying on `github.ref` would put them in separate
-# groups and run the whole job twice. `head_ref` is set only for pull_request and
-# `ref_name` is the bare branch name, so this key is the branch either way and the
-# newer run cancels the older.
+# Successive pushes to the same PR branch supersede each other. Keyed on the
+# branch rather than `github.ref`, since the two events report different refs for
+# the same branch (`refs/heads/<branch>` vs `refs/pull/<n>/merge`).
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,14 @@ on:
     branches: [main]
   workflow_dispatch:
 
-# A push to a PR branch triggers both `push` and `pull_request`. Superseded runs
-# on the same ref are cancelled rather than left to finish.
+# A push to a PR branch triggers both `push` and `pull_request`, and those two
+# events report different refs for the same branch - `refs/heads/<branch>` versus
+# `refs/pull/<n>/merge` - so keying on `github.ref` would put them in separate
+# groups and run the whole job twice. `head_ref` is set only for pull_request and
+# `ref_name` is the bare branch name, so this key is the branch either way and the
+# newer run cancels the older.
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,106 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+# A push to a PR branch triggers both `push` and `pull_request`. Superseded runs
+# on the same ref are cancelled rather than left to finish.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Rust, clippy and rustfmt are preinstalled on GitHub-hosted ubuntu runners,
+      # so no toolchain action is needed. Print the versions so a runner image
+      # update that changes behaviour is visible in the log.
+      - name: Show toolchain
+        run: |
+          rustc --version
+          cargo --version
+          cargo clippy --version
+          cargo fmt --version
+
+      # The live tests spawn their own throwaway servers on OS-assigned ports via
+      # the TestRedis harness, so only the binary needs to be on PATH - no service
+      # container and no port configuration.
+      - name: Install redis-server
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends redis-server
+          redis-server --version
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      # ---- Hard gates: these are green on main today and must stay green ----
+
+      - name: Build (debug)
+        run: cargo build --locked --all-targets
+
+      - name: Build (release)
+        run: cargo build --locked --release
+
+      - name: Test
+        run: cargo test --locked
+
+      - name: Test (live Redis)
+        run: cargo test --locked -- --ignored
+
+      # ---- Ratchet: reported, not enforced ----
+      #
+      # main carries pre-existing debt that is unrelated to any single change
+      # (12 clippy warnings, 188 rustfmt diffs). Enforcing these now would make CI
+      # red on every PR regardless of its contents, and reformatting the tree to
+      # clear it would bury real diffs in noise.
+      #
+      # `-D warnings` is deliberate: plain `cargo clippy` exits 0 on warnings, so
+      # without it the step would always pass and the debt would be invisible.
+      # Paired with continue-on-error the step goes red while the job stays green.
+      #
+      # To enforce these later, delete the `continue-on-error` lines. See #64.
+
+      - name: Clippy (reported, not enforced)
+        id: clippy
+        continue-on-error: true
+        run: cargo clippy --locked --all-targets -- -D warnings
+
+      - name: Format check (reported, not enforced)
+        id: fmt
+        continue-on-error: true
+        run: cargo fmt --check
+
+      - name: Lint debt summary
+        if: always()
+        run: |
+          {
+            echo "### Lint status"
+            echo
+            echo "| Check | Result | Enforced |"
+            echo "| ----- | ------ | -------- |"
+            echo "| Clippy | ${{ steps.clippy.outcome }} | no |"
+            echo "| Format | ${{ steps.fmt.outcome }} | no |"
+            echo
+            echo "Build and tests are enforced. Clippy and format are reported only"
+            echo "while pre-existing debt is cleared - see issue #64."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,10 @@ on:
   # covered here after merge.
   push:
     branches: [main]
+  # Deliberately unfiltered by base branch: a stacked PR targets its parent
+  # branch rather than main, and filtering on `branches: [main]` would leave it
+  # with no CI at all. There is no duplicate-run risk, since push is scoped above.
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 # Successive pushes to the same PR branch supersede each other. Keyed on the


### PR DESCRIPTION
Closes #64.

That issue was closed by #65, but #65 delivered only `docker-publish.yml` and its `.actrc`/`.secrets.example` support files — none of the build/test/lint jobs it asked for. The result is that `main` has **97 unit tests and 7 live-Redis tests that nothing runs automatically**.

## Enforced

All four are green on `main` today, so this gates real work from the first run:

```
cargo build --locked --all-targets
cargo build --locked --release
cargo test --locked
cargo test --locked -- --ignored
```

The live tests need `redis-server` on `PATH`, installed via apt. They spawn their own throwaway instances on OS-assigned ports through the `TestRedis` harness, so there is no service container and no port configuration — only the binary is required.

## Reported, not enforced

`main` carries **12 clippy warnings and 188 rustfmt diffs** that predate this workflow and belong to no single change. Enforcing them now would make CI red on every PR regardless of its contents, and reformatting the tree to clear them would bury real diffs in noise. So both run with `continue-on-error: true`, plus a job-summary table reporting their status.

To be precise about what that looks like, since I got this wrong in the first draft: `continue-on-error` rewrites the step's **conclusion** to `success`, so the step icon stays green. What actually surfaces the debt is the `##[error]Process completed with exit code 101` **annotation** on the run, and the summary table, which reads `steps.<id>.outcome` — the raw result, `failure` — rather than the rewritten conclusion. The job stays green either way.

`clippy` runs with `-D warnings` deliberately. Plain `cargo clippy` **exits 0 on warnings**, so without it the step would always pass and the debt would stay invisible in the log. Pairing `-D warnings` with `continue-on-error` is what makes it a visible-but-non-blocking ratchet.

**Flipping the ratchet later is deleting two `continue-on-error:` lines.** That is called out in a comment in the file.

## Notes

- **No toolchain action.** `rustc`, `clippy` and `rustfmt` are preinstalled on GitHub-hosted ubuntu runners, so the only new action dependency is the first-party `actions/cache`. Versions are printed so a runner-image change that alters behaviour shows up in the log.
- **`concurrency` with `cancel-in-progress`**, because a push to a PR branch fires both `push` and `pull_request`.
- **`--locked` throughout**, so a stale `Cargo.lock` fails rather than silently resolving.
- This touches no `.rs` file or `Cargo.toml`, so `cargo-version-check` does not apply and no version bump is needed.

## Verification

The YAML was parsed and every step run locally before pushing:

| Step | Exit | Expected |
|---|---|---|
| `cargo build --locked --all-targets` | 0 | gate passes |
| `cargo build --locked --release` | 0 | gate passes |
| `cargo test --locked` | 0 | 97 passed |
| `cargo test --locked -- --ignored` | 0 | 7 passed |
| `cargo clippy --locked --all-targets -- -D warnings` | 101 | annotated, green job |
| `cargo fmt --check` | 1 | annotated, green job |

This PR is its own first test — the run on this branch shows whether the gates pass and the ratchet steps report without blocking.
