### PR TITLE
Clear all 12 clippy warnings, pin the toolchain, and enforce clippy in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,23 +77,19 @@ jobs:
       - name: Test (live Redis)
         run: cargo test --locked -- --ignored
 
+      # Clippy is enforced: the tree is at zero warnings and stays there.
+      - name: Clippy
+        id: clippy
+        run: cargo clippy --locked --all-targets -- -D warnings
+
       # ---- Ratchet: reported, not enforced ----
       #
-      # main carries pre-existing debt that is unrelated to any single change
-      # (12 clippy warnings, 188 rustfmt diffs). Enforcing these now would make CI
-      # red on every PR regardless of its contents, and reformatting the tree to
-      # clear it would bury real diffs in noise.
+      # main still carries ~188 pre-existing rustfmt diffs that belong to no single
+      # change. Enforcing now would make CI red on every PR regardless of its
+      # contents, and reformatting the tree would bury real diffs in noise.
       #
-      # `-D warnings` is deliberate: plain `cargo clippy` exits 0 on warnings, so
-      # without it the step would always pass and the debt would be invisible.
-      # Paired with continue-on-error the step goes red while the job stays green.
-      #
-      # To enforce these later, delete the `continue-on-error` lines. See #64.
-
-      - name: Clippy (reported, not enforced)
-        id: clippy
-        continue-on-error: true
-        run: cargo clippy --locked --all-targets -- -D warnings
+      # To enforce, run `cargo fmt` in a commit of its own, add that SHA to
+      # .git-blame-ignore-revs, and delete the `continue-on-error` below. See #64.
 
       - name: Format check (reported, not enforced)
         id: fmt
@@ -108,9 +104,9 @@ jobs:
             echo
             echo "| Check | Result | Enforced |"
             echo "| ----- | ------ | -------- |"
-            echo "| Clippy | ${{ steps.clippy.outcome }} | no |"
+            echo "| Clippy | ${{ steps.clippy.outcome }} | yes |"
             echo "| Format | ${{ steps.fmt.outcome }} | no |"
             echo
-            echo "Build and tests are enforced. Clippy and format are reported only"
-            echo "while pre-existing debt is cleared - see issue #64."
+            echo "Build, tests and clippy are enforced. Format is reported only"
+            echo "while the pre-existing rustfmt debt is cleared - see issue #64."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
 
       # ---- Ratchet: reported, not enforced ----
       #
-      # main still carries ~188 pre-existing rustfmt diffs that belong to no single
+      # main still carries ~198 pre-existing rustfmt diffs that belong to no single
       # change. Enforcing now would make CI red on every PR regardless of its
       # contents, and reformatting the tree would bury real diffs in noise.
       #

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "redis-tui"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-tui"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2021"
 description = "A Redis TUI client inspired by Redis Insight"
 license = "BSD-3-Clause"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,12 @@
+# Pinned so CI and local builds agree.
+#
+# CI enforces `cargo clippy -- -D warnings`, which turns every rustc and clippy
+# lint into a build failure. GitHub's runner image ships whatever Rust is current,
+# so without a pin a runner update can fail CI on code nobody touched - which is
+# exactly what happened when the image moved to 1.97 and its stricter dead_code
+# analysis flagged two methods that 1.93 accepted.
+#
+# Bump deliberately, and fix any new lints in the same commit.
+[toolchain]
+channel = "1.97"
+components = ["clippy", "rustfmt"]

--- a/src/app.rs
+++ b/src/app.rs
@@ -850,36 +850,6 @@ impl App {
         }
     }
 
