### PR TITLE
Fix Docker publishing: pass registry credentials through env, not ${{ }} interpolation

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -87,30 +87,11 @@ jobs:
 
           case "$code" in
             200)
-              # HTTP 200 does NOT mean the requested scope was granted. The token
-              # server returns a token carrying the scopes it actually granted,
-              # which may be narrower than asked for - or empty. The decisive
-              # check is the "access" claim inside the token, not the status code.
+              # Never print the token itself - only whether one came back.
               if grep -q '"token"' /tmp/token.json 2>/dev/null; then
-                echo "  A token was issued. Decoding its granted scope:"
-                payload="$(python3 - <<'EOF'
-import base64, json, sys
-tok = json.load(open('/tmp/token.json')).get('token', '')
-parts = tok.split('.')
-if len(parts) < 2:
-    print('  could not parse token'); sys.exit()
-p = parts[1] + '=' * (-len(parts[1]) % 4)
-claims = json.loads(base64.urlsafe_b64decode(p))
-acc = claims.get('access', [])
-if not acc:
-    print('  GRANTED: nothing - access claim is EMPTY')
-    print('  => the account authenticated but was granted no rights on this')
-    print('     repository. This is why the push is refused despite HTTP 200.')
-for a in acc:
-    print(f"  GRANTED: {a.get('type')}:{a.get('name')} -> {a.get('actions')}")
-EOF
-)"
-                echo "$payload"
+                echo "  A push-scoped token WAS issued: the credentials are valid and"
+                echo "  have push rights. If docker login still fails, the problem is"
+                echo "  in the login step rather than the credentials."
               else
                 echo "  HTTP 200 but no token field in the response."
               fi

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -135,13 +135,29 @@ jobs:
                      "$realm?service=${service}&scope=repository:${IMAGE#*/}:pull" 2>/dev/null)" || pcode="curl-failed"
           echo "  HTTP $pcode (200 here but not above => authentication fine, push permission missing)"
 
-      - name: Log in to Harbor
+      # NOT `docker login`. Harbor robot accounts are scoped to a project and
+      # cannot obtain the *unscoped* token that `docker login` requests to
+      # validate a credential, so login fails with "unauthorized" even when the
+      # account can push. Confirmed against this registry: a token request scoped
+      # to repository:instrumentation/redis-tui:pull,push returns 200, while the
+      # same credential with no scope returns 401.
+      #
+      # Writing the auth straight into the docker config skips that validation.
+      # The push itself requests a scoped token, which this account can get.
+      - name: Configure registry credentials
         if: env.REGISTRY_USERNAME != ''
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.ADREGISTRY_INST_USERNAME }}
-          password: ${{ secrets.ADREGISTRY_INST_SECRET }}
+        env:
+          REG_USER: ${{ secrets.ADREGISTRY_INST_USERNAME }}
+          REG_PASS: ${{ secrets.ADREGISTRY_INST_SECRET }}
+        run: |
+          set -uo pipefail
+          auth="$(printf '%s:%s' "$REG_USER" "$REG_PASS" | base64 -w0)"
+          # base64 of a secret is a derived value and is not masked automatically.
+          echo "::add-mask::$auth"
+          mkdir -p ~/.docker
+          printf '{"auths":{"%s":{"auth":"%s"}}}\n' "$REGISTRY" "$auth" > ~/.docker/config.json
+          chmod 600 ~/.docker/config.json
+          echo "Wrote credentials for $REGISTRY to ~/.docker/config.json"
 
       - name: Set image tags
         id: tags

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,11 +12,15 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
-    env:
-      # Mirrored into env so step-level `if:` can test it - secrets are not
-      # available directly in an `if:` expression.
-      REGISTRY_USERNAME: ${{ secrets.ADREGISTRY_INST_USERNAME }}
+    # Must be the self-hosted runner. adregistry.fnal.gov grants push only from
+    # inside the FNAL network: from GitHub's cloud runners the same robot
+    # credential authenticates fine but is granted `pull` only, so every push
+    # from ubuntu-latest failed with "unauthorized ... action: push".
+    #
+    # This matches redis-pvxs-ioc, whose registry jobs all run on adlinux3 and
+    # succeed; its ci-image.yml uses a cloud runner for pull requests and
+    # adlinux3 for anything that touches the registry.
+    runs-on: adlinux3
 
     steps:
       - name: Checkout
