### PR TITLE
Fix the rand advisory and correct the docs' stream memory claim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,9 +1186,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "rand_core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "redis-tui"
-version = "1.3.3"
+version = "1.3.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-tui"
-version = "1.3.3"
+version = "1.3.4"
 edition = "2021"
 description = "A Redis TUI client inspired by Redis Insight"
 license = "BSD-3-Clause"

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -295,7 +295,7 @@ When a listener is active:
 - The status bar shows the entry count per update
 - A green `L` indicator appears next to the key in the list
 - Up to 4 listeners can run simultaneously (FIFO eviction if exceeded)
-- Stream entries in memory are capped at 10,000 per key to prevent OOM
+- Stream entries in memory are capped at 10 per key (`MAX_STREAM_ENTRIES`), newest kept - the last 5 are displayed and the newest is plotted. Rate statistics come from a separate 60-second ring of entry timestamps, so they survive the entries being discarded
 
 Press `l` again on the same key to stop its listener.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # redis-tui
 
+[![CI](https://github.com/fermi-ad/redis-tui/actions/workflows/ci.yml/badge.svg)](https://github.com/fermi-ad/redis-tui/actions/workflows/ci.yml)
+[![Build and Push Docker Image](https://github.com/fermi-ad/redis-tui/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/fermi-ad/redis-tui/actions/workflows/docker-publish.yml)
+
 A terminal UI client for Redis inspired by Redis Insight, built with Rust and [ratatui](https://github.com/ratatui/ratatui).
 
 ## Features
@@ -31,6 +34,16 @@ cargo build --release
 The binary will be at `target/release/redis-tui`.
 
 ### Docker
+
+Every push to `main` publishes an image to Fermilab's Harbor registry, tagged with
+both `latest` and the `Cargo.toml` version:
+
+```bash
+docker pull adregistry.fnal.gov/instrumentation/redis-tui:latest
+docker run -it --rm --network host adregistry.fnal.gov/instrumentation/redis-tui
+```
+
+To build it yourself instead:
 
 ```bash
 docker build -t redis-tui .
@@ -67,7 +80,12 @@ redis-tui --url redis://:password@host:6379/2
 
 # Connect to multiple hosts
 redis-tui --hosts-file hosts.txt
+
+# Widen the ingestion rate chart to an hour, averaged over 5s
+redis-tui --rate-history 60 --rate-avg-window 5
 ```
+
+See [MANUAL.md](MANUAL.md#command-line-options) for the full flag reference.
 
 ## Keybindings at a Glance
 
@@ -86,7 +104,14 @@ redis-tui --hosts-file hosts.txt
 | `f` | Toggle FFT |
 | `s` | Edit value |
 | `n` | New key |
+| `R` | Rename key |
+| `z` | Set TTL |
 | `d` | Delete key |
+| `t` / `T` | Cycle data type forward / back |
+| `e` | Toggle endianness |
+| `g` | Toggle FFT log scale |
+| `a` | Reset plot to auto limits |
+| `x` | Plot settings |
 | `?` | Help |
 | `q` / `Esc` | Quit |
 
@@ -100,4 +125,8 @@ The TUI is built with three main panels:
 - **Value View** (right) — display key metadata and formatted values
 - **Data Plot** (bottom) — visualize binary data as waveforms with optional FFT
 
-Background threads handle stream listening (XREAD) and signal generation (XADD + XTRIM) independently per key, with bounded memory usage (max 10,000 stream entries per key in memory).
+Background threads handle stream listening (XREAD) and signal generation (XADD + XTRIM) independently per key. Memory is bounded: only the 10 newest entries of a stream are held per key (`MAX_STREAM_ENTRIES`), of which the last 5 are displayed and the newest is plotted. Ingestion rate statistics are computed from a separate 60-second ring of entry timestamps, so the rate view stays accurate even though the entries themselves are discarded.
+
+## License
+
+BSD 3-Clause. See [LICENSE](LICENSE).


### PR DESCRIPTION
Three cleanups. The runner removal is not in this diff — see the last section.

## Dependabot GHSA-cq8v-f236-94qc (low)

`rand` 0.8.5 in `Cargo.lock` — unsound with a custom logger via `rand::rng()`, patched in 0.8.6. `cargo update -p rand` takes it to 0.8.8; two lines of lockfile.

Worth knowing: the entry is **orphaned**. `cargo tree -i rand --target all` can't reach it, and the only crate declaring it is `phf_generator`, which is equally unreachable. Nothing we build links it. Updating anyway is cheaper than arguing with the scanner.

## The docs were wrong about stream memory by 1000×

Both README and MANUAL said stream entries are capped at **10,000** per key. The real cap is `MAX_STREAM_ENTRIES = 10`. That made the memory story sound far more alarming than it is.

I verified the surrounding detail against the code rather than trusting `CLAUDE.md`:

| Claim | Verified in |
| --- | --- |
| keeps the 10 newest | `cap_stream_entries` — `app.rs:2066` |
| displays the last 5 | `format_stream_entries` — `app.rs:1483` |
| plots the newest only | `extract_stream_plot_data` — `app.rs:1969` |
| prunes timestamps to 60s | `update_rate_tracker` — `app.rs:629` |

That last row is why a cap of 10 isn't a problem, and it's now stated in both docs: rate statistics come from a separate ring of entry timestamps, so they outlive the entries.

## Other README updates

- **CI and publish badges.**
- **The Harbor image.** Publishing works again as of #77, but the only documented install route was still building it yourself.
- **`--rate-history` / `--rate-avg-window`.** Documented in MANUAL.md, absent from the README.
- **Keybindings the table omitted:** `R`, `z`, `t`/`T`, `e`, `g`, `a`, `x`. Renaming and TTL were listed as features with no key shown for either.
- **A License section.** BSD 3-Clause, which the repo carries but never mentioned.

## The self-hosted runner is not in this PR

`redis-tui-adlinux3` is a repository setting, not a file — nothing in the tree references it since #77 switched `runs-on` back to `ubuntu-latest`. It has to be deregistered through the GitHub API or repo settings, so it can't ride along in a diff. Handling it separately.

## Verification

No `.rs` changes, so no version bump is required and `cargo-version-check` doesn't trigger on these paths. Locally: build `--locked`, 98 unit tests, 7 live-Redis tests, `clippy -D warnings`, `fmt --check` — all pass.