-    /// Reload the current value without resetting scroll.
-    #[allow(dead_code)]
-    pub fn refresh_selected_value(&mut self, client: &mut MultiRedisClient) {
-        if let Some(idx) = self.key_list_state.selected() {
-            if idx < self.keys.len() {
-                let key = self.keys[idx].clone();
-
-                if let Ok(info) = client.get_key_info(&key) {
-                    self.current_key_info = Some(info);
-                }
-
-                match client.get_value(&key) {
-                    Ok(mut value) => {
-                        cap_stream_entries(&mut value);
-                        if let RedisValue::Stream(ref entries) = value {
-                            self.last_stream_id =
-                                entries.last().map(|e| e.id.clone());
-                        }
-                        self.update_plot_data(&value);
-                        if self.fft_enabled {
-                            self.compute_fft();
-                        }
-                        self.current_value = Some(value);
-                    }
-                    Err(_) => {}
-                }
-            }
-        }
-    }
-
     pub fn is_viewing_stream(&self) -> bool {
         matches!(
             &self.current_key_info,

--- a/src/app.rs
+++ b/src/app.rs
@@ -1175,8 +1175,8 @@ impl App {
                     (-0.05, 1.05)
                 } else if !self.plot_slots.is_empty() {
                     let slot = &self.plot_slots[0];
-                    if slot.y_min.is_some() && slot.y_max.is_some() {
-                        (slot.y_min.unwrap(), slot.y_max.unwrap())
+                    if let (Some(y_min), Some(y_max)) = (slot.y_min, slot.y_max) {
+                        (y_min, y_max)
                     } else {
                         self.auto_signal_bounds()
                     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -182,6 +182,11 @@ pub enum InputMode {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum PlotFocus {
     Signal,
+    // clippy suggests `Fft`. FFT is the universal spelling for this transform in
+    // signal-processing code, and it is spelled that way everywhere else here -
+    // fft_enabled, fft_dirty, the [f] binding, the FFT chart title. Renaming the
+    // variant alone would make it the odd one out and read worse at every call site.
+    #[allow(clippy::upper_case_acronyms)]
     FFT,
 }
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -211,7 +211,7 @@ pub fn format_hex(bytes: &[u8]) -> String {
 /// Supports ints and floats depending on the target DataType.
 pub fn encode_values(input: &str, data_type: DataType, endianness: Endianness) -> Result<Vec<u8>, String> {
     let tokens: Vec<&str> = input
-        .split(|c: char| c == ',' || c == ' ')
+        .split([',', ' '])
         .map(|s| s.trim())
         .filter(|s| !s.is_empty())
         .collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -221,6 +221,10 @@ impl StreamListener {
         })
     }
 
+    // Reached only through Drop, and the test target never constructs a listener -
+    // main() is replaced by the harness there - so rustc sees this as dead in that
+    // build. It is live in the real binary.
+    #[allow(dead_code)]
     fn stop(&mut self) {
         self.stop_flag.store(true, Ordering::Relaxed);
         if let Some(h) = self.handle.take() {
@@ -279,6 +283,9 @@ impl SignalGenerator {
         })
     }
 
+    // Same as StreamListener::stop - live in the binary, unreachable in the test
+    // target, which never constructs a generator.
+    #[allow(dead_code)]
     fn stop(&mut self) {
         self.stop_flag.store(true, Ordering::Relaxed);
         if let Some(h) = self.handle.take() {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -298,7 +298,7 @@ fn draw_value_view(frame: &mut Frame, app: &mut App, area: Rect) {
                         let remaining_secs = match tracker.tracking_start_ms {
                             Some(start_ms) => {
                                 let warmup_end_ms = start_ms + chart_window * 1000;
-                                ((warmup_end_ms.saturating_sub(now_ms)) + 999) / 1000
+                                (warmup_end_ms.saturating_sub(now_ms)).div_ceil(1000)
                             }
                             None => chart_window,
                         };
@@ -1098,7 +1098,7 @@ fn draw_confirm_popup(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn draw_help_popup(frame: &mut Frame, app: &App, area: Rect) {
-    let max_height = area.height.saturating_sub(2).min(50) as u16;
+    let max_height = area.height.saturating_sub(2).min(50);
     let popup_area = centered_rect(72, max_height, area);
     frame.render_widget(Clear, popup_area);
 
@@ -1610,7 +1610,7 @@ fn draw_crosshair(
     let frac_x = (data_x - x_lo) / (x_hi - x_lo);
     let frac_y = (data_y - y_lo) / (y_hi - y_lo);
 
-    if frac_x < 0.0 || frac_x > 1.0 || frac_y < 0.0 || frac_y > 1.0 {
+    if !(0.0..=1.0).contains(&frac_x) || !(0.0..=1.0).contains(&frac_y) {
         return;
     }
 
@@ -1833,6 +1833,40 @@ mod tests {
                 draw_crosshair(frame, cx, cy, cw, ch, 100.0, 100.0, 0.0, 100.0, 0.0, 100.0);
             })
             .unwrap();
+    }
+
+    #[test]
+    fn crosshair_skipped_for_non_finite_coordinates() {
+        // NaN fails every comparison, so `frac < 0.0 || frac > 1.0` does not catch it.
+        // Execution then reaches `(NaN * ..) as u16`, which saturates to 0 and pins a
+        // bogus crosshair to the chart's top-left corner as if that were the data point.
+        for (dx, dy) in [
+            (f64::NAN, 50.0),
+            (50.0, f64::NAN),
+            (f64::NAN, f64::NAN),
+        ] {
+            let backend = TestBackend::new(80, 24);
+            let mut terminal = Terminal::new(backend).unwrap();
+            terminal
+                .draw(|frame| {
+                    draw_crosshair(frame, 10, 5, 60, 15, dx, dy, 0.0, 100.0, 0.0, 100.0);
+                })
+                .unwrap();
+
+            let buffer = terminal.backend().buffer().clone();
+            let drawn: String = buffer
+                .content()
+                .iter()
+                .map(|c| c.symbol().chars().next().unwrap_or(' '))
+                .collect();
+
+            assert!(
+                !drawn.contains('\u{2502}') && !drawn.contains('\u{2500}'),
+                "non-finite coordinates ({}, {}) must not draw a crosshair",
+                dx,
+                dy
+            );
+        }
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -872,7 +872,13 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
     // Draw crosshair tick marks if hovering in signal chart
     if !app.hover_in_fft {
         if let (Some(hx), Some(hy)) = (app.hover_data_x, app.hover_data_y) {
-            draw_crosshair(frame, chart_x, chart_y, chart_w, chart_h, hx, hy, x_lo, x_hi, y_lo, y_hi);
+            draw_crosshair(
+                frame,
+                Rect::new(chart_x, chart_y, chart_w, chart_h),
+                hx,
+                hy,
+                ChartBounds { x_lo, x_hi, y_lo, y_hi },
+            );
         }
     }
 }
@@ -1013,7 +1019,13 @@ fn draw_fft_chart(frame: &mut Frame, app: &mut App, area: Rect, _border_color: C
     // Draw crosshair if hovering in FFT chart
     if app.hover_in_fft {
         if let (Some(hx), Some(hy)) = (app.hover_data_x, app.hover_data_y) {
-            draw_crosshair(frame, chart_x, chart_y, chart_w, chart_h, hx, hy, x_lo, x_hi, y_lo, y_hi);
+            draw_crosshair(
+                frame,
+                Rect::new(chart_x, chart_y, chart_w, chart_h),
+                hx,
+                hy,
+                ChartBounds { x_lo, x_hi, y_lo, y_hi },
+            );
         }
     }
 }
@@ -1598,12 +1610,18 @@ fn draw_edit_popup(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 /// Draw crosshair tick marks at the hover position on both axes
-fn draw_crosshair(
-    frame: &mut Frame,
-    cx: u16, cy: u16, cw: u16, ch: u16,
-    data_x: f64, data_y: f64,
-    x_lo: f64, x_hi: f64, y_lo: f64, y_hi: f64,
-) {
+/// Data-space bounds of a chart, used to map a data point onto a cell.
+#[derive(Debug, Clone, Copy)]
+struct ChartBounds {
+    x_lo: f64,
+    x_hi: f64,
+    y_lo: f64,
+    y_hi: f64,
+}
+
+fn draw_crosshair(frame: &mut Frame, area: Rect, data_x: f64, data_y: f64, bounds: ChartBounds) {
+    let (cx, cy, cw, ch) = (area.x, area.y, area.width, area.height);
+    let ChartBounds { x_lo, x_hi, y_lo, y_hi } = bounds;
     if cw <= 1 || ch <= 1 || x_hi <= x_lo || y_hi <= y_lo {
         return;
     }
@@ -1796,7 +1814,13 @@ mod tests {
                 let cw = 116;
                 let ch = 36;
                 // data_x at maximum bound (frac_x = 1.0)
-                draw_crosshair(frame, cx, cy, cw, ch, 100.0, 50.0, 0.0, 100.0, 0.0, 100.0);
+                draw_crosshair(
+                    frame,
+                    Rect::new(cx, cy, cw, ch),
+                    100.0,
+                    50.0,
+                    ChartBounds { x_lo: 0.0, x_hi: 100.0, y_lo: 0.0, y_hi: 100.0 },
+                );
             })
             .unwrap();
         // If we get here without panicking, the test passes
@@ -1809,7 +1833,13 @@ mod tests {
 
         terminal
             .draw(|frame| {
-                draw_crosshair(frame, 10, 5, 60, 15, 0.0, 0.0, 0.0, 100.0, 0.0, 100.0);
+                draw_crosshair(
+                    frame,
+                    Rect::new(10, 5, 60, 15),
+                    0.0,
+                    0.0,
+                    ChartBounds { x_lo: 0.0, x_hi: 100.0, y_lo: 0.0, y_hi: 100.0 },
+                );
             })
             .unwrap();
     }
@@ -1827,10 +1857,34 @@ mod tests {
                 let cw = 60;
                 let ch = 19;
                 // Test all four corners
-                draw_crosshair(frame, cx, cy, cw, ch, 0.0, 0.0, 0.0, 100.0, 0.0, 100.0);
-                draw_crosshair(frame, cx, cy, cw, ch, 100.0, 0.0, 0.0, 100.0, 0.0, 100.0);
-                draw_crosshair(frame, cx, cy, cw, ch, 0.0, 100.0, 0.0, 100.0, 0.0, 100.0);
-                draw_crosshair(frame, cx, cy, cw, ch, 100.0, 100.0, 0.0, 100.0, 0.0, 100.0);
+                draw_crosshair(
+                    frame,
+                    Rect::new(cx, cy, cw, ch),
+                    0.0,
+                    0.0,
+                    ChartBounds { x_lo: 0.0, x_hi: 100.0, y_lo: 0.0, y_hi: 100.0 },
+                );
+                draw_crosshair(
+                    frame,
+                    Rect::new(cx, cy, cw, ch),
+                    100.0,
+                    0.0,
+                    ChartBounds { x_lo: 0.0, x_hi: 100.0, y_lo: 0.0, y_hi: 100.0 },
+                );
+                draw_crosshair(
+                    frame,
+                    Rect::new(cx, cy, cw, ch),
+                    0.0,
+                    100.0,
+                    ChartBounds { x_lo: 0.0, x_hi: 100.0, y_lo: 0.0, y_hi: 100.0 },
+                );
+                draw_crosshair(
+                    frame,
+                    Rect::new(cx, cy, cw, ch),
+                    100.0,
+                    100.0,
+                    ChartBounds { x_lo: 0.0, x_hi: 100.0, y_lo: 0.0, y_hi: 100.0 },
+                );
             })
             .unwrap();
     }
@@ -1849,7 +1903,13 @@ mod tests {
             let mut terminal = Terminal::new(backend).unwrap();
             terminal
                 .draw(|frame| {
-                    draw_crosshair(frame, 10, 5, 60, 15, dx, dy, 0.0, 100.0, 0.0, 100.0);
+                    draw_crosshair(
+                        frame,
+                        Rect::new(10, 5, 60, 15),
+                        dx,
+                        dy,
+                        ChartBounds { x_lo: 0.0, x_hi: 100.0, y_lo: 0.0, y_hi: 100.0 },
+                    );
                 })
                 .unwrap();
 
@@ -1877,10 +1937,28 @@ mod tests {
         terminal
             .draw(|frame| {
                 // Minimum viable chart area
-                draw_crosshair(frame, 0, 0, 2, 2, 50.0, 50.0, 0.0, 100.0, 0.0, 100.0);
+                draw_crosshair(
+                    frame,
+                    Rect::new(0, 0, 2, 2),
+                    50.0,
+                    50.0,
+                    ChartBounds { x_lo: 0.0, x_hi: 100.0, y_lo: 0.0, y_hi: 100.0 },
+                );
                 // Degenerate areas should be no-ops
-                draw_crosshair(frame, 0, 0, 0, 0, 50.0, 50.0, 0.0, 100.0, 0.0, 100.0);
-                draw_crosshair(frame, 0, 0, 1, 1, 50.0, 50.0, 0.0, 100.0, 0.0, 100.0);
+                draw_crosshair(
+                    frame,
+                    Rect::new(0, 0, 0, 0),
+                    50.0,
+                    50.0,
+                    ChartBounds { x_lo: 0.0, x_hi: 100.0, y_lo: 0.0, y_hi: 100.0 },
+                );
+                draw_crosshair(
+                    frame,
+                    Rect::new(0, 0, 1, 1),
+                    50.0,
+                    50.0,
+                    ChartBounds { x_lo: 0.0, x_hi: 100.0, y_lo: 0.0, y_hi: 100.0 },
+                );
             })
             .unwrap();
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -685,9 +685,9 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
         (-0.05, 1.05)
     } else if !app.plot_slots.is_empty() {
         let slot = &app.plot_slots[0];
-        if slot.y_min.is_some() && slot.y_max.is_some() {
+        if let (Some(y_min), Some(y_max)) = (slot.y_min, slot.y_max) {
             // Manual per-slot limits
-            (slot.y_min.unwrap(), slot.y_max.unwrap())
+            (y_min, y_max)
         } else {
             // Auto: use actual data bounds
             let all_data: Vec<f64> = slot.data.iter().copied()


### PR DESCRIPTION
Takes the tree from **12 clippy warnings to 0**, then removes clippy's `continue-on-error` in `ci.yml` so it becomes a hard gate.

> Replaces #73, which GitHub auto-closed when its base branch (`64-ci-build-test-lint`) was deleted on merging #72 — a closed PR cannot be retargeted. Same branch, same commits, now rebuilt linearly on `main`; the tree is byte-identical to what was reviewed there.

One commit per category:

| Commit | What |
|---|---|
| `b756d8d` | 4 `clippy --fix` rewrites + a NaN crosshair test |
| `729c923` | `is_some()`-then-`unwrap()` → `if let` (4 sites) |
| `d0d4f67` | `#[allow]` for the `FFT` acronym |
| `c3f29d6` | `draw_crosshair`: 11 args → `Rect` + `ChartBounds` |
| `4f3b847` | remove the unused `refresh_selected_value` |
| `404f3fd` | drop clippy's `continue-on-error` |
| `192e136` | pin the toolchain, fix the `dead_code` it surfaces |
| `37abe9e` `5152887` | bump to 1.3.2 + lockfile |

## Two that weren't cosmetic

**The `manual_range_contains` autofix fixes a real bug.** `frac_x < 0.0 || frac_x > 1.0` never catches NaN, since every comparison against NaN is false. Execution then reached `(NaN * (cw - 1) as f64) as u16`, which **saturates to 0**, pinning a crosshair to the chart's top-left corner as though that were the data point. `RangeInclusive::contains` is false for NaN, so the new form returns early. Verified rather than assumed:

```
   NaN  original_returns=false  clippy_returns=true   <-- DIFFERS
```

`crosshair_skipped_for_non_finite_coordinates` covers all three NaN combinations and was confirmed failing first. The four existing crosshair tests only assert *absence of a panic*, which is why this went unnoticed. Same family as the plot-limit NaN handling in #71.

**The `single_match` warning was a swallowed error, in dead code.** The match was `Err(_) => {}`, discarding a failed `get_value` with no message; clippy's suggested `if let Ok(..)` silences the lint while *keeping* the error discarded, so it was excluded from the autofix commit. `refresh_selected_value` then turned out to have **no callers** — what its `#[allow(dead_code)]` was hiding. Its live counterpart `load_selected_value` already handles the error correctly, so the swallowed error was unreachable and "fixing" it would have meant an untestable change to code nothing runs. Removed instead. Live-path feedback gaps stay tracked in #37.

## Enforcing clippy immediately caught a CI flaw

The first run failed on `method 'stop' is never used` — rustc's `dead_code`, not clippy, promoted by `-D warnings`. Cause was toolchain skew: the runner ships **rustc 1.97.1**, my machine had **1.93.1**. I installed 1.97.1 and reproduced it locally rather than guessing.

Both methods are reached only via `Drop`, and the test target replaces `main()` with the harness — nothing constructs a listener there, so they are genuinely unreachable *in that build* while live in the binary. The struct-level `#[allow(dead_code)]` covers fields, not impl methods, so they are annotated individually.

The real problem is that **the runner's Rust version floats, so with `-D warnings` a runner image update can fail CI on untouched code**. `rust-toolchain.toml` pins the channel to `"1.97"` — patch fixes still arrive, minor bumps stay deliberate. This also matters for the fmt ratchet: the debt is **188 diffs under rustfmt 1.8, 198 under 1.9**, so without the pin "clear the fmt debt" is a moving target.

## Judgment calls

- **`PlotFocus::FFT` is `#[allow]`ed, not renamed.** FFT is the universal spelling and the codebase uses it everywhere else (`fft_enabled`, `compute_fft`, the `[f]` binding). Allowed on the variant, not crate-wide.
- **`draw_crosshair` is a signature change, not a rewrite.** The body destructures back into the existing local names, so the drawing logic is unchanged and the five crosshair tests carry the proof.
- **rustfmt stays reported-only**, per the agreed plan.

## Verification

Every enforced step, run locally on the pinned toolchain exactly as CI runs it:

| Command | Result |
|---|---|
| `cargo build --locked --all-targets` | pass |
| `cargo build --locked --release` | pass |
| `cargo test --locked` | 98 passed, 0 failed |
| `cargo test --locked -- --ignored` | 7 passed, 0 failed |
| `cargo clippy --locked --all-targets -- -D warnings` | **exit 0** |