### PR TITLE
Build the image on pull requests and require a real version increase

### DIFF
--- a/.github/workflows/cargo-version-check.yml
+++ b/.github/workflows/cargo-version-check.yml
@@ -1,18 +1,22 @@
 name: Require Cargo version bump
 
+# Every merge to main publishes an image tagged with the Cargo.toml version, so
+# the version has to move on every merge - otherwise the merge republishes an
+# existing tag with a new digest and that tag stops identifying one artifact.
+#
+# Deliberately unfiltered by path. The previous version only fired on '**/*.rs'
+# and Cargo.toml, which let a docs-only PR through: #78 would have republished
+# :1.3.3 over the image from #77.
+#
+# Deliberately not run on push either. The old push branch diffed origin/main
+# against itself, so it always passed vacuously, and by then the merge has
+# already happened - the gate is only meaningful before it.
 on:
   pull_request:
-    paths:
-      - '**/*.rs'
-      - 'Cargo.toml'
-  push:
-    paths:
-      - '**/*.rs'
-      - 'Cargo.toml'
   workflow_dispatch:
     inputs:
       base_ref:
-        description: 'Base branch to compare against'
+        description: 'Branch to compare against'
         default: 'main'
 
 jobs:
@@ -20,53 +24,51 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Resolve base SHA
-        id: base
+      - name: Require a strict version increase
+        env:
+          BASE_REF: ${{ github.base_ref || inputs.base_ref || 'main' }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "sha=${{ github.event.pull_request.base.sha }}" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" = "push" ]; then
-            echo "sha=$(git rev-parse origin/main)" >> $GITHUB_OUTPUT
-          else
-            echo "sha=$(git rev-parse origin/${{ inputs.base_ref || 'main' }})" >> $GITHUB_OUTPUT
+          set -uo pipefail
+
+          # Read the version from [package] only, so a [dependencies.foo] block
+          # carrying its own `version =` cannot be picked up by mistake.
+          extract() {
+            awk '/^\[package\]/ { in_pkg = 1; next }
+                 /^\[/          { in_pkg = 0 }
+                 in_pkg && /^version[[:space:]]*=/ {
+                   gsub(/^version[[:space:]]*=[[:space:]]*"|".*$/, "")
+                   print; exit
+                 }'
+          }
+
+          # Compare against the tip of the base branch rather than the PR's
+          # recorded base SHA: the version must beat what is on main *now*, so a
+          # stale branch correctly starts failing once main moves ahead.
+          git fetch --no-tags --depth=1 origin "$BASE_REF"
+
+          OLD="$(git show FETCH_HEAD:Cargo.toml | extract)"
+          NEW="$(extract < Cargo.toml)"
+
+          SEMVER_RE='^[0-9]+\.[0-9]+\.[0-9]+$'
+          fail() { echo "::error::$1"; exit 1; }
+
+          [ -n "$OLD" ] || fail "Could not read the version from Cargo.toml on $BASE_REF."
+          [ -n "$NEW" ] || fail "Could not read the version from Cargo.toml on this branch."
+
+          [[ "$OLD" =~ $SEMVER_RE ]] || fail "Version on $BASE_REF is '$OLD', which is not X.Y.Z."
+          [[ "$NEW" =~ $SEMVER_RE ]] || fail "Version '$NEW' is not X.Y.Z. Pre-release suffixes are not supported."
+
+          if [ "$OLD" = "$NEW" ]; then
+            fail "Version is still $NEW. Every merge to $BASE_REF publishes an image tagged with it, so it must be bumped."
           fi
 
-      - name: Detect changes
-        id: diff
-        run: |
-          CHANGED_FILES=$(git diff --name-only ${{ steps.base.outputs.sha }})
-
-          echo "CHANGED_FILES<<EOF" >> $GITHUB_OUTPUT
-          echo "$CHANGED_FILES" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
-      - name: Enforce version bump
-        run: |
-          CHANGED="${{ steps.diff.outputs.CHANGED_FILES }}"
-
-          # Sanity check: only enforce if Rust files actually changed
-          if ! echo "$CHANGED" | grep -q "\.rs"; then
-            echo "No Rust changes detected"
-            exit 0
+          # sort -V puts the lower version first. If that is not OLD, NEW went backwards.
+          if [ "$(printf '%s\n%s\n' "$OLD" "$NEW" | sort -V | head -n1)" != "$OLD" ]; then
+            fail "Version went backwards: $OLD -> $NEW."
           fi
 
-          # Require Cargo.toml to be modified
-          if ! echo "$CHANGED" | grep -q "Cargo.toml"; then
-            echo "Rust files changed but Cargo.toml not updated"
-            exit 1
-          fi
-
-          # Compare version values
-          OLD_VERSION=$(git show ${{ steps.base.outputs.sha }}:Cargo.toml | grep '^version' | head -1)
-          NEW_VERSION=$(grep '^version' Cargo.toml | head -1)
-
-          if [ "$OLD_VERSION" = "$NEW_VERSION" ]; then
-            echo "Cargo.toml version not bumped"
-            exit 1
-          fi
-
-          echo "Version bump detected"
+          echo "Version bump: $OLD -> $NEW"
+          echo "### Version bump: \`$OLD\` → \`$NEW\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,4 +100,37 @@ jobs:
             echo "| Format | ${{ steps.fmt.outcome }} | yes |"
             echo
             echo "All checks are enforced: build, tests, clippy and format."
+            echo "The Docker image is built by the separate \`docker-build\` job."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Builds the image without pushing, so a broken Dockerfile fails the pull
+  # request. Previously nothing built it before merge - `docker-publish.yml`
+  # only fires on push to main - so the publish job was the first thing that
+  # would notice, by which point the break was already on main.
+  #
+  # Separate job rather than a step in build-and-test: it runs in parallel and
+  # shows up as its own check. No registry credentials are involved; this never
+  # pushes.
+  docker-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # No `--target`, so this builds the final `publish` stage - the same thing
+      # docker-publish.yml builds and ships.
+      - name: Build image
+        run: docker build --platform linux/amd64 -t redis-tui:ci .
+
+      - name: Image summary
+        run: |
+          {
+            echo "### Docker image"
+            echo
+            echo "Built, not pushed."
+            echo
+            echo '```'
+            docker image ls redis-tui:ci --format '{{.Repository}}:{{.Tag}}  {{.Size}}'
+            echo '```'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "redis-tui"
-version = "1.3.3"
+version = "1.3.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "redis-tui"
-version = "1.3.5"
+version = "1.3.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "redis-tui"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "redis-tui"
-version = "1.3.4"
+version = "1.3.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-tui"
-version = "1.3.4"
+version = "1.3.5"
 edition = "2021"
 description = "A Redis TUI client inspired by Redis Insight"
 license = "BSD-3-Clause"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-tui"
-version = "1.3.5"
+version = "1.3.4"
 edition = "2021"
 description = "A Redis TUI client inspired by Redis Insight"
 license = "BSD-3-Clause"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-tui"
-version = "1.3.3"
+version = "1.3.5"
 edition = "2021"
 description = "A Redis TUI client inspired by Redis Insight"
 license = "BSD-3-Clause"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-tui"
-version = "1.3.4"
+version = "1.3.3"
 edition = "2021"
 description = "A Redis TUI client inspired by Redis Insight"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Two gaps, both of which let a broken thing reach `main` before anything noticed.

## 1. The Dockerfile was never built before merge

`ci.yml` has no Docker step, and `docker-publish.yml` only fires on push to `main`. So the publish job was the first thing that would catch a broken Dockerfile — *after* it was already merged. That is the same failure shape as the last two days of work.

Adds a **`docker-build` job to `ci.yml`**: builds the image, does not push. Runs in parallel with `build-and-test`, appears as its own check, needs no registry credentials. No `--target`, so it builds the same final `publish` stage that actually ships.

## 2. The version check was weaker than it looked

| Problem | Before | Now |
| --- | --- | --- |
| Downgrades | `[ "$OLD" = "$NEW" ]` — **1.3.3 → 1.3.2 passed** | strict increase via `sort -V` |
| Docs-only PRs | skipped via `paths:` filter | no path filter — every merge publishes, so every merge bumps |
| `push` trigger | diffed `origin/main` against itself, always passed vacuously | dropped; the gate only means anything pre-merge |
| Comparison base | PR's recorded base SHA | tip of the base branch, so a stale PR fails once main moves ahead |
| Version parsing | `grep '^version' \| head -1` — reads a `[dependencies.foo]` block sitting above `[package]` | awk scoped to `[package]` |
| `.rs` detection | `grep -q "\.rs"` also matched `.rst` | moot, file-type gate removed |

`1.9.0 → 1.10.0` is correctly a bump, not a downgrade — that's why it's `sort -V` and not string comparison.

## Verification

The comparison logic was written as a standalone script and run against a case table **before** it went near a runner:

```
PASS  patch bump                   1.3.4 -> 1.3.5
PASS  minor bump                   1.3.4 -> 1.4.0
PASS  major bump                   1.3.4 -> 2.0.0
PASS  10 > 9, not string order     1.9.0 -> 1.10.0
PASS  unchanged                    rejected
PASS  downgrade                    rejected   <- the old check PASSED this
PASS  minor downgrade              rejected
PASS  major downgrade              rejected
PASS  malformed new / malformed old / empty new / empty old   rejected
PASS  prerelease rejected (X.Y.Z only)
```

Version extraction was tested separately against a manifest with a `[dependencies.foo]` block **above** `[package]` — the case the old `grep | head -1` gets wrong.

Both workflows: YAML parsed, every `run:` block `bash -n` clean, and the Docker build run locally with the exact command the job uses (12.8 MB image).

I'll also confirm the negative case on this PR — temporarily drop the bump, watch the check actually fail, then restore it. A gate that has never failed isn't a gate.

## Two things worth knowing

**Pre-release versions are now rejected outright** (`1.3.5-rc1` fails). `sort -V`'s ordering for them isn't obvious enough to rely on silently. Easy to add later if you want them.

**A docs-only change still needs a bump, even though the image is byte-identical.** The Dockerfile only copies `Cargo.toml`, `Cargo.lock*` and `src/`, so README edits don't change the artifact. That's the cost of the simple invariant you picked: every merge → unique version → `:VERSION` never overwritten, `:latest` always equals the newest `:VERSION`.
