### PR TITLE
Format the tree, enforce all CI gates, and fix the Docker publish credentials

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,10 @@
+# Revisions to skip when running git blame - bulk mechanical rewrites only.
+#
+# Use locally with:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# GitHub reads this file automatically. Only add commits that change formatting
+# and nothing else.
+
+# Reformat with cargo fmt (rustfmt 1.9.0, 198 diffs -> 0)
+c461fa194966b5c09816621dae6553723e5c1e67

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,21 +82,13 @@ jobs:
         id: clippy
         run: cargo clippy --locked --all-targets -- -D warnings
 
-      # ---- Ratchet: reported, not enforced ----
-      #
-      # main still carries ~198 pre-existing rustfmt diffs that belong to no single
-      # change. Enforcing now would make CI red on every PR regardless of its
-      # contents, and reformatting the tree would bury real diffs in noise.
-      #
-      # To enforce, run `cargo fmt` in a commit of its own, add that SHA to
-      # .git-blame-ignore-revs, and delete the `continue-on-error` below. See #64.
-
-      - name: Format check (reported, not enforced)
+      # Enforced: the tree is formatted and stays that way. The bulk reformat is
+      # listed in .git-blame-ignore-revs so it does not pollute git blame.
+      - name: Format check
         id: fmt
-        continue-on-error: true
         run: cargo fmt --check
 
-      - name: Lint debt summary
+      - name: Lint summary
         if: always()
         run: |
           {
@@ -105,8 +97,7 @@ jobs:
             echo "| Check | Result | Enforced |"
             echo "| ----- | ------ | -------- |"
             echo "| Clippy | ${{ steps.clippy.outcome }} | yes |"
-            echo "| Format | ${{ steps.fmt.outcome }} | no |"
+            echo "| Format | ${{ steps.fmt.outcome }} | yes |"
             echo
-            echo "Build, tests and clippy are enforced. Format is reported only"
-            echo "while the pre-existing rustfmt debt is cleared - see issue #64."
+            echo "All checks are enforced: build, tests, clippy and format."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,7 +14,9 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     env:
-      HARBOR_USERNAME: ${{ secrets.HARBOR_USERNAME }}
+      # Mirrored into env so step-level `if:` can test it - secrets are not
+      # available directly in an `if:` expression.
+      REGISTRY_USERNAME: ${{ secrets.ADREGISTRY_INST_USERNAME }}
 
     steps:
       - name: Checkout
@@ -27,12 +29,12 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Log in to Harbor
-        if: env.HARBOR_USERNAME != ''
+        if: env.REGISTRY_USERNAME != ''
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.HARBOR_USERNAME }}
-          password: ${{ secrets.HARBOR_PASSWORD }}
+          username: ${{ secrets.ADREGISTRY_INST_USERNAME }}
+          password: ${{ secrets.ADREGISTRY_INST_SECRET }}
 
       - name: Set image tags
         id: tags
@@ -45,10 +47,19 @@ jobs:
             echo "tags=${{ env.IMAGE }}:latest,${{ env.IMAGE }}:${VERSION}" >> "$GITHUB_OUTPUT"
           fi
 
+      # `push` is gated on the same condition as the login above. Previously the
+      # login skipped itself when the credential was absent but this pushed
+      # unconditionally, so a missing secret surfaced as an `unauthorized` error
+      # after a full image build rather than as a clear skip.
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: ${{ env.REGISTRY_USERNAME != '' }}
           platforms: linux/amd64
           tags: ${{ steps.tags.outputs.tags }}
+
+      - name: Warn if the push was skipped
+        if: env.REGISTRY_USERNAME == ''
+        run: |
+          echo "::warning::ADREGISTRY_INST_USERNAME is not set - image was built but not pushed."

--- a/.secrets.example
+++ b/.secrets.example
@@ -1,2 +1,6 @@
-HARBOR_USERNAME=your-harbor-username
-HARBOR_PASSWORD=your-harbor-password-or-token
+# Copy to .secrets for local runs with `act` (see .actrc). Never commit .secrets.
+#
+# These must match the secret names the workflow reads, and the repository
+# secrets configured in GitHub.
+ADREGISTRY_INST_USERNAME=your-registry-username
+ADREGISTRY_INST_SECRET=your-registry-password-or-token

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "redis-tui"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-tui"
-version = "1.3.2"
+version = "1.3.3"
 edition = "2021"
 description = "A Redis TUI client inspired by Redis Insight"
 license = "BSD-3-Clause"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,8 +1,8 @@
-use crate::data::{DataType, Endianness, decode_blob, encode_values, is_binary};
+use crate::data::{decode_blob, encode_values, is_binary, DataType, Endianness};
 use crate::redis_client::{KeyInfo, MultiRedisClient, RedisValue, StreamEntry};
 use ratatui::style::Color;
 use ratatui::widgets::ListState;
-use rustfft::{FftPlanner, num_complex::Complex};
+use rustfft::{num_complex::Complex, FftPlanner};
 use std::collections::{HashMap, VecDeque};
 use std::sync::mpsc;
 
@@ -15,12 +15,8 @@ pub const MAX_PLOT_SLOTS: usize = 4;
 pub const MAX_STREAM_ENTRIES: usize = 10;
 
 /// Colors assigned to each plot slot
-pub const PLOT_COLORS: [Color; MAX_PLOT_SLOTS] = [
-    Color::Cyan,
-    Color::Yellow,
-    Color::Green,
-    Color::Magenta,
-];
+pub const PLOT_COLORS: [Color; MAX_PLOT_SLOTS] =
+    [Color::Cyan, Color::Yellow, Color::Green, Color::Magenta];
 
 /// A slot in the multi-key plot FIFO
 #[derive(Clone)]
@@ -30,12 +26,13 @@ pub struct PlotSlot {
     pub color: Color,
     pub data_type: DataType,
     pub endianness: Endianness,
-    pub y_min: Option<f64>,  // None = auto
-    pub y_max: Option<f64>,  // None = auto
+    pub y_min: Option<f64>, // None = auto
+    pub y_max: Option<f64>, // None = auto
 }
 
 /// Windows used for the multi-average display (value view + rate chart header)
-pub const RATE_WINDOWS: &[(u64, &str)] = &[(1, "1s"), (5, "5s"), (10, "10s"), (20, "20s"), (30, "30s")];
+pub const RATE_WINDOWS: &[(u64, &str)] =
+    &[(1, "1s"), (5, "5s"), (10, "10s"), (20, "20s"), (30, "30s")];
 
 /// How long (ms) a display width stays pinned after it would otherwise shrink
 const RATE_WIDTH_HYSTERESIS_MS: u64 = 3_000;
@@ -125,7 +122,13 @@ fn compute_five_num(rate_history: &VecDeque<(u64, f64)>) -> Option<[f64; 5]> {
         let frac = idx - lo as f64;
         vals[lo] * (1.0 - frac) + vals[hi] * frac
     };
-    Some([vals[0], percentile(0.25), percentile(0.5), percentile(0.75), vals[n - 1]])
+    Some([
+        vals[0],
+        percentile(0.25),
+        percentile(0.5),
+        percentile(0.75),
+        vals[n - 1],
+    ])
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -207,12 +210,21 @@ impl RateTracker {
             return 0.0;
         }
         let cutoff = now_ms.saturating_sub(window_secs * 1000);
-        let count = self.entry_timestamps.iter().filter(|&&ts| ts >= cutoff).count();
+        let count = self
+            .entry_timestamps
+            .iter()
+            .filter(|&&ts| ts >= cutoff)
+            .count();
         count as f64 / window_secs as f64
     }
 
     /// Update a sticky display width: grows immediately, shrinks only after RATE_WIDTH_HYSTERESIS_MS.