@@ -28,177 +32,50 @@ jobs:
           VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      # Temporary diagnostic for the persistent login failure. Reports only the
-      # SHAPE of the credentials and what the registry says back - never their
-      # values. Remove once the publish is working.
-      - name: Diagnose registry credentials
-        env:
-          REG_USER: ${{ secrets.ADREGISTRY_INST_USERNAME }}
-          REG_PASS: ${{ secrets.ADREGISTRY_INST_SECRET }}
-        run: |
-          set -uo pipefail
-
-          shape() {
-            local label="$1" val="$2"
-            if [ -z "$val" ]; then
-              echo "  $label: NOT SET (empty)"
-              return
-            fi
-            local trimmed
-            trimmed="$(printf '%s' "$val" | tr -d '[:space:]')"
-            echo "  $label: set, length=${#val}, length_without_whitespace=${#trimmed}"
-            if [ "${#val}" -ne "${#trimmed}" ]; then
-              echo "    WARNING: contains whitespace/newline - a stray newline when"
-              echo "    the secret was pasted is a common cause of 401s."
-            fi
-          }
-
-          echo "Registry: $REGISTRY"
-          echo "Credential shape (values are never printed):"
-          shape "ADREGISTRY_INST_USERNAME" "$REG_USER"
-          shape "ADREGISTRY_INST_SECRET  " "$REG_PASS"
-
-          echo
-          echo "Step 1: is the registry reachable, and what auth does it advertise?"
-          hdrs="$(curl -sS -D - -o /dev/null --max-time 30 "https://$REGISTRY/v2/" 2>&1)" || {
-            echo "  could not reach https://$REGISTRY/v2/"
-            echo "$hdrs" | sed 's/^/    /'
-            exit 0
-          }
-          echo "$hdrs" | grep -iE "^HTTP/|^www-authenticate:" | sed 's/^/  /'
-
-          realm="$(echo "$hdrs"   | grep -i '^www-authenticate:' | sed -n 's/.*realm="\([^"]*\)".*/\1/p')"
-          service="$(echo "$hdrs" | grep -i '^www-authenticate:' | sed -n 's/.*service="\([^"]*\)".*/\1/p')"
-          echo "  realm=${realm:-<none>}  service=${service:-<none>}"
-
-          if [ -z "$realm" ]; then
-            echo "  no token realm advertised - cannot test credentials further."
-            exit 0
-          fi
-
-          echo
-          echo "Step 2: can these credentials get a push-scoped token for the image?"
-          scope="repository:${IMAGE#*/}:pull,push"
-          echo "  scope=$scope"
-          code="$(curl -sS -o /tmp/token.json -w '%{http_code}' --max-time 30 \
-                    -u "$REG_USER:$REG_PASS" \
-                    "$realm?service=${service}&scope=${scope}" 2>/dev/null)" || code="curl-failed"
-          echo "  HTTP $code"
-
-          case "$code" in
-            200)
-              # HTTP 200 does NOT mean the requested scope was granted. The token
-              # server returns a token carrying the scopes it actually granted,
-              # which may be narrower than requested - or empty. The decisive
-              # check is the "access" claim inside the token, not the status code.
-              tok="$(jq -r '.token // .access_token // empty' /tmp/token.json 2>/dev/null)"
-              if [ -z "$tok" ]; then
-                echo "  HTTP 200 but no token field in the response."
-              else
-                body="$(echo "$tok" | cut -d. -f2)"
-                pad=$(( (4 - ${#body} % 4) % 4 ))
-                [ "$pad" -gt 0 ] && body="${body}$(printf '=%.0s' $(seq 1 "$pad"))"
-                claims="$(echo "$body" | tr '_-' '/+' | base64 -d 2>/dev/null)"
-                granted="$(echo "$claims" | jq -r '.access[]? | "  GRANTED: \(.type):\(.name) -> \(.actions | join(","))"' 2>/dev/null)"
-                if [ -z "$granted" ]; then
-                  echo "  GRANTED: nothing - the access claim is EMPTY."
-                  echo "  => the credential authenticated, but Harbor granted it no rights"
-                  echo "     on this repository. That is why the push is refused despite"
-                  echo "     the 200. This is a permissions problem, not a login problem."
-                else
-                  echo "$granted"
-                fi
-              fi
-              ;;
-            401)
-              echo "  401 - the registry rejected the username/password pair."
-              echo "  Body:"; sed 's/^/    /' /tmp/token.json 2>/dev/null
-              echo "  Likely: wrong or expired secret, or a Harbor robot account name"
-              echo "  that must be given in full (robot\$project+name)."
-              ;;
-            403)
-              echo "  403 - the credentials authenticated but lack push rights on"
-              echo "  ${IMAGE#*/}."
-              echo "  Body:"; sed 's/^/    /' /tmp/token.json 2>/dev/null
-              ;;
-            *)
-              echo "  Body:"; sed 's/^/    /' /tmp/token.json 2>/dev/null
-              ;;
-          esac
-
-          echo
-          echo "Step 4: UNSCOPED token - this is exactly what \`docker login\` requests."
-          echo "  A Harbor robot account is scoped to a project and often cannot get a"
-          echo "  global token, which makes login fail even though scoped pushes work."
-          ucode="$(curl -sS -o /tmp/token_none.json -w '%{http_code}' --max-time 30 \
-                     -u "$REG_USER:$REG_PASS" \
-                     "$realm?service=${service}" 2>/dev/null)" || ucode="curl-failed"
-          echo "  HTTP $ucode"
-          if [ "$ucode" != "200" ]; then
-            echo "  Body:"; sed 's/^/    /' /tmp/token_none.json 2>/dev/null
-            echo "  => CONFIRMS the diagnosis: scoped requests succeed, unscoped fails,"
-            echo "     so docker login cannot validate even though a push would work."
-          else
-            echo "  => unscoped auth works too, so the login failure is elsewhere."
-          fi
-
-          echo
-          echo "Step 3: pull-only scope, to separate authentication from authorisation"
-          pcode="$(curl -sS -o /tmp/token_pull.json -w '%{http_code}' --max-time 30 \
-                     -u "$REG_USER:$REG_PASS" \
-                     "$realm?service=${service}&scope=repository:${IMAGE#*/}:pull" 2>/dev/null)" || pcode="curl-failed"
-          echo "  HTTP $pcode"
-          echo "  (The decisive signal is the GRANTED line in step 2, not these status"
-          echo "   codes - Harbor answers 200 and simply omits the actions it withheld.)"
-
-      # NOT `docker login`. Harbor robot accounts are scoped to a project and
-      # cannot obtain the *unscoped* token that `docker login` requests to
-      # validate a credential, so login fails with "unauthorized" even when the
-      # account can push. Confirmed against this registry: a token request scoped
-      # to repository:instrumentation/redis-tui:pull,push returns 200, while the
-      # same credential with no scope returns 401.
-      #
-      # Writing the auth straight into the docker config skips that validation.
-      # The push itself requests a scoped token, which this account can get.
-      - name: Configure registry credentials
-        if: env.REGISTRY_USERNAME != ''
-        env:
-          REG_USER: ${{ secrets.ADREGISTRY_INST_USERNAME }}
-          REG_PASS: ${{ secrets.ADREGISTRY_INST_SECRET }}
-        run: |
-          set -uo pipefail
-          auth="$(printf '%s:%s' "$REG_USER" "$REG_PASS" | base64 -w0)"
-          # base64 of a secret is a derived value and is not masked automatically.
-          echo "::add-mask::$auth"
-          mkdir -p ~/.docker
-          printf '{"auths":{"%s":{"auth":"%s"}}}\n' "$REGISTRY" "$auth" > ~/.docker/config.json
-          chmod 600 ~/.docker/config.json
-          echo "Wrote credentials for $REGISTRY to ~/.docker/config.json"
-
       - name: Set image tags
         id: tags
         run: |
-          VERSION=${{ steps.version.outputs.version }}
-          if [ -n "$ACT" ] || { [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.ref_name }}" != "main" ]; }; then
+          VERSION="${{ steps.version.outputs.version }}"
+          if [ "${{ github.ref_name }}" != "main" ]; then
+            # Branch-suffixed tags keep dispatch runs off :latest.
             BRANCH=$(echo "${{ github.ref_name }}" | sed 's|/|-|g')
-            echo "tags=${{ env.IMAGE }}:latest-${BRANCH},${{ env.IMAGE }}:${VERSION}-${BRANCH}" >> "$GITHUB_OUTPUT"
+            echo "primary=${IMAGE}:${VERSION}-${BRANCH}" >> "$GITHUB_OUTPUT"
+            echo "moving=${IMAGE}:latest-${BRANCH}" >> "$GITHUB_OUTPUT"
           else
-            echo "tags=${{ env.IMAGE }}:latest,${{ env.IMAGE }}:${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "primary=${IMAGE}:${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "moving=${IMAGE}:latest" >> "$GITHUB_OUTPUT"
           fi
 
-      # `push` is gated on the same condition as the login above. Previously the
-      # login skipped itself when the credential was absent but this pushed
-      # unconditionally, so a missing secret surfaced as an `unauthorized` error
-      # after a full image build rather than as a clear skip.
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: ${{ env.REGISTRY_USERNAME != '' }}
-          platforms: linux/amd64
-          tags: ${{ steps.tags.outputs.tags }}
-
-      - name: Warn if the push was skipped
-        if: env.REGISTRY_USERNAME == ''
+      # Plain docker login/build/push rather than buildx and
+      # docker/build-push-action - the same commands redis-pvxs-ioc uses, and
+      # they do not assume buildx is set up on the self-hosted runner.
+      - name: Registry login
         run: |
-          echo "::warning::ADREGISTRY_INST_USERNAME is not set - image was built but not pushed."
+          printf '%s' "${{ secrets.ADREGISTRY_INST_SECRET }}" \
+            | docker login "$REGISTRY" \
+                --username "${{ secrets.ADREGISTRY_INST_USERNAME }}" \
+                --password-stdin
+
+      - name: Build and push
+        run: |
+          PRIMARY="${{ steps.tags.outputs.primary }}"
+          MOVING="${{ steps.tags.outputs.moving }}"
+
+          docker build --platform linux/amd64 -t "$PRIMARY" -t "$MOVING" .
+          docker push "$PRIMARY"
+          docker push "$MOVING"
+
+          DIGEST_REF="$(docker image inspect "$PRIMARY" \
+            --format '{{range .RepoDigests}}{{println .}}{{end}}' \
+            | grep -F "${IMAGE}@sha256:" | head -n 1)"
+          {
+            echo "### Published"
+            echo
+            echo "- \`$PRIMARY\`"
+            echo "- \`$MOVING\`"
+            echo "- Digest: \`${DIGEST_REF:-unknown}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Docker logout
+        if: always()
+        run: docker logout "$REGISTRY"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -87,11 +87,30 @@ jobs:
 
           case "$code" in
             200)
-              # Never print the token itself - only whether one came back.
+              # HTTP 200 does NOT mean the requested scope was granted. The token
+              # server returns a token carrying the scopes it actually granted,
+              # which may be narrower than asked for - or empty. The decisive
+              # check is the "access" claim inside the token, not the status code.
               if grep -q '"token"' /tmp/token.json 2>/dev/null; then
-                echo "  A push-scoped token WAS issued: the credentials are valid and"
-                echo "  have push rights. If docker login still fails, the problem is"
-                echo "  in the login step rather than the credentials."
+                echo "  A token was issued. Decoding its granted scope:"
+                payload="$(python3 - <<'EOF'
+import base64, json, sys
+tok = json.load(open('/tmp/token.json')).get('token', '')
+parts = tok.split('.')
+if len(parts) < 2:
+    print('  could not parse token'); sys.exit()
+p = parts[1] + '=' * (-len(parts[1]) % 4)
+claims = json.loads(base64.urlsafe_b64decode(p))
+acc = claims.get('access', [])
+if not acc:
+    print('  GRANTED: nothing - access claim is EMPTY')
+    print('  => the account authenticated but was granted no rights on this')
+    print('     repository. This is why the push is refused despite HTTP 200.')
+for a in acc:
+    print(f"  GRANTED: {a.get('type')}:{a.get('name')} -> {a.get('actions')}")
+EOF
+)"
+                echo "$payload"
               else
                 echo "  HTTP 200 but no token field in the response."
               fi

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,6 +28,97 @@ jobs:
           VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+      # Temporary diagnostic for the persistent login failure. Reports only the
+      # SHAPE of the credentials and what the registry says back - never their
+      # values. Remove once the publish is working.
+      - name: Diagnose registry credentials
+        env:
+          REG_USER: ${{ secrets.ADREGISTRY_INST_USERNAME }}
+          REG_PASS: ${{ secrets.ADREGISTRY_INST_SECRET }}
+        run: |
+          set -uo pipefail
+
+          shape() {
+            local label="$1" val="$2"
+            if [ -z "$val" ]; then
+              echo "  $label: NOT SET (empty)"
+              return
+            fi
+            local trimmed
+            trimmed="$(printf '%s' "$val" | tr -d '[:space:]')"
+            echo "  $label: set, length=${#val}, length_without_whitespace=${#trimmed}"
+            if [ "${#val}" -ne "${#trimmed}" ]; then
+              echo "    WARNING: contains whitespace/newline - a stray newline when"
+              echo "    the secret was pasted is a common cause of 401s."
+            fi
+          }
+
+          echo "Registry: $REGISTRY"
+          echo "Credential shape (values are never printed):"
+          shape "ADREGISTRY_INST_USERNAME" "$REG_USER"
+          shape "ADREGISTRY_INST_SECRET  " "$REG_PASS"
+
+          echo
+          echo "Step 1: is the registry reachable, and what auth does it advertise?"
+          hdrs="$(curl -sS -D - -o /dev/null --max-time 30 "https://$REGISTRY/v2/" 2>&1)" || {
+            echo "  could not reach https://$REGISTRY/v2/"
+            echo "$hdrs" | sed 's/^/    /'
+            exit 0
+          }
+          echo "$hdrs" | grep -iE "^HTTP/|^www-authenticate:" | sed 's/^/  /'
+
+          realm="$(echo "$hdrs"   | grep -i '^www-authenticate:' | sed -n 's/.*realm="\([^"]*\)".*/\1/p')"
+          service="$(echo "$hdrs" | grep -i '^www-authenticate:' | sed -n 's/.*service="\([^"]*\)".*/\1/p')"
+          echo "  realm=${realm:-<none>}  service=${service:-<none>}"
+
+          if [ -z "$realm" ]; then
+            echo "  no token realm advertised - cannot test credentials further."
+            exit 0
+          fi
+
+          echo
+          echo "Step 2: can these credentials get a push-scoped token for the image?"
+          scope="repository:${IMAGE#*/}:pull,push"
+          echo "  scope=$scope"
+          code="$(curl -sS -o /tmp/token.json -w '%{http_code}' --max-time 30 \
+                    -u "$REG_USER:$REG_PASS" \
+                    "$realm?service=${service}&scope=${scope}" 2>/dev/null)" || code="curl-failed"
+          echo "  HTTP $code"
+
+          case "$code" in
+            200)
+              # Never print the token itself - only whether one came back.
+              if grep -q '"token"' /tmp/token.json 2>/dev/null; then
+                echo "  A push-scoped token WAS issued: the credentials are valid and"
+                echo "  have push rights. If docker login still fails, the problem is"
+                echo "  in the login step rather than the credentials."
+              else
+                echo "  HTTP 200 but no token field in the response."
+              fi
+              ;;
+            401)
+              echo "  401 - the registry rejected the username/password pair."
+              echo "  Body:"; sed 's/^/    /' /tmp/token.json 2>/dev/null
+              echo "  Likely: wrong or expired secret, or a Harbor robot account name"
+              echo "  that must be given in full (robot\$project+name)."
+              ;;
+            403)
+              echo "  403 - the credentials authenticated but lack push rights on"
+              echo "  ${IMAGE#*/}."
+              echo "  Body:"; sed 's/^/    /' /tmp/token.json 2>/dev/null
+              ;;
+            *)
+              echo "  Body:"; sed 's/^/    /' /tmp/token.json 2>/dev/null
+              ;;
+          esac
+
+          echo
+          echo "Step 3: pull-only scope, to separate authentication from authorisation"
+          pcode="$(curl -sS -o /tmp/token_pull.json -w '%{http_code}' --max-time 30 \
+                     -u "$REG_USER:$REG_PASS" \
+                     "$realm?service=${service}&scope=repository:${IMAGE#*/}:pull" 2>/dev/null)" || pcode="curl-failed"
+          echo "  HTTP $pcode (200 here but not above => authentication fine, push permission missing)"
+
       - name: Log in to Harbor
         if: env.REGISTRY_USERNAME != ''
         uses: docker/login-action@v3

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -87,13 +87,27 @@ jobs:
 
           case "$code" in
             200)
-              # Never print the token itself - only whether one came back.
-              if grep -q '"token"' /tmp/token.json 2>/dev/null; then
-                echo "  A push-scoped token WAS issued: the credentials are valid and"
-                echo "  have push rights. If docker login still fails, the problem is"
-                echo "  in the login step rather than the credentials."
-              else
+              # HTTP 200 does NOT mean the requested scope was granted. The token
+              # server returns a token carrying the scopes it actually granted,
+              # which may be narrower than requested - or empty. The decisive
+              # check is the "access" claim inside the token, not the status code.
+              tok="$(jq -r '.token // .access_token // empty' /tmp/token.json 2>/dev/null)"
+              if [ -z "$tok" ]; then
                 echo "  HTTP 200 but no token field in the response."
+              else
+                body="$(echo "$tok" | cut -d. -f2)"
+                pad=$(( (4 - ${#body} % 4) % 4 ))
+                [ "$pad" -gt 0 ] && body="${body}$(printf '=%.0s' $(seq 1 "$pad"))"
+                claims="$(echo "$body" | tr '_-' '/+' | base64 -d 2>/dev/null)"
+                granted="$(echo "$claims" | jq -r '.access[]? | "  GRANTED: \(.type):\(.name) -> \(.actions | join(","))"' 2>/dev/null)"
+                if [ -z "$granted" ]; then
+                  echo "  GRANTED: nothing - the access claim is EMPTY."
+                  echo "  => the credential authenticated, but Harbor granted it no rights"
+                  echo "     on this repository. That is why the push is refused despite"
+                  echo "     the 200. This is a permissions problem, not a login problem."
+                else
+                  echo "$granted"
+                fi
               fi
               ;;
             401)

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -113,6 +113,22 @@ jobs:
           esac
 
           echo
+          echo "Step 4: UNSCOPED token - this is exactly what \`docker login\` requests."
+          echo "  A Harbor robot account is scoped to a project and often cannot get a"
+          echo "  global token, which makes login fail even though scoped pushes work."
+          ucode="$(curl -sS -o /tmp/token_none.json -w '%{http_code}' --max-time 30 \
+                     -u "$REG_USER:$REG_PASS" \
+                     "$realm?service=${service}" 2>/dev/null)" || ucode="curl-failed"
+          echo "  HTTP $ucode"
+          if [ "$ucode" != "200" ]; then
+            echo "  Body:"; sed 's/^/    /' /tmp/token_none.json 2>/dev/null
+            echo "  => CONFIRMS the diagnosis: scoped requests succeed, unscoped fails,"
+            echo "     so docker login cannot validate even though a push would work."
+          else
+            echo "  => unscoped auth works too, so the login failure is elsewhere."
+          fi
+
+          echo
           echo "Step 3: pull-only scope, to separate authentication from authorisation"
           pcode="$(curl -sS -o /tmp/token_pull.json -w '%{http_code}' --max-time 30 \
                      -u "$REG_USER:$REG_PASS" \

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,11 +49,46 @@ jobs:
       # Plain docker login/build/push rather than buildx and
       # docker/build-push-action - the same commands redis-pvxs-ioc uses, and
       # they do not assume buildx is set up on the self-hosted runner.
-      - name: Registry login
+      # TEMPORARY diagnostic. Prints only lengths, never the values, and only to
+      # confirm or rule out the mangling described on the login step below.
+      # Remove once the login is proven green.
+      - name: Credential shape check
+        env:
+          USERNAME: ${{ secrets.ADREGISTRY_INST_USERNAME }}
+          SECRET: ${{ secrets.ADREGISTRY_INST_SECRET }}
         run: |
-          printf '%s' "${{ secrets.ADREGISTRY_INST_SECRET }}" \
+          # Same text, reaching bash two different ways.
+          interpolated="${{ secrets.ADREGISTRY_INST_USERNAME }}"
+
+          echo "username via env:          ${#USERNAME} chars"
+          echo "username via interpolation: ${#interpolated} chars"
+          echo "secret via env:            ${#SECRET} chars"
+
+          case "$USERNAME" in
+            *'$'*) echo "username CONTAINS a dollar sign" ;;
+            *)     echo "username has no dollar sign" ;;
+          esac
+
+          if [ "${#USERNAME}" -ne "${#interpolated}" ]; then
+            echo "::error::The username is mangled when interpolated into a run: block."
+          else
+            echo "Interpolation is not altering the username."
+          fi
+
+      # Secrets are passed through env: rather than ${{ }} interpolation. GitHub
+      # substitutes an expression as literal text into the script, so a Harbor
+      # robot name - which contains a '$' - gets word-expanded by bash before
+      # docker ever sees it: "robot$instrumentation+redis-tui" becomes
+      # "robot+redis-tui", and Harbor rejects it. An env var is passed as data
+      # and is never re-parsed by the shell.
+      - name: Registry login
+        env:
+          USERNAME: ${{ secrets.ADREGISTRY_INST_USERNAME }}
+          SECRET: ${{ secrets.ADREGISTRY_INST_SECRET }}
+        run: |
+          printf '%s' "$SECRET" \
             | docker login "$REGISTRY" \
-                --username "${{ secrets.ADREGISTRY_INST_USERNAME }}" \
+                --username "$USERNAME" \
                 --password-stdin
 
       - name: Build and push

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,14 +12,14 @@ env:
 
 jobs:
   build-and-push:
-    # Must be the self-hosted runner. adregistry.fnal.gov grants push only from
-    # inside the FNAL network: from GitHub's cloud runners the same robot
-    # credential authenticates fine but is granted `pull` only, so every push
-    # from ubuntu-latest failed with "unauthorized ... action: push".
+    # A cloud runner is enough. An earlier revision of this workflow moved the
+    # job to the self-hosted `adlinux3` on the theory that Harbor only grants
+    # push from inside the FNAL network - that was wrong. Publishing was failing
+    # because the credentials were interpolated into the shell (see the login
+    # step below), and both runners publish fine once that is fixed.
     #
-    # This matches redis-pvxs-ioc, whose registry jobs all run on adlinux3 and
-    # succeed; its ci-image.yml uses a cloud runner for pull requests and
-    # adlinux3 for anything that touches the registry.
+    # `redis-pvxs-ioc` runs its registry jobs on `adlinux3`; switching for
+    # consistency with it would be reasonable, but is not required here.
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,7 +20,7 @@ jobs:
     # This matches redis-pvxs-ioc, whose registry jobs all run on adlinux3 and
     # succeed; its ci-image.yml uses a cloud runner for pull requests and
     # adlinux3 for anything that touches the registry.
-    runs-on: adlinux3
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -49,32 +49,6 @@ jobs:
       # Plain docker login/build/push rather than buildx and
       # docker/build-push-action - the same commands redis-pvxs-ioc uses, and
       # they do not assume buildx is set up on the self-hosted runner.
-      # TEMPORARY diagnostic. Prints only lengths, never the values, and only to
-      # confirm or rule out the mangling described on the login step below.
-      # Remove once the login is proven green.
-      - name: Credential shape check
-        env:
-          USERNAME: ${{ secrets.ADREGISTRY_INST_USERNAME }}
-          SECRET: ${{ secrets.ADREGISTRY_INST_SECRET }}
-        run: |
-          # Same text, reaching bash two different ways.
-          interpolated="${{ secrets.ADREGISTRY_INST_USERNAME }}"
-
-          echo "username via env:          ${#USERNAME} chars"
-          echo "username via interpolation: ${#interpolated} chars"
-          echo "secret via env:            ${#SECRET} chars"
-
-          case "$USERNAME" in
-            *'$'*) echo "username CONTAINS a dollar sign" ;;
-            *)     echo "username has no dollar sign" ;;
-          esac
-
-          if [ "${#USERNAME}" -ne "${#interpolated}" ]; then
-            echo "::error::The username is mangled when interpolated into a run: block."
-          else
-            echo "Interpolation is not altering the username."
-          fi
-
       # Secrets are passed through env: rather than ${{ }} interpolation. GitHub
       # substitutes an expression as literal text into the script, so a Harbor
       # robot name - which contains a '$' - gets word-expanded by bash before

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -147,7 +147,9 @@ jobs:
           pcode="$(curl -sS -o /tmp/token_pull.json -w '%{http_code}' --max-time 30 \
                      -u "$REG_USER:$REG_PASS" \
                      "$realm?service=${service}&scope=repository:${IMAGE#*/}:pull" 2>/dev/null)" || pcode="curl-failed"
-          echo "  HTTP $pcode (200 here but not above => authentication fine, push permission missing)"
+          echo "  HTTP $pcode"
+          echo "  (The decisive signal is the GRANTED line in step 2, not these status"
+          echo "   codes - Harbor answers 200 and simply omits the actions it withheld.)"
 
       # NOT `docker login`. Harbor robot accounts are scoped to a project and
       # cannot obtain the *unscoped* token that `docker login` requests to


### PR DESCRIPTION
Publishing to `adregistry.fnal.gov` has failed on every push to `main` since 2026-03-27. There were **two** causes stacked on top of each other, and both are now fixed and verified green.

## Cause 1 — the credential (fixed outside this repo)

The org secrets `ADREGISTRY_INST_USERNAME` / `ADREGISTRY_INST_SECRET` held a robot Harbor rejected outright. They were rotated on 2026-08-27 at 15:23, which fixed this half. No repo change was involved.

## Cause 2 — the workflow mangled the username (fixed here)

The login step interpolated the secrets straight into the `run:` script. GitHub substitutes an expression as **literal text** before bash runs, so a Harbor robot name — which contains a `$` — is word-expanded by the shell before docker ever sees it:

```
--username "robot$instrumentation+xxx"   ->   robot+xxx
```

A temporary diagnostic on this branch measured it directly:

```
username via env:           25 chars
username via interpolation:  9 chars
username CONTAINS a dollar sign
```

Sixteen characters silently eaten by the shell. Harbor answers that with `unauthorized:` on `GET /v2/` — the exact error this branch kept hitting even after the credential was rotated. Passing the secrets through `env:` hands them over as data, so the shell never re-parses them.

## Verified

| Run | `runs-on` | Result |
| --- | --- | --- |
| [33092492152](https://github.com/fermi-ad/redis-tui/actions/runs/33092492152) | `adlinux3` | pushed `1.3.3-diagnose-registry-auth`, `latest-diagnose-registry-auth` |
| [33092687742](https://github.com/fermi-ad/redis-tui/actions/runs/33092687742) | `ubuntu-latest` | pushed the same tags again |

## Corrections to this branch's earlier commits

I diagnosed this wrongly three times, and the commit messages on this branch still record those wrong readings:

1. *"The robot account is missing push permission in Harbor."* Wrong. `HTTP 200` from the token endpoint only means the request was answered, not that the requested scope was granted.
2. *"`adregistry.fnal.gov` grants push only from inside the FNAL network."* Wrong. Both runners publish fine.
3. *"The org credential is pull-only; this repo needs its own repo-level secrets."* Wrong, and this one was actively misleading. The scope-decoding diagnostic ran in a `run:` block, so it sent the same mangled username — and Harbor serves this repository anonymously rather than refusing an unauthenticated request:

   ```
   curl "https://adregistry.fnal.gov/service/token?service=harbor-registry\
   &scope=repository:instrumentation/redis-tui:pull,push"
   -> HTTP 200   access: [{name: instrumentation/redis-tui, actions: [pull]}]
   ```

   That is with **no credentials at all**. So `GRANTED: pull` was never evidence about the robot — it is just what anonymous gets. **No repo-level secrets are needed.**

## What this PR does

- **Passes both secrets through `env:`** instead of `${{ }}` interpolation. This is the fix.
- **Keeps `runs-on: ubuntu-latest`.** The move to `adlinux3` was made on wrong diagnosis #2; both are now proven to work, so this keeps the cloud runner rather than adding a self-hosted dependency the publish does not need. `redis-pvxs-ioc` uses `adlinux3` for its registry jobs, so switching for consistency is a defensible call — say the word and I will flip it back.
- **Plain `docker login` / `build` / `push`** rather than buildx and `build-push-action`, matching `redis-pvxs-ioc`.
- **Drops the `push:` gate on the username being non-empty** that #75 added. A missing credential is now a loud failure at login rather than a silent skip — a silent skip is how this stayed broken from March to August.
