### PR TITLE
Fix Docker publish credentials and gate the push on having them

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,7 +14,9 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     env:
-      HARBOR_USERNAME: ${{ secrets.HARBOR_USERNAME }}
+      # Mirrored into env so step-level `if:` can test it - secrets are not
+      # available directly in an `if:` expression.
+      REGISTRY_USERNAME: ${{ secrets.ADREGISTRY_INST_USERNAME }}
 
     steps:
       - name: Checkout
@@ -27,12 +29,12 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Log in to Harbor
-        if: env.HARBOR_USERNAME != ''
+        if: env.REGISTRY_USERNAME != ''
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.HARBOR_USERNAME }}
-          password: ${{ secrets.HARBOR_PASSWORD }}
+          username: ${{ secrets.ADREGISTRY_INST_USERNAME }}
+          password: ${{ secrets.ADREGISTRY_INST_SECRET }}
 
       - name: Set image tags
         id: tags
@@ -45,10 +47,19 @@ jobs:
             echo "tags=${{ env.IMAGE }}:latest,${{ env.IMAGE }}:${VERSION}" >> "$GITHUB_OUTPUT"
           fi
 
+      # `push` is gated on the same condition as the login above. Previously the
+      # login skipped itself when the credential was absent but this pushed
+      # unconditionally, so a missing secret surfaced as an `unauthorized` error
+      # after a full image build rather than as a clear skip.
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: ${{ env.REGISTRY_USERNAME != '' }}
           platforms: linux/amd64
           tags: ${{ steps.tags.outputs.tags }}
+
+      - name: Warn if the push was skipped
+        if: env.REGISTRY_USERNAME == ''
+        run: |
+          echo "::warning::ADREGISTRY_INST_USERNAME is not set - image was built but not pushed."

--- a/.secrets.example
+++ b/.secrets.example
@@ -1,2 +1,6 @@
-HARBOR_USERNAME=your-harbor-username
-HARBOR_PASSWORD=your-harbor-password-or-token
+# Copy to .secrets for local runs with `act` (see .actrc). Never commit .secrets.
+#
+# These must match the secret names the workflow reads, and the repository
+# secrets configured in GitHub.
+ADREGISTRY_INST_USERNAME=your-registry-username
+ADREGISTRY_INST_SECRET=your-registry-password-or-token


### PR DESCRIPTION
The "Build and Push Docker Image" workflow has failed on **every push to `main` since it was added** on 2026-03-27 — 03-27, 06-03, 08-03, 08-13, 08-25, and twice on 08-26. It has never once succeeded on `main`.

It is not a code problem. `main` is green on CI; this is entirely a credentials and gating issue.

## Two problems

**1. The secret names were wrong.** The workflow read `HARBOR_USERNAME` / `HARBOR_PASSWORD`. Those are not configured — `gh secret list` returns zero repository secrets — which is why the login step's `if: env.HARBOR_USERNAME != ''` guard **skipped it on every run**. The real credentials are `ADREGISTRY_INST_USERNAME` / `ADREGISTRY_INST_SECRET`.

**2. The push was ungated.** The login degraded gracefully when the credential was missing, but the build step ran `push: true` regardless. So every run built the entire image successfully and only then failed:

```
#22 pushing adregistry.fnal.gov/instrumentation/redis-tui:latest with docker
#22 ERROR: unauthorized: unauthorized to access repository:
    instrumentation/redis-tui, action: push
```

A missing secret should not present as a registry permissions problem. `push` now uses the same condition as the login, so a missing credential builds the image and skips the push — and emits a `::warning::` naming the secret, so it is visible rather than silent.

```yaml
- name: Build and push
  uses: docker/build-push-action@v6
  with:
    push: ${{ env.REGISTRY_USERNAME != '' }}
```

`.secrets.example` is updated to the same names so local `act` runs match CI. `.secrets` itself is already gitignored.

## What I could and could not verify

Verified: the YAML parses, the step conditions resolve as intended, and no stale `HARBOR` reference remains anywhere in the repo.

**Not verified: that the push actually succeeds.** The credentials live only in the repository's secret store, so this cannot be proven from a local checkout — the first push to `main` after merge is the real test. A `workflow_dispatch` run from this branch would exercise it beforehand, but that pushes a real branch-tagged image (`latest-fix-docker-publish-credentials`) to Harbor, so I have not done it unprompted. Say the word if you'd rather confirm that way before merging.

Touches only `.github/` and `.secrets.example`, so no version bump is required.