-    fn update_sticky_width(pinned: &mut usize, pinned_until_ms: &mut u64, needed: usize, now_ms: u64) {
+    fn update_sticky_width(
+        pinned: &mut usize,
+        pinned_until_ms: &mut u64,
+        needed: usize,
+        now_ms: u64,
+    ) {
         if needed > *pinned {
             *pinned = needed;
             *pinned_until_ms = now_ms + RATE_WIDTH_HYSTERESIS_MS;
@@ -257,10 +269,10 @@ pub struct App {
     // Data plot
     pub data_type: DataType,
     pub endianness: Endianness,
-    pub plot_data: Vec<f64>,            // primary key's plot data (backward compat)
-    pub plot_slots: Vec<PlotSlot>,      // multi-key plot FIFO (up to MAX_PLOT_SLOTS)
-    pub listening_keys: Vec<String>,    // keys with active stream listeners (set by main loop)
-    pub siggen_keys: Vec<String>,       // keys with active signal generators (set by main loop)
+    pub plot_data: Vec<f64>, // primary key's plot data (backward compat)
+    pub plot_slots: Vec<PlotSlot>, // multi-key plot FIFO (up to MAX_PLOT_SLOTS)
+    pub listening_keys: Vec<String>, // keys with active stream listeners (set by main loop)
+    pub siggen_keys: Vec<String>, // keys with active signal generators (set by main loop)
     pub plot_auto_limits: bool,
     pub plot_y_min: f64,
     pub plot_y_max: f64,
@@ -285,8 +297,8 @@ pub struct App {
     pub fft_x_max: f64,
 
     // Mouse state
-    pub mouse_x: u16,         // terminal column
-    pub mouse_y: u16,         // terminal row
+    pub mouse_x: u16, // terminal column
+    pub mouse_y: u16, // terminal row
     pub mouse_dragging: bool,
     pub drag_start_x: u16,
     pub drag_start_y: u16,
@@ -297,11 +309,11 @@ pub struct App {
     /// Data coordinates of hover position (if mouse is in a chart area)
     pub hover_data_x: Option<f64>,
     pub hover_data_y: Option<f64>,
-    pub hover_in_fft: bool,   // true if hovering in FFT chart
+    pub hover_in_fft: bool, // true if hovering in FFT chart
 
     // Panel area rects (set during draw)
-    pub key_list_area: Option<(u16, u16, u16, u16)>,     // x, y, w, h
-    pub value_view_area: Option<(u16, u16, u16, u16)>,   // x, y, w, h
+    pub key_list_area: Option<(u16, u16, u16, u16)>, // x, y, w, h
+    pub value_view_area: Option<(u16, u16, u16, u16)>, // x, y, w, h
     pub signal_chart_area: Option<(u16, u16, u16, u16)>, // x, y, w, h (inner)
     pub fft_chart_area: Option<(u16, u16, u16, u16)>,
 
@@ -327,10 +339,10 @@ pub struct App {
     pub edit_operation: Option<EditOperation>,
     pub edit_fields: Vec<(String, String)>, // (label, value)
     pub edit_focus: usize,
-    pub edit_key: String,          // the key being edited
-    pub edit_multi_count: usize,   // how many entries submitted in this session
-    pub new_key_type_idx: usize,   // index into KEY_TYPES for new key creation
-    pub edit_binary_mode: bool,    // encode values as binary blobs
+    pub edit_key: String,             // the key being edited
+    pub edit_multi_count: usize,      // how many entries submitted in this session
+    pub new_key_type_idx: usize,      // index into KEY_TYPES for new key creation
+    pub edit_binary_mode: bool,       // encode values as binary blobs
     pub edit_binary_dtype_idx: usize, // index into DataType::all() for binary encoding
 
     // Signal generator state
@@ -440,7 +452,7 @@ impl App {
 
             rate_view: false,
             rate_history_secs: 1200, // 20 minutes default (overridden by CLI)
-            rate_avg_window_secs: 2,  // 2 seconds default (overridden by CLI)
+            rate_avg_window_secs: 2, // 2 seconds default (overridden by CLI)
             rate_trackers: HashMap::new(),
         }
     }
@@ -479,7 +491,10 @@ impl App {
 
     /// Get the color assigned to a plotted key, if any
     pub fn plot_color_for_key(&self, key_name: &str) -> Option<Color> {
-        self.plot_slots.iter().find(|s| s.key_name == key_name).map(|s| s.color)
+        self.plot_slots
+            .iter()
+            .find(|s| s.key_name == key_name)
+            .map(|s| s.color)
     }
 
     /// Update plot data for a specific slot by key name, using the slot's own data type
@@ -488,12 +503,8 @@ impl App {
             let dt = slot.data_type;
             let en = slot.endianness;
             slot.data = match value {
-                RedisValue::String(bytes) => {
-                    decode_blob(bytes, dt, en)
-                }
-                RedisValue::Stream(entries) => {
-                    extract_stream_plot_data(entries, dt, en)
-                }
+                RedisValue::String(bytes) => decode_blob(bytes, dt, en),
+                RedisValue::Stream(entries) => extract_stream_plot_data(entries, dt, en),
                 RedisValue::List(items) => {
                     let mut data = Vec::new();
                     for item in items {
@@ -507,9 +518,7 @@ impl App {
                     }
                     data
                 }
-                RedisValue::ZSet(pairs) => {
-                    pairs.iter().map(|(_, score)| *score).collect()
-                }
+                RedisValue::ZSet(pairs) => pairs.iter().map(|(_, score)| *score).collect(),
                 RedisValue::Hash(pairs) => {
                     let mut data = Vec::new();
                     for (_, val) in pairs {
@@ -558,7 +567,12 @@ impl App {
 
     /// Update the ingestion rate tracker for a stream key with newly received entries.
     /// Called from the main loop drain for every active StreamListener.
-    pub fn update_rate_tracker(&mut self, key_name: &str, new_entries: &[StreamEntry], now_ms: u64) {
+    pub fn update_rate_tracker(
+        &mut self,
+        key_name: &str,
+        new_entries: &[StreamEntry],
+        now_ms: u64,
+    ) {
         let history_secs = self.rate_history_secs;
 
         // Parse unix_ms from entry IDs (format: "{unix_ms}-{seq}")
@@ -584,8 +598,16 @@ impl App {
 
                 let now_for_gap = first_new_ms; // approximate: compare relative to arrival
                 let cutoff_30s = now_for_gap.saturating_sub(30_000);
-                let count_30s = tracker.entry_timestamps.iter().filter(|&&ts| ts >= cutoff_30s).count();
-                let current_rate = if count_30s > 0 { count_30s as f64 / 30.0 } else { 0.0 };
+                let count_30s = tracker
+                    .entry_timestamps
+                    .iter()
+                    .filter(|&&ts| ts >= cutoff_30s)
+                    .count();
+                let current_rate = if count_30s > 0 {
+                    count_30s as f64 / 30.0
+                } else {
+                    0.0
+                };
 
                 let threshold_ms = if current_rate > 0.0 {
                     ((1000.0 / current_rate) * 1.85).max(500.0) as u64
@@ -619,7 +641,11 @@ impl App {
         // Chart rate: sliding window controlled by --rate-avg-window (default 2s)
         let chart_window = self.rate_avg_window_secs.max(1);
         let chart_cutoff_ms = now_ms.saturating_sub(chart_window * 1000);
-        let chart_count = tracker.entry_timestamps.iter().filter(|&&ts| ts >= chart_cutoff_ms).count();
+        let chart_count = tracker
+            .entry_timestamps
+            .iter()
+            .filter(|&&ts| ts >= chart_cutoff_ms)
+            .count();
         let chart_rate = chart_count as f64 / chart_window as f64;
 
         // Only record once the window is full — avoids low warmup samples skewing the minimum
@@ -659,7 +685,12 @@ impl App {
                 now_ms,
             );
         }
-        let rate_needed = tracker.rate_display_vals.iter().map(|r| format!("{:.1}", r).len()).max().unwrap_or(3);
+        let rate_needed = tracker
+            .rate_display_vals
+            .iter()
+            .map(|r| format!("{:.1}", r).len())
+            .max()
+            .unwrap_or(3);
         RateTracker::update_sticky_width(
             &mut tracker.rate_display_width,
             &mut tracker.rate_display_width_until_ms,
@@ -676,7 +707,12 @@ impl App {
                     now_ms,
                 );
             }
-            let stat_needed = tracker.stat_display_vals.iter().map(|v| format!("{:.1}", v).len()).max().unwrap_or(3);
+            let stat_needed = tracker
+                .stat_display_vals
+                .iter()
+                .map(|v| format!("{:.1}", v).len())
+                .max()
+                .unwrap_or(3);
             RateTracker::update_sticky_width(
                 &mut tracker.stat_display_width,
                 &mut tracker.stat_display_width_until_ms,
@@ -783,8 +819,7 @@ impl App {
                         cap_stream_entries(&mut value);
                         // Track last stream ID for XREAD polling
                         if let RedisValue::Stream(ref entries) = value {
-                            self.last_stream_id =
-                                entries.last().map(|e| e.id.clone());
+                            self.last_stream_id = entries.last().map(|e| e.id.clone());
                         } else {
                             self.last_stream_id = None;
                         }
@@ -805,7 +840,10 @@ impl App {
 
     /// Append new stream entries from XREAD into the current value.
     /// Returns true if new entries were added.
-    pub fn append_stream_entries(&mut self, new_entries: Vec<crate::redis_client::StreamEntry>) -> bool {
+    pub fn append_stream_entries(
+        &mut self,
+        new_entries: Vec<crate::redis_client::StreamEntry>,
+    ) -> bool {
         if new_entries.is_empty() {
             return false;
         }
@@ -859,9 +897,7 @@ impl App {
 
     fn update_plot_data(&mut self, value: &RedisValue) {
         self.plot_data = match value {
-            RedisValue::String(bytes) => {
-                decode_blob(bytes, self.data_type, self.endianness)
-            }
+            RedisValue::String(bytes) => decode_blob(bytes, self.data_type, self.endianness),
             RedisValue::Stream(entries) => {
                 // Extract _ fields from stream entries and decode
                 self.expanded_stream_entries = vec![false; entries.len()];
@@ -914,11 +950,19 @@ impl App {
     /// Cycle the data type for the currently selected key's plot slot (if plotted),
     /// otherwise cycle the global data type. Then recompute.
     pub fn cycle_data_type(&mut self, forward: bool) {
-        let new_type = if forward { self.data_type.next() } else { self.data_type.prev() };
+        let new_type = if forward {
+            self.data_type.next()
+        } else {
+            self.data_type.prev()
+        };
         // Update the slot for the selected key if it's plotted
         if let Some(key) = self.selected_key_name().map(|s| s.to_string()) {
             if let Some(slot) = self.plot_slots.iter_mut().find(|s| s.key_name == key) {
-                slot.data_type = if forward { slot.data_type.next() } else { slot.data_type.prev() };
+                slot.data_type = if forward {
+                    slot.data_type.next()
+                } else {
+                    slot.data_type.prev()
+                };
                 self.data_type = slot.data_type;
             } else {
                 self.data_type = new_type;
@@ -974,7 +1018,9 @@ impl App {
             self.fft_rx = None;
             // Non-blocking join — avoid stalling the UI thread
             if let Some(h) = self.fft_handle.take() {
-                std::thread::spawn(move || { let _ = h.join(); });
+                std::thread::spawn(move || {
+                    let _ = h.join();
+                });
             }
         }
     }
@@ -987,7 +1033,9 @@ impl App {
             self.fft_rx = None;
             // Non-blocking join — avoid stalling the UI thread
             if let Some(h) = self.fft_handle.take() {
-                std::thread::spawn(move || { let _ = h.join(); });
+                std::thread::spawn(move || {
+                    let _ = h.join();
+                });
             }
             return;
         }
@@ -1098,7 +1146,14 @@ impl App {
             };
             let full_x = self.fft_data.len() as f64;
             let (nx0, nx1) = zoom_range(x0, x1, factor, center_frac_x, 0.0, full_x);
-            let (ny0, ny1) = zoom_range(y0, y1, factor, center_frac_y, f64::NEG_INFINITY, f64::INFINITY);
+            let (ny0, ny1) = zoom_range(
+                y0,
+                y1,
+                factor,
+                center_frac_y,
+                f64::NEG_INFINITY,
+                f64::INFINITY,
+            );
             self.fft_x_min = nx0;
             self.fft_x_max = nx1;
             self.fft_y_min = ny0;
@@ -1113,7 +1168,14 @@ impl App {
             };
             let full_x = self.plot_data.len() as f64;
             let (nx0, nx1) = zoom_range(x0, x1, factor, center_frac_x, 0.0, full_x);
-            let (ny0, ny1) = zoom_range(y0, y1, factor, center_frac_y, f64::NEG_INFINITY, f64::INFINITY);
+            let (ny0, ny1) = zoom_range(
+                y0,
+                y1,
+                factor,
+                center_frac_y,
+                f64::NEG_INFINITY,
+                f64::INFINITY,
+            );
             self.plot_x_min = nx0;
             self.plot_x_max = nx1;
             self.plot_y_min = ny0;
@@ -1192,12 +1254,24 @@ impl App {
         } else {
             // Per-slot Y limits
             for slot in &self.plot_slots {
-                let auto_min = slot.data.iter().copied()
-                    .filter(|v| v.is_finite()).fold(f64::INFINITY, f64::min);
-                let auto_max = slot.data.iter().copied()
-                    .filter(|v| v.is_finite()).fold(f64::NEG_INFINITY, f64::max);
-                let y_min = slot.y_min.unwrap_or(if auto_min.is_finite() { auto_min } else { 0.0 });
-                let y_max = slot.y_max.unwrap_or(if auto_max.is_finite() { auto_max } else { 1.0 });
+                let auto_min = slot
+                    .data
+                    .iter()
+                    .copied()
+                    .filter(|v| v.is_finite())
+                    .fold(f64::INFINITY, f64::min);
+                let auto_max = slot
+                    .data
+                    .iter()
+                    .copied()
+                    .filter(|v| v.is_finite())
+                    .fold(f64::NEG_INFINITY, f64::max);
+                let y_min = slot
+                    .y_min
+                    .unwrap_or(if auto_min.is_finite() { auto_min } else { 0.0 });
+                let y_max = slot
+                    .y_max
+                    .unwrap_or(if auto_max.is_finite() { auto_max } else { 1.0 });
                 let short_name = if slot.key_name.len() > 10 {
                     format!("{}...", &slot.key_name[..10])
                 } else {
@@ -1367,7 +1441,10 @@ impl App {
                 if show_binary {
                     let mut lines = Vec::new();
                     // Show decoded values using current data type
-                    lines.push(format!("── Decoded as {} ({}) ──", self.data_type, self.endianness));
+                    lines.push(format!(
+                        "── Decoded as {} ({}) ──",
+                        self.data_type, self.endianness
+                    ));
                     let decoded = crate::data::format_blob(bytes, self.data_type, self.endianness);
                     for l in decoded.lines() {
                         lines.push(l.to_string());
@@ -1389,44 +1466,38 @@ impl App {
                     s.lines().map(|l| l.to_string()).collect()
                 }
             }
-            Some(RedisValue::List(items)) => {
-                items
-                    .iter()
-                    .enumerate()
-                    .map(|(i, item)| {
-                        let s = String::from_utf8_lossy(item);
-                        format!("[{}] {}", i, s)
-                    })
-                    .collect()
+            Some(RedisValue::List(items)) => items
+                .iter()
+                .enumerate()
+                .map(|(i, item)| {
+                    let s = String::from_utf8_lossy(item);
+                    format!("[{}] {}", i, s)
+                })
+                .collect(),
+            Some(RedisValue::Set(items)) => items
+                .iter()
+                .map(|item| {
+                    let s = String::from_utf8_lossy(item);
+                    format!("- {}", s)
+                })
+                .collect(),
+            Some(RedisValue::ZSet(pairs)) => pairs
+                .iter()
+                .map(|(member, score)| {
+                    let s = String::from_utf8_lossy(member);
+                    format!("{:.4}  {}", score, s)
+                })
+                .collect(),
+            Some(RedisValue::Hash(pairs)) => pairs
+                .iter()
+                .map(|(field, val)| {
+                    let s = String::from_utf8_lossy(val);
+                    format!("{}  =>  {}", field, s)
+                })
+                .collect(),
+            Some(RedisValue::Stream(entries)) => {
+                format_stream_entries(entries, self.data_type, self.endianness)
             }
-            Some(RedisValue::Set(items)) => {
-                items
-                    .iter()
-                    .map(|item| {
-                        let s = String::from_utf8_lossy(item);
-                        format!("- {}", s)
-                    })
-                    .collect()
-            }
-            Some(RedisValue::ZSet(pairs)) => {
-                pairs
-                    .iter()
-                    .map(|(member, score)| {
-                        let s = String::from_utf8_lossy(member);
-                        format!("{:.4}  {}", score, s)
-                    })
-                    .collect()
-            }
-            Some(RedisValue::Hash(pairs)) => {
-                pairs
-                    .iter()
-                    .map(|(field, val)| {
-                        let s = String::from_utf8_lossy(val);
-                        format!("{}  =>  {}", field, s)
-                    })
-                    .collect()
-            }
-            Some(RedisValue::Stream(entries)) => format_stream_entries(entries, self.data_type, self.endianness),
             Some(RedisValue::Unknown(msg)) => vec![msg.clone()],
         }
     }
@@ -1554,9 +1625,13 @@ impl App {
                 let value = &self.edit_fields[0].1;
                 if binary_mode {
                     let bytes = encode_values(value, bin_dtype, bin_endian)?;
-                    client.set_bytes(&self.edit_key, &bytes).map_err(|e| e.to_string())
+                    client
+                        .set_bytes(&self.edit_key, &bytes)
+                        .map_err(|e| e.to_string())
                 } else {
-                    client.set_string(&self.edit_key, value).map_err(|e| e.to_string())
+                    client
+                        .set_string(&self.edit_key, value)
+                        .map_err(|e| e.to_string())
                 }
             }
             EditOperation::HSet => {
@@ -1567,18 +1642,26 @@ impl App {
                 }
                 if binary_mode {
                     let bytes = encode_values(value, bin_dtype, bin_endian)?;
-                    client.hset_bytes(&self.edit_key, field, &bytes).map_err(|e| e.to_string())
+                    client
+                        .hset_bytes(&self.edit_key, field, &bytes)
+                        .map_err(|e| e.to_string())
                 } else {
-                    client.hset(&self.edit_key, field, value).map_err(|e| e.to_string())
+                    client
+                        .hset(&self.edit_key, field, value)
+                        .map_err(|e| e.to_string())
                 }
             }
             EditOperation::RPush => {
                 let value = &self.edit_fields[0].1;
                 if binary_mode {
                     let bytes = encode_values(value, bin_dtype, bin_endian)?;
-                    client.rpush_bytes(&self.edit_key, &bytes).map_err(|e| e.to_string())
+                    client
+                        .rpush_bytes(&self.edit_key, &bytes)
+                        .map_err(|e| e.to_string())
                 } else {
-                    client.rpush(&self.edit_key, value).map_err(|e| e.to_string())
+                    client
+                        .rpush(&self.edit_key, value)
+                        .map_err(|e| e.to_string())
                 }
             }
             EditOperation::LSet => {
@@ -1589,18 +1672,26 @@ impl App {
                 let value = &self.edit_fields[1].1;
                 if binary_mode {
                     let bytes = encode_values(value, bin_dtype, bin_endian)?;
-                    client.lset_bytes(&self.edit_key, index, &bytes).map_err(|e| e.to_string())
+                    client
+                        .lset_bytes(&self.edit_key, index, &bytes)
+                        .map_err(|e| e.to_string())
                 } else {
-                    client.lset(&self.edit_key, index, value).map_err(|e| e.to_string())
+                    client
+                        .lset(&self.edit_key, index, value)
+                        .map_err(|e| e.to_string())
                 }
             }
             EditOperation::SAdd => {
                 let member = &self.edit_fields[0].1;
                 if binary_mode {
                     let bytes = encode_values(member, bin_dtype, bin_endian)?;
-                    client.sadd_bytes(&self.edit_key, &bytes).map_err(|e| e.to_string())
+                    client
+                        .sadd_bytes(&self.edit_key, &bytes)
+                        .map_err(|e| e.to_string())
                 } else {
-                    client.sadd(&self.edit_key, member).map_err(|e| e.to_string())
+                    client
+                        .sadd(&self.edit_key, member)
+                        .map_err(|e| e.to_string())
                 }
             }
             EditOperation::ZAdd => {
@@ -1611,9 +1702,13 @@ impl App {
                 let member = &self.edit_fields[1].1;
                 if binary_mode {
                     let bytes = encode_values(member, bin_dtype, bin_endian)?;
-                    client.zadd_bytes(&self.edit_key, score, &bytes).map_err(|e| e.to_string())
+                    client
+                        .zadd_bytes(&self.edit_key, score, &bytes)
+                        .map_err(|e| e.to_string())
                 } else {
-                    client.zadd(&self.edit_key, score, member).map_err(|e| e.to_string())
+                    client
+                        .zadd(&self.edit_key, score, member)
+                        .map_err(|e| e.to_string())
                 }
             }
             EditOperation::XAdd => {
@@ -1624,9 +1719,13 @@ impl App {
                 }
                 if binary_mode {
                     let bytes = encode_values(value, bin_dtype, bin_endian)?;
-                    client.xadd_binary(&self.edit_key, field, &bytes).map_err(|e| e.to_string())
+                    client
+                        .xadd_binary(&self.edit_key, field, &bytes)
+                        .map_err(|e| e.to_string())
                 } else {
-                    client.xadd(&self.edit_key, field, value).map_err(|e| e.to_string())
+                    client
+                        .xadd(&self.edit_key, field, value)
+                        .map_err(|e| e.to_string())
                 }
             }
             EditOperation::SetTTL => {
@@ -1662,11 +1761,17 @@ impl App {
                     let bytes = encode_values(value, bin_dtype, bin_endian)?;
                     match key_type {
                         "string" => client.set_bytes(key, &bytes).map_err(|e| e.to_string()),
-                        "hash" => client.hset_bytes(key, "field", &bytes).map_err(|e| e.to_string()),
+                        "hash" => client
+                            .hset_bytes(key, "field", &bytes)
+                            .map_err(|e| e.to_string()),
                         "list" => client.rpush_bytes(key, &bytes).map_err(|e| e.to_string()),
                         "set" => client.sadd_bytes(key, &bytes).map_err(|e| e.to_string()),
-                        "zset" => client.zadd_bytes(key, 0.0, &bytes).map_err(|e| e.to_string()),
-                        "stream" => client.xadd_binary(key, "data", &bytes).map_err(|e| e.to_string()),
+                        "zset" => client
+                            .zadd_bytes(key, 0.0, &bytes)
+                            .map_err(|e| e.to_string()),
+                        "stream" => client
+                            .xadd_binary(key, "data", &bytes)
+                            .map_err(|e| e.to_string()),
                         _ => Err(format!("Unknown type: {}", key_type)),
                     }
                 } else {
@@ -1794,14 +1899,30 @@ pub fn encode_wave_sample(val: f64, data_type: DataType, endianness: Endianness)
     match (data_type, endianness) {
         (DataType::Int8, _) => vec![(val.clamp(-128.0, 127.0) as i8) as u8],
         (DataType::UInt8, _) => vec![val.clamp(0.0, 255.0) as u8],
-        (DataType::Int16, Endianness::Little) => (val.clamp(-32768.0, 32767.0) as i16).to_le_bytes().to_vec(),
-        (DataType::Int16, Endianness::Big) => (val.clamp(-32768.0, 32767.0) as i16).to_be_bytes().to_vec(),
-        (DataType::UInt16, Endianness::Little) => (val.clamp(0.0, 65535.0) as u16).to_le_bytes().to_vec(),
-        (DataType::UInt16, Endianness::Big) => (val.clamp(0.0, 65535.0) as u16).to_be_bytes().to_vec(),
-        (DataType::Int32, Endianness::Little) => (val.clamp(-2147483648.0, 2147483647.0) as i32).to_le_bytes().to_vec(),
-        (DataType::Int32, Endianness::Big) => (val.clamp(-2147483648.0, 2147483647.0) as i32).to_be_bytes().to_vec(),
-        (DataType::UInt32, Endianness::Little) => (val.clamp(0.0, 4294967295.0) as u32).to_le_bytes().to_vec(),
-        (DataType::UInt32, Endianness::Big) => (val.clamp(0.0, 4294967295.0) as u32).to_be_bytes().to_vec(),
+        (DataType::Int16, Endianness::Little) => {
+            (val.clamp(-32768.0, 32767.0) as i16).to_le_bytes().to_vec()
+        }
+        (DataType::Int16, Endianness::Big) => {
+            (val.clamp(-32768.0, 32767.0) as i16).to_be_bytes().to_vec()
+        }
+        (DataType::UInt16, Endianness::Little) => {
+            (val.clamp(0.0, 65535.0) as u16).to_le_bytes().to_vec()
+        }
+        (DataType::UInt16, Endianness::Big) => {
+            (val.clamp(0.0, 65535.0) as u16).to_be_bytes().to_vec()
+        }
+        (DataType::Int32, Endianness::Little) => (val.clamp(-2147483648.0, 2147483647.0) as i32)
+            .to_le_bytes()
+            .to_vec(),
+        (DataType::Int32, Endianness::Big) => (val.clamp(-2147483648.0, 2147483647.0) as i32)
+            .to_be_bytes()
+            .to_vec(),
+        (DataType::UInt32, Endianness::Little) => {
+            (val.clamp(0.0, 4294967295.0) as u32).to_le_bytes().to_vec()
+        }
+        (DataType::UInt32, Endianness::Big) => {
+            (val.clamp(0.0, 4294967295.0) as u32).to_be_bytes().to_vec()
+        }
         (DataType::Float32, Endianness::Little) => (val as f32).to_le_bytes().to_vec(),
         (DataType::Float32, Endianness::Big) => (val as f32).to_be_bytes().to_vec(),
         (DataType::Float64, Endianness::Little) => val.to_le_bytes().to_vec(),
@@ -1827,7 +1948,11 @@ pub fn generate_wave_blob(config: &SignalGenConfig, time_offset: f64) -> Vec<u8>
         let raw = match config.wave_type.as_str() {
             "sine" => (2.0 * std::f64::consts::PI * phase).sin(),
             "square" => {
-                if (2.0 * std::f64::consts::PI * phase).sin() >= 0.0 { 1.0 } else { -1.0 }
+                if (2.0 * std::f64::consts::PI * phase).sin() >= 0.0 {
+                    1.0
+                } else {
+                    -1.0
+                }
             }
             "sawtooth" => 2.0 * (phase.fract() + 1.0).fract() - 1.0,
             "triangle" => {
@@ -1850,7 +1975,11 @@ pub fn generate_wave_blob(config: &SignalGenConfig, time_offset: f64) -> Vec<u8>
     blob
 }
 
-fn format_stream_entries(entries: &[StreamEntry], data_type: DataType, endianness: Endianness) -> Vec<String> {
+fn format_stream_entries(
+    entries: &[StreamEntry],
+    data_type: DataType,
+    endianness: Endianness,
+) -> Vec<String> {
     let mut lines = Vec::new();
     let total = entries.len();
     // Show only last 5 entries (newest first)
@@ -1867,19 +1996,26 @@ fn format_stream_entries(entries: &[StreamEntry], data_type: DataType, endiannes
                 // Binary data field - show decoded values + hex summary
                 let decoded = decode_blob(fval, data_type, endianness);
                 if !decoded.is_empty() {
-                    let preview: Vec<String> = decoded.iter().take(8).map(|v| {
-                        match data_type {
+                    let preview: Vec<String> = decoded
+                        .iter()
+                        .take(8)
+                        .map(|v| match data_type {
                             DataType::Float32 | DataType::Float64 => format!("{:.4}", v),
                             _ => format!("{}", *v as i64),
-                        }
-                    }).collect();
+                        })
+                        .collect();
                     let suffix = if decoded.len() > 8 {
                         format!(" ..({} vals)", decoded.len())
                     } else {
                         String::new()
                     };
-                    lines.push(format!("  {} [{}]: [{}]{}",
-                        fname, data_type, preview.join(", "), suffix));
+                    lines.push(format!(
+                        "  {} [{}]: [{}]{}",
+                        fname,
+                        data_type,
+                        preview.join(", "),
+                        suffix
+                    ));
                 }
                 // Hex summary
                 let hex: String = fval
@@ -1993,8 +2129,16 @@ fn auto_bounds(data: &[f64]) -> (f64, f64) {
     if data.is_empty() {
         return (0.0, 1.0);
     }
-    let y_min = data.iter().copied().filter(|v| v.is_finite()).fold(f64::INFINITY, f64::min);
-    let y_max = data.iter().copied().filter(|v| v.is_finite()).fold(f64::NEG_INFINITY, f64::max);
+    let y_min = data
+        .iter()
+        .copied()
+        .filter(|v| v.is_finite())
+        .fold(f64::INFINITY, f64::min);
+    let y_max = data
+        .iter()
+        .copied()
+        .filter(|v| v.is_finite())
+        .fold(f64::NEG_INFINITY, f64::max);
     // If all values were non-finite, return safe defaults
     if !y_min.is_finite() || !y_max.is_finite() || y_min > y_max {
         return (0.0, 1.0);
@@ -2029,10 +2173,7 @@ pub fn compute_fft_magnitude(data: &[f64]) -> Vec<f64> {
 
     let half = n / 2;
     let inv_n = 1.0 / n as f64;
-    buffer[..half]
-        .iter()
-        .map(|c| c.norm() * inv_n)
-        .collect()
+    buffer[..half].iter().map(|c| c.norm() * inv_n).collect()
 }
 
 #[cfg(test)]
@@ -2233,7 +2374,10 @@ mod tests {
             // Oldest entries should have been drained — first entry should be "500-0"
             assert_eq!(entries[0].id, "500-0");
             // Last entry should be the newest appended
-            assert_eq!(entries.last().unwrap().id, format!("{}-0", MAX_STREAM_ENTRIES + 499));
+            assert_eq!(
+                entries.last().unwrap().id,
+                format!("{}-0", MAX_STREAM_ENTRIES + 499)
+            );
         } else {
             panic!("expected Stream value");
         }
@@ -2241,43 +2385,67 @@ mod tests {
 
     #[test]
     fn format_stream_entries_uint8_printable_ascii() {
-        use crate::redis_client::StreamEntry;
         use crate::data::{DataType, Endianness};
+        use crate::redis_client::StreamEntry;
 
         // Create stream entry with uint8 data in printable ASCII range (65-90 = 'A'-'Z')
         let entries = vec![StreamEntry {
             id: "1000-0".to_string(),
-            fields: vec![
-                ("_waveform".to_string(), vec![65, 66, 67, 68, 69]),
-            ],
+            fields: vec![("_waveform".to_string(), vec![65, 66, 67, 68, 69])],
         }];
         let result = format_stream_entries(&entries, DataType::UInt8, Endianness::Little);
         let joined = result.join("\n");
         // Should contain decoded numeric values, not ASCII text
-        assert!(joined.contains("[uint8]"), "should show data type label, got:\n{}", joined);
-        assert!(joined.contains("65"), "should contain decoded value 65, got:\n{}", joined);
-        assert!(joined.contains("hex"), "should contain hex dump, got:\n{}", joined);
+        assert!(
+            joined.contains("[uint8]"),
+            "should show data type label, got:\n{}",
+            joined
+        );
+        assert!(
+            joined.contains("65"),
+            "should contain decoded value 65, got:\n{}",
+            joined
+        );
+        assert!(
+            joined.contains("hex"),
+            "should contain hex dump, got:\n{}",
+            joined
+        );
         // Should NOT contain the ASCII interpretation 'ABCDE'
-        assert!(!joined.contains("ABCDE"), "should not show ASCII text, got:\n{}", joined);
+        assert!(
+            !joined.contains("ABCDE"),
+            "should not show ASCII text, got:\n{}",
+            joined
+        );
     }
 
     #[test]
     fn format_stream_entries_uint16_data() {
-        use crate::redis_client::StreamEntry;
         use crate::data::{DataType, Endianness};
+        use crate::redis_client::StreamEntry;
 
         // Create uint16 LE data: 256 = [0x00, 0x01], 512 = [0x00, 0x02]
         let entries = vec![StreamEntry {
             id: "1000-0".to_string(),
-            fields: vec![
-                ("_data".to_string(), vec![0x00, 0x01, 0x00, 0x02]),
-            ],
+            fields: vec![("_data".to_string(), vec![0x00, 0x01, 0x00, 0x02])],
         }];
         let result = format_stream_entries(&entries, DataType::UInt16, Endianness::Little);
         let joined = result.join("\n");
-        assert!(joined.contains("[uint16]"), "should show uint16 label, got:\n{}", joined);
-        assert!(joined.contains("256"), "should contain decoded value 256, got:\n{}", joined);
-        assert!(joined.contains("512"), "should contain decoded value 512, got:\n{}", joined);
+        assert!(
+            joined.contains("[uint16]"),
+            "should show uint16 label, got:\n{}",
+            joined
+        );
+        assert!(
+            joined.contains("256"),
+            "should contain decoded value 256, got:\n{}",
+            joined
+        );
+        assert!(
+            joined.contains("512"),
+            "should contain decoded value 512, got:\n{}",
+            joined
+        );
     }
 
     // ── RateTracker tests ──────────────────────────────────────────────────────
@@ -2348,7 +2516,10 @@ mod tests {
         app.update_rate_tracker("k", &entries, base_ms);
 
         let tracker = app.rate_trackers.get("k").unwrap();
-        assert!(tracker.rate_history.is_empty(), "rate_history should be empty during warmup");
+        assert!(
+            tracker.rate_history.is_empty(),
+            "rate_history should be empty during warmup"
+        );
         assert!(tracker.tracking_start_ms.is_some());
     }
 
@@ -2368,7 +2539,10 @@ mod tests {
         app.update_rate_tracker("k", &batch2, now2);
 
         let tracker = app.rate_trackers.get("k").unwrap();
-        assert!(!tracker.rate_history.is_empty(), "should have recorded rate after warmup elapsed");
+        assert!(
+            !tracker.rate_history.is_empty(),
+            "should have recorded rate after warmup elapsed"
+        );
     }
 
     #[test]
@@ -2385,7 +2559,7 @@ mod tests {
         // Jump of 2000ms from last entry (base+29900ms → base+31900ms)
         // gap_ms = 2000ms > threshold 500ms → gap detected
         let last_ms = base_ms + 299 * 100; // base + 29900
-        let gap_start = last_ms + 2000;    // base + 31900
+        let gap_start = last_ms + 2000; // base + 31900
         let now2 = base_ms + 35_000;
         let batch2: Vec<_> = (0..5).map(|i| make_entry(gap_start + i * 100)).collect();
         app.update_rate_tracker("k", &batch2, now2);
@@ -2419,7 +2593,10 @@ mod tests {
         app.update_rate_tracker("k", &batch2, now2);
 
         let tracker = app.rate_trackers.get("k").unwrap();
-        assert!(!tracker.gaps.contains(&old_gap), "old gap should have been pruned");
+        assert!(
+            !tracker.gaps.contains(&old_gap),
+            "old gap should have been pruned"
+        );
     }
 
     #[test]

--- a/src/data.rs
+++ b/src/data.rs
@@ -160,11 +160,9 @@ pub fn format_blob(bytes: &[u8], data_type: DataType, endianness: Endianness) ->
             }
             let formatted: Vec<String> = values
                 .iter()
-                .map(|v| {
-                    match data_type {
-                        DataType::Float32 | DataType::Float64 => format!("{:.6}", v),
-                        _ => format!("{}", *v as i64),
-                    }
+                .map(|v| match data_type {
+                    DataType::Float32 | DataType::Float64 => format!("{:.6}", v),
+                    _ => format!("{}", *v as i64),
                 })
                 .collect();
             formatted.join(", ")
@@ -209,7 +207,11 @@ pub fn format_hex(bytes: &[u8]) -> String {
 
 /// Encode a string of comma/space-separated numeric values into binary bytes.
 /// Supports ints and floats depending on the target DataType.
-pub fn encode_values(input: &str, data_type: DataType, endianness: Endianness) -> Result<Vec<u8>, String> {
+pub fn encode_values(
+    input: &str,
+    data_type: DataType,
+    endianness: Endianness,
+) -> Result<Vec<u8>, String> {
     let tokens: Vec<&str> = input
         .split([',', ' '])
         .map(|s| s.trim())
@@ -225,50 +227,66 @@ pub fn encode_values(input: &str, data_type: DataType, endianness: Endianness) -
     for token in &tokens {
         match data_type {
             DataType::Int8 => {
-                let v: i8 = token.parse().map_err(|_| format!("'{}' is not a valid i8", token))?;
+                let v: i8 = token
+                    .parse()
+                    .map_err(|_| format!("'{}' is not a valid i8", token))?;
                 bytes.push(v as u8);
             }
             DataType::UInt8 => {
-                let v: u8 = token.parse().map_err(|_| format!("'{}' is not a valid u8", token))?;
+                let v: u8 = token
+                    .parse()
+                    .map_err(|_| format!("'{}' is not a valid u8", token))?;
                 bytes.push(v);
             }
             DataType::Int16 => {
-                let v: i16 = token.parse().map_err(|_| format!("'{}' is not a valid i16", token))?;
+                let v: i16 = token
+                    .parse()
+                    .map_err(|_| format!("'{}' is not a valid i16", token))?;
                 match endianness {
                     Endianness::Little => bytes.extend_from_slice(&v.to_le_bytes()),
                     Endianness::Big => bytes.extend_from_slice(&v.to_be_bytes()),
                 }
             }
             DataType::UInt16 => {
-                let v: u16 = token.parse().map_err(|_| format!("'{}' is not a valid u16", token))?;
+                let v: u16 = token
+                    .parse()
+                    .map_err(|_| format!("'{}' is not a valid u16", token))?;
                 match endianness {
                     Endianness::Little => bytes.extend_from_slice(&v.to_le_bytes()),
                     Endianness::Big => bytes.extend_from_slice(&v.to_be_bytes()),
                 }
             }
             DataType::Int32 => {
-                let v: i32 = token.parse().map_err(|_| format!("'{}' is not a valid i32", token))?;
+                let v: i32 = token
+                    .parse()
+                    .map_err(|_| format!("'{}' is not a valid i32", token))?;
                 match endianness {
                     Endianness::Little => bytes.extend_from_slice(&v.to_le_bytes()),
                     Endianness::Big => bytes.extend_from_slice(&v.to_be_bytes()),
                 }
             }
             DataType::UInt32 => {
-                let v: u32 = token.parse().map_err(|_| format!("'{}' is not a valid u32", token))?;
+                let v: u32 = token
+                    .parse()
+                    .map_err(|_| format!("'{}' is not a valid u32", token))?;
                 match endianness {
                     Endianness::Little => bytes.extend_from_slice(&v.to_le_bytes()),
                     Endianness::Big => bytes.extend_from_slice(&v.to_be_bytes()),
                 }
             }
             DataType::Float32 => {
-                let v: f32 = token.parse().map_err(|_| format!("'{}' is not a valid f32", token))?;
+                let v: f32 = token
+                    .parse()
+                    .map_err(|_| format!("'{}' is not a valid f32", token))?;
                 match endianness {
                     Endianness::Little => bytes.extend_from_slice(&v.to_le_bytes()),
                     Endianness::Big => bytes.extend_from_slice(&v.to_be_bytes()),
                 }
             }
             DataType::Float64 => {
-                let v: f64 = token.parse().map_err(|_| format!("'{}' is not a valid f64", token))?;
+                let v: f64 = token
+                    .parse()
+                    .map_err(|_| format!("'{}' is not a valid f64", token))?;
                 match endianness {
                     Endianness::Little => bytes.extend_from_slice(&v.to_le_bytes()),
                     Endianness::Big => bytes.extend_from_slice(&v.to_be_bytes()),
@@ -285,7 +303,9 @@ pub fn encode_values(input: &str, data_type: DataType, endianness: Endianness) -
 
 /// Check if bytes look like they contain binary (non-UTF8 or control chars)
 pub fn is_binary(bytes: &[u8]) -> bool {
-    bytes.iter().any(|&b| b < 0x20 && b != b'\n' && b != b'\r' && b != b'\t')
+    bytes
+        .iter()
+        .any(|&b| b < 0x20 && b != b'\n' && b != b'\r' && b != b'\t')
 }
 
 #[cfg(test)]
@@ -405,9 +425,8 @@ mod tests {
 
     #[test]
     fn decode_chunks_exact_fit() {
-        let result: Vec<f64> = decode_chunks(&[1, 0, 2, 0], |arr: [u8; 2]| {
-            u16::from_le_bytes(arr) as f64
-        });
+        let result: Vec<f64> =
+            decode_chunks(&[1, 0, 2, 0], |arr: [u8; 2]| u16::from_le_bytes(arr) as f64);
         assert_eq!(result, vec![1.0, 2.0]);
     }
 
@@ -422,9 +441,7 @@ mod tests {
 
     #[test]
     fn decode_chunks_empty() {
-        let result: Vec<f64> = decode_chunks(&[], |arr: [u8; 4]| {
-            f32::from_le_bytes(arr) as f64
-        });
+        let result: Vec<f64> = decode_chunks(&[], |arr: [u8; 4]| f32::from_le_bytes(arr) as f64);
         assert!(result.is_empty());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,10 @@ use anyhow::{Context, Result};
 use app::{App, InputMode, Panel};
 use clap::Parser;
 use crossterm::{
-    event::{self, Event, KeyCode, KeyModifiers, MouseEvent, MouseEventKind, EnableMouseCapture, DisableMouseCapture, EnableBracketedPaste, DisableBracketedPaste},
+    event::{
+        self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
+        Event, KeyCode, KeyModifiers, MouseEvent, MouseEventKind,
+    },
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
     ExecutableCommand,
 };
@@ -15,11 +18,17 @@ use ratatui::prelude::*;
 use redis_client::{MultiRedisClient, RedisClient, StreamEntry};
 use std::io;
 use std::sync::mpsc;
-use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 use std::time::Duration;
 
 #[derive(Parser, Debug)]
-#[command(name = "redis-tui", about = "A Redis TUI client inspired by Redis Insight")]
+#[command(
+    name = "redis-tui",
+    about = "A Redis TUI client inspired by Redis Insight"
+)]
 struct Args {
     /// Redis host
     #[arg(long, default_value = "127.0.0.1")]
@@ -64,10 +73,7 @@ impl Args {
             Some(pw) => format!(":{}@", pw),
             None => String::new(),
         };
-        format!(
-            "redis://{}{}:{}/{}",
-            auth, self.host, self.port, self.db
-        )
+        format!("redis://{}{}:{}/{}", auth, self.host, self.port, self.db)
     }
 }
 
@@ -150,7 +156,12 @@ fn main() -> Result<()> {
     let mut terminal = Terminal::new(backend).context("Failed to create terminal")?;
 
     // Run app
-    let result = run_app(&mut terminal, &mut client, args.rate_history * 60, args.rate_avg_window);
+    let result = run_app(
+        &mut terminal,
+        &mut client,
+        args.rate_history * 60,
+        args.rate_avg_window,
+    );
 
     // Restore terminal
     disable_raw_mode().context("Failed to disable raw mode")?;
@@ -346,7 +357,10 @@ fn run_app(
                     // Otherwise: swallow the event entirely (don't let terminal see it)
                 } else if mouse.modifiers.contains(KeyModifiers::SHIFT) {
                     // Starting a new selection — only activate on drag/down
-                    if matches!(mouse.kind, MouseEventKind::Down(_) | MouseEventKind::Drag(_)) {
+                    if matches!(
+                        mouse.kind,
+                        MouseEventKind::Down(_) | MouseEventKind::Drag(_)
+                    ) {
                         shift_selecting = true;
                     }
                 } else {
@@ -398,143 +412,195 @@ fn run_app(
                 // Only handle key press events — ignore release/repeat to prevent
                 // input issues with crossterm 0.28+ terminal protocols
                 if key.kind == event::KeyEventKind::Press {
-                match app.input_mode {
-                    InputMode::Filter => handle_filter_input(&mut app, client, key.code),
-                    InputMode::Confirm => handle_confirm_input(&mut app, client, key.code),
-                    InputMode::Help => match key.code {
-                        KeyCode::Up => {
-                            app.help_scroll = app.help_scroll.saturating_sub(1);
-                        }
-                        KeyCode::Down => {
-                            app.help_scroll = app.help_scroll.saturating_add(1);
-                        }
-                        _ => {
-                            app.help_scroll = 0;
-                            app.input_mode = InputMode::Normal;
-                        }
-                    },
-                    InputMode::Edit => {
-                        handle_edit_input(&mut app, client, key.code, key.modifiers)
-                    }
-                    InputMode::PlotLimit => {
-                        handle_plot_limit_input(&mut app, key.code)
-                    }
-                    InputMode::SignalGen => {
-                        handle_signal_gen_input(&mut app, key.code);
-                        // Check if user pressed Enter to start the generator
-                        if app.input_mode == InputMode::Normal && app.status_message == "Signal gen: starting" {
-                            // Parse config and start generator
-                            let all_types = data::DataType::all();
-                            let config = app::SignalGenConfig {
-                                wave_type: app.signal_gen_wave_type().to_string(),
-                                data_type: all_types[app.signal_gen_dtype_idx],
-                                endianness: app.endianness,
-                                frequency: app.signal_gen_fields[0].1.trim().parse().unwrap_or(1.0),
-                                amplitude: app.signal_gen_fields[1].1.trim().parse().unwrap_or(1.0),
-                                noise: app.signal_gen_fields[2].1.trim().parse().unwrap_or(0.0),
-                                samples_per_entry: app.signal_gen_fields[3].1.trim().parse().unwrap_or(100),
-                                entries_per_sec: app.signal_gen_fields[4].1.trim().parse().unwrap_or(10.0),
-                            };
-                            if let Some(k) = app.selected_key_name().map(|s| s.to_string()) {
-                                let key_url = client.url_for_key(&k).to_string();
-                                if let Some(sg) = SignalGenerator::start(&key_url, &k, app.db, config) {
-                                    // Evict oldest if at capacity (non-blocking)
-                                    if signal_generators.len() >= app::MAX_PLOT_SLOTS {
-                                        let mut oldest = signal_generators.remove(0);
-                                        oldest.stop_flag.store(true, Ordering::Relaxed);
-                                        if let Some(h) = oldest.handle.take() {
-                                            std::thread::spawn(move || { let _ = h.join(); });
-                                        }
-                                    }
-                                    signal_generators.push(sg);
-                                    app.status_message = format!("Signal gen: running on '{}' ({}/{})", k, signal_generators.len(), app::MAX_PLOT_SLOTS);
-                                } else {
-                                    app.status_message = "Signal gen: failed to start".to_string();
-                                }
+                    match app.input_mode {
+                        InputMode::Filter => handle_filter_input(&mut app, client, key.code),
+                        InputMode::Confirm => handle_confirm_input(&mut app, client, key.code),
+                        InputMode::Help => match key.code {
+                            KeyCode::Up => {
+                                app.help_scroll = app.help_scroll.saturating_sub(1);
                             }
-                        }
-                    }
-                    InputMode::Normal => {
-                        handle_normal_input(&mut app, client, key.code, key.modifiers);
-
-                        // Toggle key in plot slots with 'p'
-                        if key.code == KeyCode::Char('p') {
-                            if let Some(k) = app.selected_key_name().map(|s| s.to_string()) {
-                                let added = app.toggle_plot_slot(&k);
-                                if added {
-                                    // Fetch value directly from Redis for this key
-                                    if let Ok(value) = client.get_value(&k) {
-                                        app.update_slot_data(&k, &value);
-                                    }
-                                    app.plot_visible = true;
-                                    app.status_message = format!("Plot: added '{}' ({}/{})", k, app.plot_slots.len(), app::MAX_PLOT_SLOTS);
-                                } else {
-                                    if app.plot_slots.is_empty() {
-                                        app.plot_visible = false;
-                                    }
-                                    app.status_message = format!("Plot: removed '{}'", k);
-                                }
+                            KeyCode::Down => {
+                                app.help_scroll = app.help_scroll.saturating_add(1);
                             }
+                            _ => {
+                                app.help_scroll = 0;
+                                app.input_mode = InputMode::Normal;
+                            }
+                        },
+                        InputMode::Edit => {
+                            handle_edit_input(&mut app, client, key.code, key.modifiers)
                         }
-
-                        // Toggle stream listener with 'l'
-                        if key.code == KeyCode::Char('l') && app.is_viewing_stream() {
-                            if let Some(k) = app.selected_key_name().map(|s| s.to_string()) {
-                                // Check if already listening on this key
-                                if let Some(idx) = stream_listeners.iter().position(|sl| sl.watching_key == k) {
-                                    // Stop this specific listener (non-blocking)
-                                    let mut sl = stream_listeners.remove(idx);
-                                    sl.stop_flag.store(true, Ordering::Relaxed);
-                                    if let Some(h) = sl.handle.take() {
-                                        std::thread::spawn(move || { let _ = h.join(); });
-                                    }
-                                    app.clear_rate_tracker(&k);
-                                    app.rate_view = false;
-                                    app.status_message = format!("Stream: stopped '{}'", k);
-                                } else {
-                                    // Start new listener
-                                    let lid = app.last_stream_id.clone().unwrap_or_else(|| "$".to_string());
+                        InputMode::PlotLimit => handle_plot_limit_input(&mut app, key.code),
+                        InputMode::SignalGen => {
+                            handle_signal_gen_input(&mut app, key.code);
+                            // Check if user pressed Enter to start the generator
+                            if app.input_mode == InputMode::Normal
+                                && app.status_message == "Signal gen: starting"
+                            {
+                                // Parse config and start generator
+                                let all_types = data::DataType::all();
+                                let config = app::SignalGenConfig {
+                                    wave_type: app.signal_gen_wave_type().to_string(),
+                                    data_type: all_types[app.signal_gen_dtype_idx],
+                                    endianness: app.endianness,
+                                    frequency: app.signal_gen_fields[0]
+                                        .1
+                                        .trim()
+                                        .parse()
+                                        .unwrap_or(1.0),
+                                    amplitude: app.signal_gen_fields[1]
+                                        .1
+                                        .trim()
+                                        .parse()
+                                        .unwrap_or(1.0),
+                                    noise: app.signal_gen_fields[2].1.trim().parse().unwrap_or(0.0),
+                                    samples_per_entry: app.signal_gen_fields[3]
+                                        .1
+                                        .trim()
+                                        .parse()
+                                        .unwrap_or(100),
+                                    entries_per_sec: app.signal_gen_fields[4]
+                                        .1
+                                        .trim()
+                                        .parse()
+                                        .unwrap_or(10.0),
+                                };
+                                if let Some(k) = app.selected_key_name().map(|s| s.to_string()) {
                                     let key_url = client.url_for_key(&k).to_string();
-                                    if let Some(sl) = StreamListener::start(&key_url, &k, &lid, app.db) {
+                                    if let Some(sg) =
+                                        SignalGenerator::start(&key_url, &k, app.db, config)
+                                    {
                                         // Evict oldest if at capacity (non-blocking)
-                                        if stream_listeners.len() >= app::MAX_PLOT_SLOTS {
-                                            let mut oldest = stream_listeners.remove(0);
+                                        if signal_generators.len() >= app::MAX_PLOT_SLOTS {
+                                            let mut oldest = signal_generators.remove(0);
                                             oldest.stop_flag.store(true, Ordering::Relaxed);
                                             if let Some(h) = oldest.handle.take() {
-                                                std::thread::spawn(move || { let _ = h.join(); });
+                                                std::thread::spawn(move || {
+                                                    let _ = h.join();
+                                                });
                                             }
                                         }
-                                        stream_listeners.push(sl);
-                                        app.status_message = format!("Stream: listening on '{}' ({}/{})", k, stream_listeners.len(), app::MAX_PLOT_SLOTS);
+                                        signal_generators.push(sg);
+                                        app.status_message = format!(
+                                            "Signal gen: running on '{}' ({}/{})",
+                                            k,
+                                            signal_generators.len(),
+                                            app::MAX_PLOT_SLOTS
+                                        );
+                                    } else {
+                                        app.status_message =
+                                            "Signal gen: failed to start".to_string();
                                     }
                                 }
                             }
                         }
+                        InputMode::Normal => {
+                            handle_normal_input(&mut app, client, key.code, key.modifiers);
 
-                        // Toggle signal generator with 'w'
-                        if key.code == KeyCode::Char('w') {
-                            if let Some(k) = app.selected_key_name().map(|s| s.to_string()) {
-                                // Check if already generating on this key
-                                if let Some(idx) = signal_generators.iter().position(|sg| sg.watching_key == k) {
-                                    // Non-blocking stop
-                                    let mut sg = signal_generators.remove(idx);
-                                    sg.stop_flag.store(true, Ordering::Relaxed);
-                                    if let Some(h) = sg.handle.take() {
-                                        std::thread::spawn(move || { let _ = h.join(); });
+                            // Toggle key in plot slots with 'p'
+                            if key.code == KeyCode::Char('p') {
+                                if let Some(k) = app.selected_key_name().map(|s| s.to_string()) {
+                                    let added = app.toggle_plot_slot(&k);
+                                    if added {
+                                        // Fetch value directly from Redis for this key
+                                        if let Ok(value) = client.get_value(&k) {
+                                            app.update_slot_data(&k, &value);
+                                        }
+                                        app.plot_visible = true;
+                                        app.status_message = format!(
+                                            "Plot: added '{}' ({}/{})",
+                                            k,
+                                            app.plot_slots.len(),
+                                            app::MAX_PLOT_SLOTS
+                                        );
+                                    } else {
+                                        if app.plot_slots.is_empty() {
+                                            app.plot_visible = false;
+                                        }
+                                        app.status_message = format!("Plot: removed '{}'", k);
                                     }
-                                    app.status_message = format!("Signal gen: stopped '{}'", k);
-                                } else if app.is_viewing_stream() {
-                                    app.start_signal_gen_popup();
-                                } else {
-                                    app.status_message = "Signal gen: select a stream key first".to_string();
                                 }
                             }
-                        }
 
-                        // No longer stop generators on key navigation — they run independently
+                            // Toggle stream listener with 'l'
+                            if key.code == KeyCode::Char('l') && app.is_viewing_stream() {
+                                if let Some(k) = app.selected_key_name().map(|s| s.to_string()) {
+                                    // Check if already listening on this key
+                                    if let Some(idx) =
+                                        stream_listeners.iter().position(|sl| sl.watching_key == k)
+                                    {
+                                        // Stop this specific listener (non-blocking)
+                                        let mut sl = stream_listeners.remove(idx);
+                                        sl.stop_flag.store(true, Ordering::Relaxed);
+                                        if let Some(h) = sl.handle.take() {
+                                            std::thread::spawn(move || {
+                                                let _ = h.join();
+                                            });
+                                        }
+                                        app.clear_rate_tracker(&k);
+                                        app.rate_view = false;
+                                        app.status_message = format!("Stream: stopped '{}'", k);
+                                    } else {
+                                        // Start new listener
+                                        let lid = app
+                                            .last_stream_id
+                                            .clone()
+                                            .unwrap_or_else(|| "$".to_string());
+                                        let key_url = client.url_for_key(&k).to_string();
+                                        if let Some(sl) =
+                                            StreamListener::start(&key_url, &k, &lid, app.db)
+                                        {
+                                            // Evict oldest if at capacity (non-blocking)
+                                            if stream_listeners.len() >= app::MAX_PLOT_SLOTS {
+                                                let mut oldest = stream_listeners.remove(0);
+                                                oldest.stop_flag.store(true, Ordering::Relaxed);
+                                                if let Some(h) = oldest.handle.take() {
+                                                    std::thread::spawn(move || {
+                                                        let _ = h.join();
+                                                    });
+                                                }
+                                            }
+                                            stream_listeners.push(sl);
+                                            app.status_message = format!(
+                                                "Stream: listening on '{}' ({}/{})",
+                                                k,
+                                                stream_listeners.len(),
+                                                app::MAX_PLOT_SLOTS
+                                            );
+                                        }
+                                    }
+                                }
+                            }
+
+                            // Toggle signal generator with 'w'
+                            if key.code == KeyCode::Char('w') {
+                                if let Some(k) = app.selected_key_name().map(|s| s.to_string()) {
+                                    // Check if already generating on this key
+                                    if let Some(idx) =
+                                        signal_generators.iter().position(|sg| sg.watching_key == k)
+                                    {
+                                        // Non-blocking stop
+                                        let mut sg = signal_generators.remove(idx);
+                                        sg.stop_flag.store(true, Ordering::Relaxed);
+                                        if let Some(h) = sg.handle.take() {
+                                            std::thread::spawn(move || {
+                                                let _ = h.join();
+                                            });
+                                        }
+                                        app.status_message = format!("Signal gen: stopped '{}'", k);
+                                    } else if app.is_viewing_stream() {
+                                        app.start_signal_gen_popup();
+                                    } else {
+                                        app.status_message =
+                                            "Signal gen: select a stream key first".to_string();
+                                    }
+                                }
+                            }
+
+                            // No longer stop generators on key navigation — they run independently
+                        }
                     }
-                }
-            } // if KeyEventKind::Press
+                } // if KeyEventKind::Press
             }
         }
 
@@ -567,13 +633,22 @@ fn run_app(
                 }
             }
             if total_new > 0 {
-                app.status_message = format!("Stream: +{} entries on '{}' (live)", total_new, listener.watching_key);
+                app.status_message = format!(
+                    "Stream: +{} entries on '{}' (live)",
+                    total_new, listener.watching_key
+                );
             }
         }
 
         // Sync active key indicators for UI
-        app.listening_keys = stream_listeners.iter().map(|sl| sl.watching_key.clone()).collect();
-        app.siggen_keys = signal_generators.iter().map(|sg| sg.watching_key.clone()).collect();
+        app.listening_keys = stream_listeners
+            .iter()
+            .map(|sl| sl.watching_key.clone())
+            .collect();
+        app.siggen_keys = signal_generators
+            .iter()
+            .map(|sg| sg.watching_key.clone())
+            .collect();
 
         if !app.running {
             // Disable mouse capture immediately so events don't queue
@@ -828,7 +903,10 @@ fn handle_edit_input(
         return;
     }
     // Ctrl+T: cycle binary data type
-    if code == KeyCode::Char('t') && modifiers.contains(KeyModifiers::CONTROL) && app.edit_binary_mode {
+    if code == KeyCode::Char('t')
+        && modifiers.contains(KeyModifiers::CONTROL)
+        && app.edit_binary_mode
+    {
         let all = data::DataType::all();
         // Skip String and Blob types (last two)
         let max_idx = all.len() - 2;
@@ -837,7 +915,10 @@ fn handle_edit_input(
         return;
     }
     // Ctrl+E: toggle endianness
-    if code == KeyCode::Char('e') && modifiers.contains(KeyModifiers::CONTROL) && app.edit_binary_mode {
+    if code == KeyCode::Char('e')
+        && modifiers.contains(KeyModifiers::CONTROL)
+        && app.edit_binary_mode
+    {
         app.endianness = app.endianness.toggle();
         app.status_message = format!("Endianness: {}", app.endianness);
         return;
@@ -927,38 +1008,34 @@ fn handle_signal_gen_input(app: &mut App, code: KeyCode) {
         KeyCode::BackTab => {
             app.signal_gen_prev_field();
         }
-        KeyCode::Left => {
-            match app.signal_gen_focus {
-                0 => {
-                    if app.signal_gen_wave_idx == 0 {
-                        app.signal_gen_wave_idx = app::WAVE_TYPES.len() - 1;
-                    } else {
-                        app.signal_gen_wave_idx -= 1;
-                    }
+        KeyCode::Left => match app.signal_gen_focus {
+            0 => {
+                if app.signal_gen_wave_idx == 0 {
+                    app.signal_gen_wave_idx = app::WAVE_TYPES.len() - 1;
+                } else {
+                    app.signal_gen_wave_idx -= 1;
                 }
-                1 => {
-                    let all = data::DataType::all();
-                    if app.signal_gen_dtype_idx == 0 {
-                        app.signal_gen_dtype_idx = all.len() - 1;
-                    } else {
-                        app.signal_gen_dtype_idx -= 1;
-                    }
-                }
-                _ => {}
             }
-        }
-        KeyCode::Right => {
-            match app.signal_gen_focus {
-                0 => {
-                    app.signal_gen_wave_idx = (app.signal_gen_wave_idx + 1) % app::WAVE_TYPES.len();
+            1 => {
+                let all = data::DataType::all();
+                if app.signal_gen_dtype_idx == 0 {
+                    app.signal_gen_dtype_idx = all.len() - 1;
+                } else {
+                    app.signal_gen_dtype_idx -= 1;
                 }
-                1 => {
-                    let all = data::DataType::all();
-                    app.signal_gen_dtype_idx = (app.signal_gen_dtype_idx + 1) % all.len();
-                }
-                _ => {}
             }
-        }
+            _ => {}
+        },
+        KeyCode::Right => match app.signal_gen_focus {
+            0 => {
+                app.signal_gen_wave_idx = (app.signal_gen_wave_idx + 1) % app::WAVE_TYPES.len();
+            }
+            1 => {
+                let all = data::DataType::all();
+                app.signal_gen_dtype_idx = (app.signal_gen_dtype_idx + 1) % all.len();
+            }
+            _ => {}
+        },
         KeyCode::Enter => {
             let freq: f64 = match app.signal_gen_fields[0].1.trim().parse::<f64>() {
                 Ok(v) if v > 0.0 && v.is_finite() => v,
@@ -1255,7 +1332,11 @@ mod tests {
     fn zero_freq_rejected() {
         let mut app = make_app_with_fields("0", "1.0", "0.0", "100", "10.0");
         submit(&mut app);
-        assert!(app.status_message.contains("cycles/entry"), "{}", app.status_message);
+        assert!(
+            app.status_message.contains("cycles/entry"),
+            "{}",
+            app.status_message
+        );
         assert_eq!(app.input_mode, InputMode::SignalGen);
     }
 
@@ -1263,28 +1344,44 @@ mod tests {
     fn negative_freq_rejected() {
         let mut app = make_app_with_fields("-1.0", "1.0", "0.0", "100", "10.0");
         submit(&mut app);
-        assert!(app.status_message.contains("cycles/entry"), "{}", app.status_message);
+        assert!(
+            app.status_message.contains("cycles/entry"),
+            "{}",
+            app.status_message
+        );
     }
 
     #[test]
     fn infinite_freq_rejected() {
         let mut app = make_app_with_fields("inf", "1.0", "0.0", "100", "10.0");
         submit(&mut app);
-        assert!(app.status_message.contains("cycles/entry"), "{}", app.status_message);
+        assert!(
+            app.status_message.contains("cycles/entry"),
+            "{}",
+            app.status_message
+        );
     }
 
     #[test]
     fn negative_infinite_freq_rejected() {
         let mut app = make_app_with_fields("-inf", "1.0", "0.0", "100", "10.0");
         submit(&mut app);
-        assert!(app.status_message.contains("cycles/entry"), "{}", app.status_message);
+        assert!(
+            app.status_message.contains("cycles/entry"),
+            "{}",
+            app.status_message
+        );
     }
 
     #[test]
     fn nan_freq_rejected() {
         let mut app = make_app_with_fields("NaN", "1.0", "0.0", "100", "10.0");
         submit(&mut app);
-        assert!(app.status_message.contains("cycles/entry"), "{}", app.status_message);
+        assert!(
+            app.status_message.contains("cycles/entry"),
+            "{}",
+            app.status_message
+        );
     }
 
     // --- amplitude ---
@@ -1293,7 +1390,11 @@ mod tests {
     fn nan_amp_rejected() {
         let mut app = make_app_with_fields("2.0", "NaN", "0.0", "100", "10.0");
         submit(&mut app);
-        assert!(app.status_message.contains("amplitude"), "{}", app.status_message);
+        assert!(
+            app.status_message.contains("amplitude"),
+            "{}",
+            app.status_message
+        );
         assert_eq!(app.input_mode, InputMode::SignalGen);
     }
 
@@ -1301,14 +1402,22 @@ mod tests {
     fn infinite_amp_rejected() {
         let mut app = make_app_with_fields("2.0", "inf", "0.0", "100", "10.0");
         submit(&mut app);
-        assert!(app.status_message.contains("amplitude"), "{}", app.status_message);
+        assert!(
+            app.status_message.contains("amplitude"),
+            "{}",
+            app.status_message
+        );
     }
 
     #[test]
     fn negative_infinite_amp_rejected() {
         let mut app = make_app_with_fields("2.0", "-inf", "0.0", "100", "10.0");
         submit(&mut app);
-        assert!(app.status_message.contains("amplitude"), "{}", app.status_message);
+        assert!(
+            app.status_message.contains("amplitude"),
+            "{}",
+            app.status_message
+        );
     }
 
     #[test]
@@ -1331,7 +1440,11 @@ mod tests {
     fn negative_noise_rejected() {
         let mut app = make_app_with_fields("2.0", "1.0", "-0.1", "100", "10.0");
         submit(&mut app);
-        assert!(app.status_message.contains("noise"), "{}", app.status_message);
+        assert!(
+            app.status_message.contains("noise"),
+            "{}",
+            app.status_message
+        );
         assert_eq!(app.input_mode, InputMode::SignalGen);
     }
 
@@ -1339,21 +1452,33 @@ mod tests {
     fn infinite_noise_rejected() {
         let mut app = make_app_with_fields("2.0", "1.0", "inf", "100", "10.0");
         submit(&mut app);
-        assert!(app.status_message.contains("noise"), "{}", app.status_message);
+        assert!(
+            app.status_message.contains("noise"),
+            "{}",
+            app.status_message
+        );
     }
 
     #[test]
     fn negative_infinite_noise_rejected() {
         let mut app = make_app_with_fields("2.0", "1.0", "-inf", "100", "10.0");
         submit(&mut app);
-        assert!(app.status_message.contains("noise"), "{}", app.status_message);
+        assert!(
+            app.status_message.contains("noise"),
+            "{}",
+            app.status_message
+        );
     }
 
     #[test]
     fn nan_noise_rejected() {
         let mut app = make_app_with_fields("2.0", "1.0", "NaN", "100", "10.0");
         submit(&mut app);
-        assert!(app.status_message.contains("noise"), "{}", app.status_message);
+        assert!(
+            app.status_message.contains("noise"),
+            "{}",
+            app.status_message
+        );
     }
 
     #[test]
@@ -1369,7 +1494,11 @@ mod tests {
     fn zero_samples_rejected() {
         let mut app = make_app_with_fields("2.0", "1.0", "0.0", "0", "10.0");
         submit(&mut app);
-        assert!(app.status_message.contains("samples/entry"), "{}", app.status_message);
+        assert!(
+            app.status_message.contains("samples/entry"),
+            "{}",
+            app.status_message
+        );
         assert_eq!(app.input_mode, InputMode::SignalGen);
     }
 
@@ -1377,7 +1506,11 @@ mod tests {
     fn oversized_samples_rejected() {
         let mut app = make_app_with_fields("2.0", "1.0", "0.0", "1000001", "10.0");
         submit(&mut app);
-        assert!(app.status_message.contains("samples/entry"), "{}", app.status_message);
+        assert!(
+            app.status_message.contains("samples/entry"),
+            "{}",
+            app.status_message
+        );
     }
 
     #[test]
@@ -1393,7 +1526,11 @@ mod tests {
     fn zero_rate_rejected() {
         let mut app = make_app_with_fields("2.0", "1.0", "0.0", "100", "0");
         submit(&mut app);
-        assert!(app.status_message.contains("entries/sec"), "{}", app.status_message);
+        assert!(
+            app.status_message.contains("entries/sec"),
+            "{}",
+            app.status_message
+        );
         assert_eq!(app.input_mode, InputMode::SignalGen);
     }
 
@@ -1401,27 +1538,43 @@ mod tests {
     fn negative_rate_rejected() {
         let mut app = make_app_with_fields("2.0", "1.0", "0.0", "100", "-1.0");
         submit(&mut app);
-        assert!(app.status_message.contains("entries/sec"), "{}", app.status_message);
+        assert!(
+            app.status_message.contains("entries/sec"),
+            "{}",
+            app.status_message
+        );
     }
 
     #[test]
     fn infinite_rate_rejected() {
         let mut app = make_app_with_fields("2.0", "1.0", "0.0", "100", "inf");
         submit(&mut app);
-        assert!(app.status_message.contains("entries/sec"), "{}", app.status_message);
+        assert!(
+            app.status_message.contains("entries/sec"),
+            "{}",
+            app.status_message
+        );
     }
 
     #[test]
     fn negative_infinite_rate_rejected() {
         let mut app = make_app_with_fields("2.0", "1.0", "0.0", "100", "-inf");
         submit(&mut app);
-        assert!(app.status_message.contains("entries/sec"), "{}", app.status_message);
+        assert!(
+            app.status_message.contains("entries/sec"),
+            "{}",
+            app.status_message
+        );
     }
 
     #[test]
     fn nan_rate_rejected() {
         let mut app = make_app_with_fields("2.0", "1.0", "0.0", "100", "NaN");
         submit(&mut app);
-        assert!(app.status_message.contains("entries/sec"), "{}", app.status_message);
+        assert!(
+            app.status_message.contains("entries/sec"),
+            "{}",
+            app.status_message
+        );
     }
 }

--- a/src/redis_client.rs
+++ b/src/redis_client.rs
@@ -205,10 +205,8 @@ impl RedisClient {
                 Ok(RedisValue::ZSet(vals))
             }
             "hash" => {
-                let map: HashMap<String, Vec<u8>> = self
-                    .connection
-                    .hgetall(key)
-                    .context("Failed to HGETALL")?;
+                let map: HashMap<String, Vec<u8>> =
+                    self.connection.hgetall(key).context("Failed to HGETALL")?;
                 let mut pairs: Vec<(String, Vec<u8>)> = map.into_iter().collect();
                 pairs.sort_by(|a, b| a.0.cmp(&b.0));
                 Ok(RedisValue::Hash(pairs))
@@ -237,9 +235,7 @@ impl RedisClient {
             if let redis::Value::Array(parts) = entry_val {
                 if parts.len() >= 2 {
                     let id = match &parts[0] {
-                        redis::Value::BulkString(b) => {
-                            String::from_utf8_lossy(b).to_string()
-                        }
+                        redis::Value::BulkString(b) => String::from_utf8_lossy(b).to_string(),
                         _ => continue,
                     };
 
@@ -276,7 +272,12 @@ impl RedisClient {
     /// Blocking XREAD for new entries after `last_id`.
     /// Blocks up to `timeout_ms` milliseconds (0 = forever).
     /// Returns new entries (empty vec if timeout).
-    pub fn xread_blocking(&mut self, key: &str, last_id: &str, timeout_ms: u64) -> Result<Vec<StreamEntry>> {
+    pub fn xread_blocking(
+        &mut self,
+        key: &str,
+        last_id: &str,
+        timeout_ms: u64,
+    ) -> Result<Vec<StreamEntry>> {
         let raw: redis::Value = redis::cmd("XREAD")
             .arg("BLOCK")
             .arg(timeout_ms)
@@ -318,7 +319,10 @@ impl RedisClient {
                                                 redis::Value::BulkString(b) => {
                                                     String::from_utf8_lossy(b).to_string()
                                                 }
-                                                _ => { i += 2; continue; }
+                                                _ => {
+                                                    i += 2;
+                                                    continue;
+                                                }
                                             };
                                             let fval = match &fv[i + 1] {
                                                 redis::Value::BulkString(b) => b.clone(),
@@ -340,9 +344,7 @@ impl RedisClient {
     }
 
     pub fn delete_key(&mut self, key: &str) -> Result<()> {
-        let _: () = self.connection
-            .del(key)
-            .context("Failed to DEL key")?;
+        let _: () = self.connection.del(key).context("Failed to DEL key")?;
         Ok(())
     }
 
@@ -374,7 +376,10 @@ impl RedisClient {
     }
 
     pub fn set_bytes(&mut self, key: &str, value: &[u8]) -> Result<()> {
-        let _: () = self.connection.set(key, value).context("Failed to SET bytes")?;
+        let _: () = self
+            .connection
+            .set(key, value)
+            .context("Failed to SET bytes")?;
         Ok(())
     }
 
@@ -666,7 +671,8 @@ impl MultiRedisClient {
         // Record collisions
         for (key, hosts) in &seen {
             if hosts.len() > 1 {
-                let host_names: Vec<String> = hosts.iter().map(|&i| self.labels[i].clone()).collect();
+                let host_names: Vec<String> =
+                    hosts.iter().map(|&i| self.labels[i].clone()).collect();
                 self.collisions.push((key.clone(), host_names));
             }
         }
@@ -723,7 +729,10 @@ impl MultiRedisClient {
     }
 
     pub fn num_connected(&mut self) -> usize {
-        self.clients.iter_mut().filter(|c| c.connection.is_open()).count()
+        self.clients
+            .iter_mut()
+            .filter(|c| c.connection.is_open())
+            .count()
     }
 
     // ─── Write operations (route to key owner) ────────────────
@@ -1091,7 +1100,10 @@ mod tests {
             .arg("keeper")
             .query(&mut client.connection)
             .unwrap();
-        assert!(exists, "the key must still exist - no command should have been sent");
+        assert!(
+            exists,
+            "the key must still exist - no command should have been sent"
+        );
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,4 +1,7 @@
-use crate::app::{App, EditOperation, InputMode, Panel, PlotFocus, RateTracker, RATE_WINDOWS, KEY_TYPES, WAVE_TYPES};
+use crate::app::{
+    App, EditOperation, InputMode, Panel, PlotFocus, RateTracker, KEY_TYPES, RATE_WINDOWS,
+    WAVE_TYPES,
+};
 use crate::data::DataType;
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
@@ -23,7 +26,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(1), // title bar
-            Constraint::Min(5),   // body
+            Constraint::Min(5),    // body
             Constraint::Length(1), // status bar
         ])
         .split(size);
@@ -52,14 +55,17 @@ fn draw_title_bar(frame: &mut Frame, app: &App, area: Rect) {
     // Split title bar into left (title/url/help) and right (version) so they never overlap
     let h_split = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Min(0),
-            Constraint::Length(version_width),
-        ])
+        .constraints([Constraint::Min(0), Constraint::Length(version_width)])
         .split(area);
 
     let title = Line::from(vec![
-        Span::styled(" Redis TUI ", Style::default().fg(Color::White).bg(Color::Blue).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            " Redis TUI ",
+            Style::default()
+                .fg(Color::White)
+                .bg(Color::Blue)
+                .add_modifier(Modifier::BOLD),
+        ),
         Span::raw(" "),
         Span::styled(url_text, Style::default().fg(Color::DarkGray)),
         Span::raw("  "),
@@ -67,7 +73,10 @@ fn draw_title_bar(frame: &mut Frame, app: &App, area: Rect) {
     ]);
     frame.render_widget(Paragraph::new(title), h_split[0]);
     frame.render_widget(
-        Paragraph::new(Line::from(Span::styled(version, Style::default().fg(Color::DarkGray)))),
+        Paragraph::new(Line::from(Span::styled(
+            version,
+            Style::default().fg(Color::DarkGray),
+        ))),
         h_split[1],
     );
 }
@@ -77,19 +86,13 @@ fn draw_body(frame: &mut Frame, app: &mut App, area: Rect) {
         // Vertical split: top row (keys + value) | bottom (full-width plot)
         let v_split = Layout::default()
             .direction(Direction::Vertical)
-            .constraints([
-                Constraint::Percentage(50),
-                Constraint::Percentage(50),
-            ])
+            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
             .split(area);
 
         // Top row: key list | value/rate view side by side
         let h_split = Layout::default()
             .direction(Direction::Horizontal)
-            .constraints([
-                Constraint::Percentage(25),
-                Constraint::Percentage(75),
-            ])
+            .constraints([Constraint::Percentage(25), Constraint::Percentage(75)])
             .split(v_split[0]);
 
         draw_key_list(frame, app, h_split[0]);
@@ -105,10 +108,7 @@ fn draw_body(frame: &mut Frame, app: &mut App, area: Rect) {
         // No plot: full height for keys + value
         let h_split = Layout::default()
             .direction(Direction::Horizontal)
-            .constraints([
-                Constraint::Percentage(25),
-                Constraint::Percentage(75),
-            ])
+            .constraints([Constraint::Percentage(25), Constraint::Percentage(75)])
             .split(area);
 
         draw_key_list(frame, app, h_split[0]);
@@ -128,16 +128,10 @@ fn draw_key_list(frame: &mut Frame, app: &mut App, area: Rect) {
         BORDER_INACTIVE
     };
 
-    let title = format!(
-        " Keys ({}) [/]Filter [r]Refresh ",
-        app.keys.len()
-    );
+    let title = format!(" Keys ({}) [/]Filter [r]Refresh ", app.keys.len());
 
-    let collision_keys: std::collections::HashSet<&str> = app
-        .collisions
-        .iter()
-        .map(|(k, _)| k.as_str())
-        .collect();
+    let collision_keys: std::collections::HashSet<&str> =
+        app.collisions.iter().map(|(k, _)| k.as_str()).collect();
 
     let items: Vec<ListItem> = app
         .keys
@@ -154,12 +148,10 @@ fn draw_key_list(frame: &mut Frame, app: &mut App, area: Rect) {
             let plot_color = app.plot_color_for_key(key);
             let is_listening = app.listening_keys.iter().any(|k| k == key);
             let is_siggen = app.siggen_keys.iter().any(|k| k == key);
-            let mut spans = vec![
-                Span::styled(
-                    format!("{:<6}", type_badge.0),
-                    Style::default().fg(type_badge.1),
-                ),
-            ];
+            let mut spans = vec![Span::styled(
+                format!("{:<6}", type_badge.0),
+                Style::default().fg(type_badge.1),
+            )];
             // Indicators: P=plotting, L=listening, W=signal gen
             if let Some(color) = plot_color {
                 spans.push(Span::styled("P", Style::default().fg(color)));
@@ -218,7 +210,12 @@ fn draw_value_view(frame: &mut Frame, app: &mut App, area: Rect) {
     if let Some(info) = &app.current_key_info {
         lines.push(Line::from(vec![
             Span::styled("Key: ", Style::default().fg(Color::Yellow)),
-            Span::styled(&info.name, Style::default().fg(Color::White).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                &info.name,
+                Style::default()
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD),
+            ),
         ]));
         lines.push(Line::from(vec![
             Span::styled("Type: ", Style::default().fg(Color::Yellow)),
@@ -250,7 +247,11 @@ fn draw_value_view(frame: &mut Frame, app: &mut App, area: Rect) {
 
     // Ingestion rate summary — shown for stream keys being actively listened to
     if let Some(key) = app.selected_key_name() {
-        let is_stream = app.current_key_info.as_ref().map(|i| i.key_type == "stream").unwrap_or(false);
+        let is_stream = app
+            .current_key_info
+            .as_ref()
+            .map(|i| i.key_type == "stream")
+            .unwrap_or(false);
         if is_stream && app.listening_keys.iter().any(|k| k == key) {
             if let Some(tracker) = app.rate_trackers.get(key) {
                 let now_ms = std::time::SystemTime::now()
@@ -267,12 +268,19 @@ fn draw_value_view(frame: &mut Frame, app: &mut App, area: Rect) {
                 let mut spans = vec![Span::styled("Rate: ", label_style)];
                 for (i, (_, window_label)) in RATE_WINDOWS.iter().enumerate() {
                     spans.push(Span::styled(format!("{}:", window_label), dim));
-                    spans.push(Span::styled(format!("{:>1$.1}  ", tracker.rate_display_vals[i], rate_w), val_style));
+                    spans.push(Span::styled(
+                        format!("{:>1$.1}  ", tracker.rate_display_vals[i], rate_w),
+                        val_style,
+                    ));
                 }
                 spans.push(Span::styled("/s", dim));
                 if gap_count > 0 {
                     spans.push(Span::styled(
-                        format!("  ⚠ {} gap{}", gap_count, if gap_count == 1 { "" } else { "s" }),
+                        format!(
+                            "  ⚠ {} gap{}",
+                            gap_count,
+                            if gap_count == 1 { "" } else { "s" }
+                        ),
                         Style::default().fg(Color::Red),
                     ));
                 }
@@ -285,11 +293,16 @@ fn draw_value_view(frame: &mut Frame, app: &mut App, area: Rect) {
                         let [min, q1, med, q3, max] = tracker.stat_display_vals;
                         lines.push(Line::from(vec![
                             Span::styled("Stats: ", label_style),
-                            Span::styled("Min:", dim), Span::styled(format!("{:>1$.1}  ", min, stat_w), val_style),
-                            Span::styled("Q1:", dim),  Span::styled(format!("{:>1$.1}  ", q1,  stat_w), val_style),
-                            Span::styled("Med:", dim), Span::styled(format!("{:>1$.1}  ", med, stat_w), val_style),
-                            Span::styled("Q3:", dim),  Span::styled(format!("{:>1$.1}  ", q3,  stat_w), val_style),
-                            Span::styled("Max:", dim), Span::styled(format!("{:>1$.1}", max, stat_w), val_style),
+                            Span::styled("Min:", dim),
+                            Span::styled(format!("{:>1$.1}  ", min, stat_w), val_style),
+                            Span::styled("Q1:", dim),
+                            Span::styled(format!("{:>1$.1}  ", q1, stat_w), val_style),
+                            Span::styled("Med:", dim),
+                            Span::styled(format!("{:>1$.1}  ", med, stat_w), val_style),
+                            Span::styled("Q3:", dim),
+                            Span::styled(format!("{:>1$.1}  ", q3, stat_w), val_style),
+                            Span::styled("Max:", dim),
+                            Span::styled(format!("{:>1$.1}", max, stat_w), val_style),
                             Span::styled("  /s", dim),
                         ]));
                     }
@@ -325,7 +338,11 @@ fn draw_value_view(frame: &mut Frame, app: &mut App, area: Rect) {
         " Value [t]{} [e]{} {}",
         app.data_type,
         app.endianness,
-        if app.active_panel == Panel::ValueView { "[Up/Down]Scroll" } else { "" }
+        if app.active_panel == Panel::ValueView {
+            "[Up/Down]Scroll"
+        } else {
+            ""
+        }
     );
 
     let paragraph = Paragraph::new(lines)
@@ -350,7 +367,8 @@ fn draw_rate_view(frame: &mut Frame, app: &App, area: Rect) {
 
     let key_name = app.selected_key_name().map(|s| s.to_string());
 
-    let has_data = key_name.as_ref()
+    let has_data = key_name
+        .as_ref()
         .and_then(|k| app.rate_trackers.get(k))
         .map(|t| !t.rate_history.is_empty())
         .unwrap_or(false);
@@ -389,7 +407,11 @@ fn draw_rate_view(frame: &mut Frame, app: &App, area: Rect) {
     let total = tracker.total_entries;
 
     let gap_label = if gap_count > 0 {
-        format!("  | {} gap{}", gap_count, if gap_count == 1 { "" } else { "s" })
+        format!(
+            "  | {} gap{}",
+            gap_count,
+            if gap_count == 1 { "" } else { "s" }
+        )
     } else {
         String::new()
     };
@@ -422,7 +444,10 @@ fn draw_rate_view(frame: &mut Frame, app: &App, area: Rect) {
     let mut avg_spans = vec![Span::styled("Avg: ", dim)];
     for (i, (_, label)) in RATE_WINDOWS.iter().enumerate() {
         avg_spans.push(Span::styled(format!("{}:", label), dim));
-        avg_spans.push(Span::styled(format!("{:>1$.1}  ", tracker.rate_display_vals[i], rate_w), val_style));
+        avg_spans.push(Span::styled(
+            format!("{:>1$.1}  ", tracker.rate_display_vals[i], rate_w),
+            val_style,
+        ));
     }
     avg_spans.push(Span::styled("/s", dim));
 
@@ -434,11 +459,16 @@ fn draw_rate_view(frame: &mut Frame, app: &App, area: Rect) {
             Line::from(avg_spans),
             Line::from(vec![
                 Span::styled("Stats: ", dim),
-                Span::styled("Min:", dim), Span::styled(format!("{:>1$.1}  ", min, stat_w), val_style),
-                Span::styled("Q1:", dim),  Span::styled(format!("{:>1$.1}  ", q1,  stat_w), val_style),
-                Span::styled("Med:", dim), Span::styled(format!("{:>1$.1}  ", med, stat_w), val_style),
-                Span::styled("Q3:", dim),  Span::styled(format!("{:>1$.1}  ", q3,  stat_w), val_style),
-                Span::styled("Max:", dim), Span::styled(format!("{:>1$.1}", max, stat_w), val_style),
+                Span::styled("Min:", dim),
+                Span::styled(format!("{:>1$.1}  ", min, stat_w), val_style),
+                Span::styled("Q1:", dim),
+                Span::styled(format!("{:>1$.1}  ", q1, stat_w), val_style),
+                Span::styled("Med:", dim),
+                Span::styled(format!("{:>1$.1}  ", med, stat_w), val_style),
+                Span::styled("Q3:", dim),
+                Span::styled(format!("{:>1$.1}  ", q3, stat_w), val_style),
+                Span::styled("Max:", dim),
+                Span::styled(format!("{:>1$.1}", max, stat_w), val_style),
                 Span::styled("  /s", dim),
             ]),
         ]
@@ -472,19 +502,21 @@ fn draw_rate_view(frame: &mut Frame, app: &App, area: Rect) {
         .filter_map(|&gap_ms| {
             let secs_ago = (now_ms.saturating_sub(gap_ms)) as f64 / 1000.0;
             let x = history_window_secs - secs_ago;
-            if x >= 0.0 { Some(x) } else { None }
+            if x >= 0.0 {
+                Some(x)
+            } else {
+                None
+            }
         })
         .flat_map(|x| (0u32..=10).map(move |i| (x, y_max * i as f64 / 10.0)))
         .collect();
 
-    let mut datasets = vec![
-        Dataset::default()
-            .name(format!("entries/s ({}s avg)", chart_window))
-            .marker(safe_marker(chart_area))
-            .graph_type(GraphType::Line)
-            .style(Style::default().fg(Color::Cyan))
-            .data(&rate_points),
-    ];
+    let mut datasets = vec![Dataset::default()
+        .name(format!("entries/s ({}s avg)", chart_window))
+        .marker(safe_marker(chart_area))
+        .graph_type(GraphType::Line)
+        .style(Style::default().fg(Color::Cyan))
+        .data(&rate_points)];
     if !gap_points.is_empty() {
         datasets.push(
             Dataset::default()
@@ -504,7 +536,11 @@ fn draw_rate_view(frame: &mut Frame, app: &App, area: Rect) {
             } else if secs_ago >= 60.0 {
                 let m = (secs_ago / 60.0) as u64;
                 let s = secs_ago as u64 % 60;
-                if s == 0 { format!("-{}m", m) } else { format!("-{}m{:02}s", m, s) }
+                if s == 0 {
+                    format!("-{}m", m)
+                } else {
+                    format!("-{}m{:02}s", m, s)
+                }
             } else {
                 format!("-{}s", secs_ago as u64)
             };
@@ -519,7 +555,9 @@ fn draw_rate_view(frame: &mut Frame, app: &App, area: Rect) {
         })
         .collect();
 
-    let x_axis = Axis::default().bounds([0.0, history_window_secs]).labels(x_labels);
+    let x_axis = Axis::default()
+        .bounds([0.0, history_window_secs])
+        .labels(x_labels);
     let y_axis = Axis::default().bounds([0.0, y_max]).labels(y_labels);
 
     let chart = Chart::new(datasets).x_axis(x_axis).y_axis(y_axis);
@@ -534,17 +572,37 @@ fn draw_data_plot(frame: &mut Frame, app: &mut App, area: Rect) {
     };
 
     let focused_limits = match app.plot_focus {
-        PlotFocus::Signal => if app.plot_auto_limits { "auto" } else { "manual" },
-        PlotFocus::FFT => if app.fft_auto_limits { "auto" } else { "manual" },
+        PlotFocus::Signal => {
+            if app.plot_auto_limits {
+                "auto"
+            } else {
+                "manual"
+            }
+        }
+        PlotFocus::FFT => {
+            if app.fft_auto_limits {
+                "auto"
+            } else {
+                "manual"
+            }
+        }
     };
     let fft_label = if app.fft_enabled { "ON" } else { "OFF" };
-    let log_label = if app.fft_enabled && app.fft_log_scale { " [g]log" } else if app.fft_enabled { " [g]linear" } else { "" };
+    let log_label = if app.fft_enabled && app.fft_log_scale {
+        " [g]log"
+    } else if app.fft_enabled {
+        " [g]linear"
+    } else {
+        ""
+    };
     let focus_label = if app.fft_enabled {
         match app.plot_focus {
             PlotFocus::Signal => " [Signal]",
             PlotFocus::FFT => " [FFT]",
         }
-    } else { "" };
+    } else {
+        ""
+    };
     let title = format!(
         " Plot [a]{} [f]FFT:{}{}{}",
         focused_limits, fft_label, log_label, focus_label
@@ -611,7 +669,13 @@ fn safe_marker(area: Rect) -> symbols::Marker {
     }
 }
 
-fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, border_color: Color) {
+fn draw_signal_chart(
+    frame: &mut Frame,
+    app: &mut App,
+    area: Rect,
+    title: &str,
+    border_color: Color,
+) {
     if area.width < 12 || area.height < 5 {
         return;
     }
@@ -636,15 +700,25 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
         .plot_slots
         .iter()
         .map(|slot| {
-            let auto_min = slot.data.iter().copied()
+            let auto_min = slot
+                .data
+                .iter()
+                .copied()
                 .filter(|v| v.is_finite())
                 .fold(f64::INFINITY, f64::min);
-            let auto_max = slot.data.iter().copied()
+            let auto_max = slot
+                .data
+                .iter()
+                .copied()
                 .filter(|v| v.is_finite())
                 .fold(f64::NEG_INFINITY, f64::max);
             // Use per-slot limits if set, otherwise auto
-            let y_min = slot.y_min.unwrap_or(if auto_min.is_finite() { auto_min } else { 0.0 });
-            let y_max = slot.y_max.unwrap_or(if auto_max.is_finite() { auto_max } else { 1.0 });
+            let y_min = slot
+                .y_min
+                .unwrap_or(if auto_min.is_finite() { auto_min } else { 0.0 });
+            let y_max = slot
+                .y_max
+                .unwrap_or(if auto_max.is_finite() { auto_max } else { 1.0 });
             let points = if normalize {
                 let range = y_max - y_min;
                 let safe_range = if range == 0.0 { 1.0 } else { range };
@@ -657,14 +731,24 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
                     })
                     .collect()
             } else {
-                slot.data.iter().enumerate().map(|(i, v)| (i as f64, *v)).collect()
+                slot.data
+                    .iter()
+                    .enumerate()
+                    .map(|(i, v)| (i as f64, *v))
+                    .collect()
             };
-            SlotRender { points, y_min, y_max }
+            SlotRender {
+                points,
+                y_min,
+                y_max,
+            }
         })
         .collect();
 
     let (x_lo, x_hi) = if !app.plot_slots.is_empty() {
-        let max_len = app.plot_slots.iter()
+        let max_len = app
+            .plot_slots
+            .iter()
             .map(|s| s.data.len())
             .max()
             .unwrap_or(0)
@@ -690,8 +774,12 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
             (y_min, y_max)
         } else {
             // Auto: use actual data bounds
-            let all_data: Vec<f64> = slot.data.iter().copied()
-                .filter(|v| v.is_finite()).collect();
+            let all_data: Vec<f64> = slot
+                .data
+                .iter()
+                .copied()
+                .filter(|v| v.is_finite())
+                .collect();
             if all_data.is_empty() {
                 (0.0, 1.0)
             } else {
@@ -753,12 +841,14 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
     let mut datasets = Vec::new();
     if app.plot_slots.is_empty() {
         // Fallback: single dataset from primary plot_data
-        datasets.push(Dataset::default()
-            .name(format!("{} values", app.plot_data.len()))
-            .marker(marker)
-            .graph_type(GraphType::Line)
-            .style(Style::default().fg(Color::Cyan))
-            .data(&primary_points));
+        datasets.push(
+            Dataset::default()
+                .name(format!("{} values", app.plot_data.len()))
+                .marker(marker)
+                .graph_type(GraphType::Line)
+                .style(Style::default().fg(Color::Cyan))
+                .data(&primary_points),
+        );
     } else {
         for (i, slot) in app.plot_slots.iter().enumerate() {
             if !slot.data.is_empty() {
@@ -769,13 +859,18 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
                 } else {
                     slot.key_name.clone()
                 };
-                let legend_name = format!("{} {} [{:.0}..{:.0}]", short_name, slot.data_type, sr.y_min, sr.y_max);
-                datasets.push(Dataset::default()
-                    .name(legend_name)
-                    .marker(marker)
-                    .graph_type(GraphType::Line)
-                    .style(Style::default().fg(slot.color))
-                    .data(&sr.points));
+                let legend_name = format!(
+                    "{} {} [{:.0}..{:.0}]",
+                    short_name, slot.data_type, sr.y_min, sr.y_max
+                );
+                datasets.push(
+                    Dataset::default()
+                        .name(legend_name)
+                        .marker(marker)
+                        .graph_type(GraphType::Line)
+                        .style(Style::default().fg(slot.color))
+                        .data(&sr.points),
+                );
             }
         }
     }
@@ -799,9 +894,11 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
         )
         .y_axis(if app.plot_slots.len() > 1 {
             // Multi-key: hide default Y-axis labels, we'll draw per-key ones
-            Axis::default()
-                .bounds([y_lo, y_hi])
-                .labels(vec![Line::from(""), Line::from(""), Line::from("")])
+            Axis::default().bounds([y_lo, y_hi]).labels(vec![
+                Line::from(""),
+                Line::from(""),
+                Line::from(""),
+            ])
         } else {
             Axis::default()
                 .title("Value")
@@ -837,13 +934,14 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
         for (i, sr) in slot_renders.iter().enumerate().take(num_slots) {
             let color = app.plot_slots[i].color;
             let col_x = inner.x + (i as u16) * label_width;
-            if col_x + label_width > buf_area.width { break; }
+            if col_x + label_width > buf_area.width {
+                break;
+            }
 
             // Top: Y max
             if chart_y > 0 && chart_y < buf_area.height {
                 frame.render_widget(
-                    Paragraph::new(format!("{:.1}", sr.y_max))
-                        .style(Style::default().fg(color)),
+                    Paragraph::new(format!("{:.1}", sr.y_max)).style(Style::default().fg(color)),
                     Rect::new(col_x, chart_y, label_width, 1),
                 );
             }
@@ -852,8 +950,7 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
             if mid_y < buf_area.height {
                 let mid_val = (sr.y_min + sr.y_max) / 2.0;
                 frame.render_widget(
-                    Paragraph::new(format!("{:.1}", mid_val))
-                        .style(Style::default().fg(color)),
+                    Paragraph::new(format!("{:.1}", mid_val)).style(Style::default().fg(color)),
                     Rect::new(col_x, mid_y, label_width, 1),
                 );
             }
@@ -861,8 +958,7 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
             let bot_y = chart_y + chart_h.saturating_sub(1);
             if bot_y < buf_area.height && bot_y != mid_y {
                 frame.render_widget(
-                    Paragraph::new(format!("{:.1}", sr.y_min))
-                        .style(Style::default().fg(color)),
+                    Paragraph::new(format!("{:.1}", sr.y_min)).style(Style::default().fg(color)),
                     Rect::new(col_x, bot_y, label_width, 1),
                 );
             }
@@ -877,7 +973,12 @@ fn draw_signal_chart(frame: &mut Frame, app: &mut App, area: Rect, title: &str, 
                 Rect::new(chart_x, chart_y, chart_w, chart_h),
                 hx,
                 hy,
-                ChartBounds { x_lo, x_hi, y_lo, y_hi },
+                ChartBounds {
+                    x_lo,
+                    x_hi,
+                    y_lo,
+                    y_hi,
+                },
             );
         }
     }
@@ -897,37 +998,56 @@ fn draw_fft_chart(frame: &mut Frame, app: &mut App, area: Rect, _border_color: C
         .collect();
 
     // Compute FFT per slot
-    let slot_fft_data: Vec<Vec<f64>> = app.plot_slots.iter().map(|slot| {
-        let mut magnitudes = crate::app::compute_fft_magnitude(&slot.data);
-        if app.fft_log_scale {
-            for v in &mut magnitudes {
-                *v = if *v > 0.0 { v.log10() } else { -10.0 };
+    let slot_fft_data: Vec<Vec<f64>> = app
+        .plot_slots
+        .iter()
+        .map(|slot| {
+            let mut magnitudes = crate::app::compute_fft_magnitude(&slot.data);
+            if app.fft_log_scale {
+                for v in &mut magnitudes {
+                    *v = if *v > 0.0 { v.log10() } else { -10.0 };
+                }
             }
-        }
-        magnitudes
-    }).collect();
-    let slot_fft_points: Vec<Vec<(f64, f64)>> = slot_fft_data.iter().map(|data| {
-        data.iter().enumerate().map(|(i, v)| (i as f64, *v)).collect()
-    }).collect();
+            magnitudes
+        })
+        .collect();
+    let slot_fft_points: Vec<Vec<(f64, f64)>> = slot_fft_data
+        .iter()
+        .map(|data| {
+            data.iter()
+                .enumerate()
+                .map(|(i, v)| (i as f64, *v))
+                .collect()
+        })
+        .collect();
 
     // Compute unified bounds across all FFT data
     let (x_lo, x_hi) = if !app.plot_slots.is_empty() {
-        let max_bins = slot_fft_data.iter().map(|d| d.len()).max().unwrap_or(0)
+        let max_bins = slot_fft_data
+            .iter()
+            .map(|d| d.len())
+            .max()
+            .unwrap_or(0)
             .max(display_data.len());
-        if app.fft_x_max > 0.0 { (app.fft_x_min, app.fft_x_max) }
-        else { (0.0, max_bins as f64) }
+        if app.fft_x_max > 0.0 {
+            (app.fft_x_min, app.fft_x_max)
+        } else {
+            (0.0, max_bins as f64)
+        }
     } else {
         app.fft_x_bounds()
     };
 
     let (y_lo, y_hi) = if app.fft_auto_limits {
-        let all_fft: Vec<f64> = slot_fft_data.iter()
+        let all_fft: Vec<f64> = slot_fft_data
+            .iter()
             .flat_map(|d| d.iter().copied())
             .chain(display_data.iter().copied())
             .filter(|v| v.is_finite())
             .collect();
-        if all_fft.is_empty() { (0.0, 1.0) }
-        else {
+        if all_fft.is_empty() {
+            (0.0, 1.0)
+        } else {
             let y_min = all_fft.iter().copied().fold(f64::INFINITY, f64::min);
             let y_max = all_fft.iter().copied().fold(f64::NEG_INFINITY, f64::max);
             let range = y_max - y_min;
@@ -938,43 +1058,61 @@ fn draw_fft_chart(frame: &mut Frame, app: &mut App, area: Rect, _border_color: C
         (app.fft_y_min, app.fft_y_max)
     };
 
-    let chart_border = if app.plot_focus == PlotFocus::FFT { Color::Cyan } else { Color::DarkGray };
+    let chart_border = if app.plot_focus == PlotFocus::FFT {
+        Color::Cyan
+    } else {
+        Color::DarkGray
+    };
 
     let scale_label = if app.fft_log_scale { "log" } else { "linear" };
     let hover_suffix = if app.hover_in_fft {
         if let (Some(hx), Some(hy)) = (app.hover_data_x, app.hover_data_y) {
             format!(" bin:{:.1} mag:{:.2}", hx, hy)
-        } else { String::new() }
-    } else { String::new() };
+        } else {
+            String::new()
+        }
+    } else {
+        String::new()
+    };
     let fft_title = format!(" FFT Magnitude ({}){} ", scale_label, hover_suffix);
 
     let marker = safe_marker(area);
     let mut datasets = Vec::new();
 
     if app.plot_slots.is_empty() {
-        datasets.push(Dataset::default()
-            .name(format!("{} bins", display_data.len()))
-            .marker(marker)
-            .graph_type(GraphType::Line)
-            .style(Style::default().fg(Color::Yellow))
-            .data(&primary_fft_points));
+        datasets.push(
+            Dataset::default()
+                .name(format!("{} bins", display_data.len()))
+                .marker(marker)
+                .graph_type(GraphType::Line)
+                .style(Style::default().fg(Color::Yellow))
+                .data(&primary_fft_points),
+        );
     } else {
         for (i, slot) in app.plot_slots.iter().enumerate() {
             if i < slot_fft_points.len() && !slot_fft_points[i].is_empty() {
                 let short_name = if slot.key_name.len() > 12 {
                     format!("{}...", &slot.key_name[..12])
-                } else { slot.key_name.clone() };
-                datasets.push(Dataset::default()
-                    .name(short_name)
-                    .marker(marker)
-                    .graph_type(GraphType::Line)
-                    .style(Style::default().fg(slot.color))
-                    .data(&slot_fft_points[i]));
+                } else {
+                    slot.key_name.clone()
+                };
+                datasets.push(
+                    Dataset::default()
+                        .name(short_name)
+                        .marker(marker)
+                        .graph_type(GraphType::Line)
+                        .style(Style::default().fg(slot.color))
+                        .data(&slot_fft_points[i]),
+                );
             }
         }
     }
 
-    let y_title = if app.fft_log_scale { "log10(Mag)" } else { "Magnitude" };
+    let y_title = if app.fft_log_scale {
+        "log10(Mag)"
+    } else {
+        "Magnitude"
+    };
 
     let chart = Chart::new(datasets)
         .block(
@@ -1024,7 +1162,12 @@ fn draw_fft_chart(frame: &mut Frame, app: &mut App, area: Rect, _border_color: C
                 Rect::new(chart_x, chart_y, chart_w, chart_h),
                 hx,
                 hy,
-                ChartBounds { x_lo, x_hi, y_lo, y_hi },
+                ChartBounds {
+                    x_lo,
+                    x_hi,
+                    y_lo,
+                    y_hi,
+                },
             );
         }
     }
@@ -1043,7 +1186,11 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
         let conn_text = format!("{}/{} hosts", app.hosts_connected, app.host_count);
         spans.push(Span::styled(conn_text, Style::default().fg(status_color)));
     } else {
-        let status_text = if app.connected { "Connected" } else { "Disconnected" };
+        let status_text = if app.connected {
+            "Connected"
+        } else {
+            "Disconnected"
+        };
         spans.push(Span::styled(status_text, Style::default().fg(status_color)));
     }
 
@@ -1069,7 +1216,10 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
     }
 
     spans.push(Span::raw("| "));
-    spans.push(Span::styled(&app.status_message, Style::default().fg(Color::DarkGray)));
+    spans.push(Span::styled(
+        &app.status_message,
+        Style::default().fg(Color::DarkGray),
+    ));
 
     let line = Line::from(spans);
     let bar = Paragraph::new(line).style(Style::default().bg(Color::Black));
@@ -1115,13 +1265,25 @@ fn draw_help_popup(frame: &mut Frame, app: &App, area: Rect) {
     frame.render_widget(Clear, popup_area);
 
     let dim = Style::default().fg(Color::DarkGray);
-    let key_style = Style::default().fg(Color::Green).add_modifier(Modifier::BOLD);
+    let key_style = Style::default()
+        .fg(Color::Green)
+        .add_modifier(Modifier::BOLD);
 
     let help_text = vec![
-        Line::from(Span::styled("Redis TUI — Controls Reference", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD))),
+        Line::from(Span::styled(
+            "Redis TUI — Controls Reference",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )),
         Line::from(""),
         // --- Navigation ---
-        Line::from(vec![Span::styled("Navigation", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))]),
+        Line::from(vec![Span::styled(
+            "Navigation",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )]),
         Line::from(vec![
             Span::styled("  Up/Down  ", key_style),
             Span::raw("Navigate keys, scroll value view, or select"),
@@ -1145,7 +1307,12 @@ fn draw_help_popup(frame: &mut Frame, app: &App, area: Rect) {
         ]),
         Line::from(""),
         // --- Key Operations ---
-        Line::from(vec![Span::styled("Key Operations", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))]),
+        Line::from(vec![Span::styled(
+            "Key Operations",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )]),
         Line::from(vec![
             Span::styled("  /        ", key_style),
             Span::raw("Filter keys by glob pattern (e.g. sensor:*)"),
@@ -1176,7 +1343,12 @@ fn draw_help_popup(frame: &mut Frame, app: &App, area: Rect) {
         ]),
         Line::from(""),
         // --- Edit Mode ---
-        Line::from(vec![Span::styled("Edit Mode", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))]),
+        Line::from(vec![Span::styled(
+            "Edit Mode",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )]),
         Line::from(vec![
             Span::styled("  Tab      ", key_style),
             Span::raw("Next field"),
@@ -1205,10 +1377,18 @@ fn draw_help_popup(frame: &mut Frame, app: &App, area: Rect) {
             Span::styled("  Ctrl+E   ", key_style),
             Span::raw("Toggle endianness (LE/BE)"),
         ]),
-        Line::from(Span::styled("            Paste supported in all input fields", dim)),
+        Line::from(Span::styled(
+            "            Paste supported in all input fields",
+            dim,
+        )),
         Line::from(""),
         // --- Streams ---
-        Line::from(vec![Span::styled("Streams", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))]),
+        Line::from(vec![Span::styled(
+            "Streams",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )]),
         Line::from(vec![
             Span::styled("  l        ", key_style),
             Span::raw("Toggle live stream listener (up to 4 keys)"),
@@ -1217,15 +1397,26 @@ fn draw_help_popup(frame: &mut Frame, app: &App, area: Rect) {
             Span::styled("  i        ", key_style),
             Span::raw("Toggle ingestion rate view (stream + listening only)"),
         ]),
-        Line::from(Span::styled("            Shows entries/s chart with gap detection", dim)),
+        Line::from(Span::styled(
+            "            Shows entries/s chart with gap detection",
+            dim,
+        )),
         Line::from(vec![
             Span::styled("  w        ", key_style),
             Span::raw("Toggle signal generator (sine/square/saw/tri)"),
         ]),
-        Line::from(Span::styled("            ←/→ to select wave type and data type", dim)),
+        Line::from(Span::styled(
+            "            ←/→ to select wave type and data type",
+            dim,
+        )),
         Line::from(""),
         // --- Data Plot ---
-        Line::from(vec![Span::styled("Data Plot", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))]),
+        Line::from(vec![Span::styled(
+            "Data Plot",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )]),
         Line::from(vec![
             Span::styled("  p        ", key_style),
             Span::raw("Toggle key in plot (up to 4, FIFO eviction)"),
@@ -1256,7 +1447,12 @@ fn draw_help_popup(frame: &mut Frame, app: &App, area: Rect) {
         ]),
         Line::from(""),
         // --- Mouse ---
-        Line::from(vec![Span::styled("Mouse", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))]),
+        Line::from(vec![Span::styled(
+            "Mouse",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )]),
         Line::from(vec![
             Span::styled("  Click    ", key_style),
             Span::raw("Select a key in the key list"),
@@ -1265,7 +1461,10 @@ fn draw_help_popup(frame: &mut Frame, app: &App, area: Rect) {
             Span::styled("  Scroll   ", key_style),
             Span::raw("Key list / value view: scroll content"),
         ]),
-        Line::from(Span::styled("            Data plot: zoom in/out at cursor", dim)),
+        Line::from(Span::styled(
+            "            Data plot: zoom in/out at cursor",
+            dim,
+        )),
         Line::from(vec![
             Span::styled("  Drag     ", key_style),
             Span::raw("Pan the plot (X and Y axes)"),
@@ -1276,7 +1475,12 @@ fn draw_help_popup(frame: &mut Frame, app: &App, area: Rect) {
         ]),
         Line::from(""),
         // --- General ---
-        Line::from(vec![Span::styled("General", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))]),
+        Line::from(vec![Span::styled(
+            "General",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )]),
         Line::from(vec![
             Span::styled("  ?        ", key_style),
             Span::raw("Toggle this help screen"),
@@ -1292,14 +1496,12 @@ fn draw_help_popup(frame: &mut Frame, app: &App, area: Rect) {
     let max_scroll = total_lines.saturating_sub(inner_height);
     let scroll = app.help_scroll.min(max_scroll);
 
-    let popup = Paragraph::new(help_text)
-        .scroll((scroll, 0))
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(Style::default().fg(HIGHLIGHT_COLOR))
-                .title(" Help — Up/Down to scroll, ? or Esc to close "),
-        );
+    let popup = Paragraph::new(help_text).scroll((scroll, 0)).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(HIGHLIGHT_COLOR))
+            .title(" Help — Up/Down to scroll, ? or Esc to close "),
+    );
     frame.render_widget(popup, popup_area);
 }
 
@@ -1376,7 +1578,9 @@ fn draw_signal_gen_popup(frame: &mut Frame, app: &App, area: Rect) {
     let wave_focused = app.signal_gen_focus == 0;
     let wave_indicator = if wave_focused { "> " } else { "  " };
     let wave_label_style = if wave_focused {
-        Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(Color::Yellow)
     };
@@ -1386,7 +1590,9 @@ fn draw_signal_gen_popup(frame: &mut Frame, app: &App, area: Rect) {
         Span::styled("< ", Style::default().fg(Color::DarkGray)),
         Span::styled(
             WAVE_TYPES[app.signal_gen_wave_idx],
-            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(" >", Style::default().fg(Color::DarkGray)),
         if wave_focused {
@@ -1400,7 +1606,9 @@ fn draw_signal_gen_popup(frame: &mut Frame, app: &App, area: Rect) {
     let dtype_focused = app.signal_gen_focus == 1;
     let dtype_indicator = if dtype_focused { "> " } else { "  " };
     let dtype_label_style = if dtype_focused {
-        Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(Color::Yellow)
     };
@@ -1411,7 +1619,9 @@ fn draw_signal_gen_popup(frame: &mut Frame, app: &App, area: Rect) {
         Span::styled("< ", Style::default().fg(Color::DarkGray)),
         Span::styled(
             dtype_name,
-            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(" >", Style::default().fg(Color::DarkGray)),
         if dtype_focused {
@@ -1429,7 +1639,9 @@ fn draw_signal_gen_popup(frame: &mut Frame, app: &App, area: Rect) {
         let is_focused = app.signal_gen_focus == focus_idx;
         let indicator = if is_focused { "> " } else { "  " };
         let label_style = if is_focused {
-            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(Color::Yellow)
         };
@@ -1470,7 +1682,11 @@ fn draw_edit_popup(frame: &mut Frame, app: &App, area: Rect) {
     let is_new_key = app.edit_operation == Some(EditOperation::NewKey);
     let is_multi = app.is_multi_entry_edit();
     let extra_type = if is_new_key { 2 } else { 0 };
-    let extra_count = if is_multi && app.edit_multi_count > 0 { 1 } else { 0 };
+    let extra_count = if is_multi && app.edit_multi_count > 0 {
+        1
+    } else {
+        0
+    };
     let extra_binary = if app.edit_binary_mode { 2 } else { 1 }; // binary mode row + type/endian row
     let height = (5 + field_count * 2 + extra_type + extra_count + extra_binary).min(24) as u16;
     let popup_area = centered_rect(60, height, area);
@@ -1521,10 +1737,17 @@ fn draw_edit_popup(frame: &mut Frame, app: &App, area: Rect) {
 
     // Binary mode toggle
     let bin_label = if app.edit_binary_mode { "ON" } else { "OFF" };
-    let bin_color = if app.edit_binary_mode { Color::Green } else { Color::DarkGray };
+    let bin_color = if app.edit_binary_mode {
+        Color::Green
+    } else {
+        Color::DarkGray
+    };
     lines.push(Line::from(vec![
         Span::styled("Binary: ", Style::default().fg(Color::Yellow)),
-        Span::styled(bin_label, Style::default().fg(bin_color).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            bin_label,
+            Style::default().fg(bin_color).add_modifier(Modifier::BOLD),
+        ),
         Span::styled("  [Ctrl+B]toggle", Style::default().fg(Color::DarkGray)),
     ]));
 
@@ -1534,10 +1757,23 @@ fn draw_edit_popup(frame: &mut Frame, app: &App, area: Rect) {
     if app.edit_binary_mode {
         lines.push(Line::from(vec![
             Span::styled("  Encode: ", Style::default().fg(Color::Yellow)),
-            Span::styled(&dtype_name, Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                &dtype_name,
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::styled(" / ", Style::default().fg(Color::DarkGray)),
-            Span::styled(&endian_name, Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
-            Span::styled("  [Ctrl+T]type [Ctrl+E]endian", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                &endian_name,
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                "  [Ctrl+T]type [Ctrl+E]endian",
+                Style::default().fg(Color::DarkGray),
+            ),
         ]));
     }
 
@@ -1621,7 +1857,12 @@ struct ChartBounds {
 
 fn draw_crosshair(frame: &mut Frame, area: Rect, data_x: f64, data_y: f64, bounds: ChartBounds) {
     let (cx, cy, cw, ch) = (area.x, area.y, area.width, area.height);
-    let ChartBounds { x_lo, x_hi, y_lo, y_hi } = bounds;
+    let ChartBounds {
+        x_lo,
+        x_hi,
+        y_lo,
+        y_hi,
+    } = bounds;
     if cw <= 1 || ch <= 1 || x_hi <= x_lo || y_hi <= y_lo {
         return;
     }
@@ -1770,14 +2011,37 @@ mod tests {
 
         let buffer = terminal.backend().buffer().clone();
         // Collect the first row into a string
-        let row: String = (0..80).map(|x| buffer.cell((x, 0)).unwrap().symbol().chars().next().unwrap_or(' ')).collect();
+        let row: String = (0..80)
+            .map(|x| {
+                buffer
+                    .cell((x, 0))
+                    .unwrap()
+                    .symbol()
+                    .chars()
+                    .next()
+                    .unwrap_or(' ')
+            })
+            .collect();
 
         let version_string = format!("v{}", env!("CARGO_PKG_VERSION"));
-        assert!(row.contains("Redis TUI"), "title bar should contain 'Redis TUI', got: {}", row);
-        assert!(row.contains(&version_string), "title bar should contain '{}' in top-right, got: {}", version_string, row);
+        assert!(
+            row.contains("Redis TUI"),
+            "title bar should contain 'Redis TUI', got: {}",
+            row
+        );
+        assert!(
+            row.contains(&version_string),
+            "title bar should contain '{}' in top-right, got: {}",
+            version_string,
+            row
+        );
         // Version should be right-aligned (near end of row)
         let version_pos = row.find(&version_string).unwrap();
-        assert!(version_pos > 60, "version should be right-aligned, found at position {}", version_pos);
+        assert!(
+            version_pos > 60,
+            "version should be right-aligned, found at position {}",
+            version_pos
+        );
     }
 
     #[test]
@@ -1794,10 +2058,28 @@ mod tests {
             .unwrap();
 
         let buffer = terminal.backend().buffer().clone();
-        let row: String = (0..80).map(|x| buffer.cell((x, 0)).unwrap().symbol().chars().next().unwrap_or(' ')).collect();
+        let row: String = (0..80)
+            .map(|x| {
+                buffer
+                    .cell((x, 0))
+                    .unwrap()
+                    .symbol()
+                    .chars()
+                    .next()
+                    .unwrap_or(' ')
+            })
+            .collect();
 
-        assert!(row.contains("[?]Help"), "title bar should contain '[?]Help', got: {}", row);
-        assert!(row.contains("[q]Quit"), "title bar should contain '[q]Quit', got: {}", row);
+        assert!(
+            row.contains("[?]Help"),
+            "title bar should contain '[?]Help', got: {}",
+            row
+        );
+        assert!(
+            row.contains("[q]Quit"),
+            "title bar should contain '[q]Quit', got: {}",
+            row
+        );
     }
 
     #[test]
@@ -1819,7 +2101,12 @@ mod tests {
                     Rect::new(cx, cy, cw, ch),
                     100.0,
                     50.0,
-                    ChartBounds { x_lo: 0.0, x_hi: 100.0, y_lo: 0.0, y_hi: 100.0 },
+                    ChartBounds {
+                        x_lo: 0.0,
+                        x_hi: 100.0,
+                        y_lo: 0.0,
+                        y_hi: 100.0,
+                    },
                 );
             })
             .unwrap();
@@ -1838,7 +2125,12 @@ mod tests {
                     Rect::new(10, 5, 60, 15),
                     0.0,
                     0.0,
-                    ChartBounds { x_lo: 0.0, x_hi: 100.0, y_lo: 0.0, y_hi: 100.0 },
+                    ChartBounds {
+                        x_lo: 0.0,
+                        x_hi: 100.0,
+                        y_lo: 0.0,
+                        y_hi: 100.0,
+                    },
                 );
             })
             .unwrap();
@@ -1862,28 +2154,48 @@ mod tests {
                     Rect::new(cx, cy, cw, ch),
                     0.0,
                     0.0,
-                    ChartBounds { x_lo: 0.0, x_hi: 100.0, y_lo: 0.0, y_hi: 100.0 },
+                    ChartBounds {
+                        x_lo: 0.0,
+                        x_hi: 100.0,
+                        y_lo: 0.0,
+                        y_hi: 100.0,
+                    },
                 );
                 draw_crosshair(
                     frame,
                     Rect::new(cx, cy, cw, ch),
                     100.0,
                     0.0,
-                    ChartBounds { x_lo: 0.0, x_hi: 100.0, y_lo: 0.0, y_hi: 100.0 },
+                    ChartBounds {
+                        x_lo: 0.0,
+                        x_hi: 100.0,
+                        y_lo: 0.0,
+                        y_hi: 100.0,
+                    },
                 );
                 draw_crosshair(
                     frame,
                     Rect::new(cx, cy, cw, ch),
                     0.0,
                     100.0,
-                    ChartBounds { x_lo: 0.0, x_hi: 100.0, y_lo: 0.0, y_hi: 100.0 },
+                    ChartBounds {
+                        x_lo: 0.0,
+                        x_hi: 100.0,
+                        y_lo: 0.0,
+                        y_hi: 100.0,
+                    },
                 );
                 draw_crosshair(
                     frame,
                     Rect::new(cx, cy, cw, ch),
                     100.0,
                     100.0,
-                    ChartBounds { x_lo: 0.0, x_hi: 100.0, y_lo: 0.0, y_hi: 100.0 },
+                    ChartBounds {
+                        x_lo: 0.0,
+                        x_hi: 100.0,
+                        y_lo: 0.0,
+                        y_hi: 100.0,
+                    },
                 );
             })
             .unwrap();
@@ -1894,11 +2206,7 @@ mod tests {
         // NaN fails every comparison, so `frac < 0.0 || frac > 1.0` does not catch it.
         // Execution then reaches `(NaN * ..) as u16`, which saturates to 0 and pins a
         // bogus crosshair to the chart's top-left corner as if that were the data point.
-        for (dx, dy) in [
-            (f64::NAN, 50.0),
-            (50.0, f64::NAN),
-            (f64::NAN, f64::NAN),
-        ] {
+        for (dx, dy) in [(f64::NAN, 50.0), (50.0, f64::NAN), (f64::NAN, f64::NAN)] {
             let backend = TestBackend::new(80, 24);
             let mut terminal = Terminal::new(backend).unwrap();
             terminal
@@ -1908,7 +2216,12 @@ mod tests {
                         Rect::new(10, 5, 60, 15),
                         dx,
                         dy,
-                        ChartBounds { x_lo: 0.0, x_hi: 100.0, y_lo: 0.0, y_hi: 100.0 },
+                        ChartBounds {
+                            x_lo: 0.0,
+                            x_hi: 100.0,
+                            y_lo: 0.0,
+                            y_hi: 100.0,
+                        },
                     );
                 })
                 .unwrap();
@@ -1942,7 +2255,12 @@ mod tests {
                     Rect::new(0, 0, 2, 2),
                     50.0,
                     50.0,
-                    ChartBounds { x_lo: 0.0, x_hi: 100.0, y_lo: 0.0, y_hi: 100.0 },
+                    ChartBounds {
+                        x_lo: 0.0,
+                        x_hi: 100.0,
+                        y_lo: 0.0,
+                        y_hi: 100.0,
+                    },
                 );
                 // Degenerate areas should be no-ops
                 draw_crosshair(
@@ -1950,14 +2268,24 @@ mod tests {
                     Rect::new(0, 0, 0, 0),
                     50.0,
                     50.0,
-                    ChartBounds { x_lo: 0.0, x_hi: 100.0, y_lo: 0.0, y_hi: 100.0 },
+                    ChartBounds {
+                        x_lo: 0.0,
+                        x_hi: 100.0,
+                        y_lo: 0.0,
+                        y_hi: 100.0,
+                    },
                 );
                 draw_crosshair(
                     frame,
                     Rect::new(0, 0, 1, 1),
                     50.0,
                     50.0,
-                    ChartBounds { x_lo: 0.0, x_hi: 100.0, y_lo: 0.0, y_hi: 100.0 },
+                    ChartBounds {
+                        x_lo: 0.0,
+                        x_hi: 100.0,
+                        y_lo: 0.0,
+                        y_hi: 100.0,
+                    },
                 );
             })
             .unwrap();


### PR DESCRIPTION
Two related pieces of CI cleanup. Together they close out the lint debt from #64 and stop `main` showing red on every push.

| Commit | What |
|---|---|
| `c461fa1` | `cargo fmt` — **nothing else** |
| `e6068d2` | `.git-blame-ignore-revs` listing that SHA |
| `b69370c` | drop fmt's `continue-on-error` |
| `7aa2e8a` | bump to 1.3.3 + lockfile |
| `95bacb5` | fix Docker publish credentials and gate the push |

---

# 1. Formatting, and CI fully enforced

`cargo fmt --check` goes from **198 diffs to 0**, and its `continue-on-error` comes off. **No `continue-on-error` remains anywhere in the workflow** — every step is now a hard gate: build (debug + release), `cargo test`, `cargo test -- --ignored`, clippy `-D warnings`, and `cargo fmt --check`.

### The reformat is verified as formatting-only, not assumed

A 1,254-line mechanical diff is exactly where a semantic change hides, and "tests pass" alone is weak evidence. So I stripped **all whitespace** from every file before and after and compared the resulting token streams. They are identical apart from:

- trailing commas rustfmt adds when breaking an expression across lines, and
- reordering of names inside `use` groups — `{DataType, Endianness, decode_blob}` → `{decode_blob, DataType, Endianness}`, the same import set.

No logic moved. 98 unit tests, 7 live-Redis tests and clippy all still pass.

The reformat commit contains **no hand edits** — pure `cargo fmt` output under the toolchain pinned in `rust-toolchain.toml`. That pin matters: the debt count is toolchain-dependent (188 diffs under rustfmt 1.8, 198 under 1.9), so without #74 this would have been a moving target.

### git blame

The reformat touched all five source files and would otherwise sit on top of every line. `.git-blame-ignore-revs` lists it; GitHub reads it automatically, locally it needs `git config blame.ignoreRevsFile .git-blame-ignore-revs`. Confirmed working — blaming `src/app.rs` afterwards attributes lines to "Add multi-key plotting…" and "Cap stream entries…", not to the reformat.

---

# 2. Why `main` has been red on every push

The "Build and Push Docker Image" workflow has failed on **every push to `main` since it was added** on 2026-03-27 — 03-27, 06-03, 08-03, 08-13, 08-25, and twice on 08-26. Never once succeeded there. Not a code problem; CI itself is green.

**The secret names were wrong.** It read `HARBOR_USERNAME` / `HARBOR_PASSWORD`, which are not configured — `gh secret list` returns zero repository secrets — so the login step's own `if: env.HARBOR_USERNAME != ''` guard **skipped it on every run**. The real credentials are `ADREGISTRY_INST_USERNAME` / `ADREGISTRY_INST_SECRET`.

**And the push was ungated.** Login degraded gracefully when the credential was missing, but the build ran `push: true` regardless — so every run built the whole image and only then failed:

```
#22 ERROR: unauthorized: unauthorized to access repository:
    instrumentation/redis-tui, action: push
```

A missing secret should not present as a registry permissions problem. `push` now uses the same condition as the login, and a skipped push emits a `::warning::` naming the secret:

```yaml
- name: Build and push
  uses: docker/build-push-action@v6
  with:
    push: ${{ env.REGISTRY_USERNAME != '' }}
```

`.secrets.example` is updated to match so local `act` runs line up with CI. `.secrets` itself is already gitignored.

### What I could not verify

The YAML parses, the step conditions resolve as intended, and no stale `HARBOR` reference remains anywhere in the repo. But **I could not verify the push actually succeeds** — the credentials exist only in the repository's secret store, so the first push to `main` after merge is the real test. A `workflow_dispatch` run from this branch would exercise it beforehand, but that pushes a real branch-tagged image to Harbor, so I have not done it unprompted.

---

## Verification

| Command | Result |
|---|---|
| `cargo build --locked --all-targets` | pass |
| `cargo build --locked --release` | pass |
| `cargo test --locked` | 98 passed, 0 failed |
| `cargo test --locked -- --ignored` | 7 passed, 0 failed |
| `cargo clippy --locked --all-targets -- -D warnings` | exit 0 |
| `cargo fmt --check` | exit 0 |
| both workflow YAMLs | parse clean |