### PR TITLE
Validate hosts file entries and bound the startup retry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "redis-tui"
-version = "1.3.5"
+version = "1.3.6"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-tui"
-version = "1.3.5"
+version = "1.3.6"
 edition = "2021"
 description = "A Redis TUI client inspired by Redis Insight"
 license = "BSD-3-Clause"

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -34,6 +34,8 @@ redis-tui [OPTIONS]
 | `--hosts-file <PATH>` | Path to hosts file for multi-host mode | None |
 | `--rate-history <MINUTES>` | Rolling window for the ingestion rate chart | `20` |
 | `--rate-avg-window <SECONDS>` | Sliding average window for the plotted rate line | `2` |
+| `--connect-retries <N>` | Retry attempts for a multi-host entry that is not up yet | `5` |
+| `--connect-timeout <SECONDS>` | Socket timeout per connection attempt in multi-host mode | `3` |
 
 ### Examples
 
@@ -76,6 +78,27 @@ redis://:password@10.0.0.5:6379/0
 ```
 
 Run with: `redis-tui --hosts-file hosts.txt`
+
+Every entry is validated before any connection is attempted, using the same URL
+parser the client itself uses. If any line is unparseable the run stops and lists
+all of them at once, with physical line numbers, so one run tells you everything
+to fix:
+
+```
+Error: Hosts file 'hosts.txt' has 2 invalid entries:
+  line 3: localhost:6379
+    Redis URL did not parse - InvalidClientConfig - did you mean redis://localhost:6379 ?
+  line 7: !!! junk
+    Redis URL did not parse - InvalidClientConfig
+```
+
+**TLS is not supported.** This build declares `redis = "1.0"` with no TLS
+feature, so a `rediss://` entry is rejected at parse time rather than failing
+later at connect.
+
+A host that parses but is not up yet is retried `--connect-retries` times, each
+attempt bounded by `--connect-timeout`. Hosts that never come up are reported and
+the session continues without them; if none come up at all, the run fails.
 
 In multi-host mode, keys from all hosts are aggregated into a single list. If the same key exists on multiple hosts, a collision warning is displayed when selecting it. The status bar shows which host each key belongs to.
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ redis-tui --hosts-file hosts.txt
 
 # Widen the ingestion rate chart to an hour, averaged over 5s
 redis-tui --rate-history 60 --rate-avg-window 5
+
+# Wait longer for multi-host entries that are still booting
+redis-tui --hosts-file hosts.txt --connect-retries 10 --connect-timeout 5
 ```
 
 See [MANUAL.md](MANUAL.md#command-line-options) for the full flag reference.

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,14 @@ struct Args {
     /// Sliding window for the plotted ingestion rate line (seconds)
     #[arg(long, default_value_t = 2, value_parser = clap::value_parser!(u64).range(1..))]
     rate_avg_window: u64,
+
+    /// Retry attempts for a multi-host entry that is not up yet
+    #[arg(long, default_value_t = 5, value_parser = clap::value_parser!(u32).range(0..))]
+    connect_retries: u32,
+
+    /// Socket timeout per connection attempt in multi-host mode (seconds)
+    #[arg(long, default_value_t = 3, value_parser = clap::value_parser!(u64).range(1..))]
+    connect_timeout: u64,
 }
 
 impl Args {
@@ -84,11 +92,32 @@ fn parse_hosts_file(path: &str) -> Result<Vec<(String, String)>> {
         .with_context(|| format!("Failed to read hosts file: {}", path))?;
 
     let mut hosts = Vec::new();
+    let mut problems: Vec<String> = Vec::new();
+
     for (i, line) in content.lines().enumerate() {
+        // Physical line number, so blanks and comments above a bad entry do not
+        // shift what gets reported back to the user.
+        let lineno = i + 1;
         let trimmed = line.trim();
         if trimmed.is_empty() || trimmed.starts_with('#') {
             continue;
         }
+
+        // Validate with the same parser `RedisClient::connect` uses, rather than
+        // a hand-rolled check that could drift from what redis-rs accepts. An
+        // entry that fails here can never connect, so it must not reach the
+        // retry loop in `MultiRedisClient::from_urls`.
+        if let Err(e) = redis::Client::open(trimmed) {
+            problems.push(format!(
+                "  line {}: {}\n    {}{}",
+                lineno,
+                trimmed,
+                e,
+                scheme_hint(trimmed)
+            ));
+            continue;
+        }
+
         // Use the host:port portion as a label, or fallback to line number
         let label = trimmed
             .strip_prefix("redis://")
@@ -101,8 +130,22 @@ fn parse_hosts_file(path: &str) -> Result<Vec<(String, String)>> {
                     s.to_string()
                 }
             })
-            .unwrap_or_else(|| format!("host-{}", i + 1));
+            .unwrap_or_else(|| format!("host-{}", lineno));
         hosts.push((label, trimmed.to_string()));
+    }
+
+    if !problems.is_empty() {
+        anyhow::bail!(
+            "Hosts file '{}' has {} invalid {}:\n{}",
+            path,
+            problems.len(),
+            if problems.len() == 1 {
+                "entry"
+            } else {
+                "entries"
+            },
+            problems.join("\n")
+        );
     }
 
     if hosts.is_empty() {
@@ -112,6 +155,22 @@ fn parse_hosts_file(path: &str) -> Result<Vec<(String, String)>> {
     Ok(hosts)
 }
 
+/// Suggest the scheme-prefixed form when an entry looks like a bare `host:port`.
+/// That is the likeliest typo, and the raw redis-rs error for it does not say so.
+fn scheme_hint(entry: &str) -> String {
+    if entry.contains("://") {
+        return String::new();
+    }
+    match entry.split_once(':') {
+        Some((host, port))
+            if !host.is_empty() && !port.is_empty() && port.chars().all(|c| c.is_ascii_digit()) =>
+        {
+            format!(" - did you mean redis://{} ?", entry)
+        }
+        _ => String::new(),
+    }
+}
+
 fn main() -> Result<()> {
     let args = Args::parse();
 
@@ -119,7 +178,11 @@ fn main() -> Result<()> {
     let mut client = if let Some(ref hosts_path) = args.hosts_file {
         let hosts = parse_hosts_file(hosts_path)?;
         eprintln!("Connecting to {} hosts...", hosts.len());
-        MultiRedisClient::from_urls(&hosts)?
+        MultiRedisClient::from_urls(
+            &hosts,
+            args.connect_retries,
+            Duration::from_secs(args.connect_timeout),
+        )?
     } else {
         let url = args.redis_url();
         MultiRedisClient::from_single(&url)
@@ -1576,5 +1639,119 @@ mod tests {
             "{}",
             app.status_message
         );
+    }
+
+    // ─── parse_hosts_file ────────────────────────────────────
+
+    /// Write `content` to a temp file and parse it. Returns the parse result so a
+    /// test can assert on either the hosts or the error text.
+    fn parse_hosts_str(content: &str) -> Result<Vec<(String, String)>> {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!(
+            "redis-tui-hosts-test-{}-{:?}.txt",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::write(&path, content).unwrap();
+        let result = parse_hosts_file(path.to_str().unwrap());
+        let _ = std::fs::remove_file(&path);
+        result
+    }
+
+    #[test]
+    fn parse_hosts_accepts_a_valid_file_with_comments_and_blanks() {
+        let hosts = parse_hosts_str(
+            "# leading comment\n\nredis://127.0.0.1:6379/0\n\n# another\nredis://127.0.0.1:6380/1\n",
+        )
+        .expect("valid file should parse");
+        assert_eq!(hosts.len(), 2);
+        assert_eq!(hosts[0].1, "redis://127.0.0.1:6379/0");
+        assert_eq!(hosts[1].1, "redis://127.0.0.1:6380/1");
+    }
+
+    /// This build has no TLS: Cargo.toml declares `redis = "1.0"` with no TLS
+    /// feature, so redis-rs refuses a `rediss://` URL outright. Reporting that at
+    /// parse time is the point - previously the entry was accepted, then spent the
+    /// whole retry budget failing to connect before being silently dropped.
+    #[test]
+    fn parse_hosts_rejects_rediss_because_tls_is_not_compiled_in() {
+        let err = parse_hosts_str("rediss://example.com:6380/0\n")
+            .expect_err("this build has no TLS support");
+        let msg = err.to_string();
+        assert!(msg.contains("line 1"), "should name the line: {}", msg);
+        assert!(
+            msg.to_lowercase().contains("tls"),
+            "should say why, mentioning TLS: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn parse_hosts_rejects_bare_host_port_with_a_scheme_hint() {
+        let err = parse_hosts_str("localhost:6379\n").expect_err("bare host:port is not a URL");
+        let msg = err.to_string();
+        assert!(msg.contains("line 1"), "should name the line: {}", msg);
+        assert!(
+            msg.contains("localhost:6379"),
+            "should quote the entry: {}",
+            msg
+        );
+        assert!(
+            msg.contains("redis://localhost:6379"),
+            "should suggest the scheme-prefixed form: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn parse_hosts_rejects_a_url_with_no_host() {
+        let err = parse_hosts_str("redis://\n").expect_err("no host is not usable");
+        assert!(err.to_string().contains("line 1"), "{}", err);
+    }
+
+    #[test]
+    fn parse_hosts_rejects_outright_garbage() {
+        let err = parse_hosts_str("!!! not a url at all\n").expect_err("garbage is not a URL");
+        assert!(err.to_string().contains("line 1"), "{}", err);
+    }
+
+    #[test]
+    fn parse_hosts_reports_every_bad_line_not_just_the_first() {
+        let err = parse_hosts_str("localhost:6379\nredis://127.0.0.1:6379\nalso-bad:1\n")
+            .expect_err("two bad lines");
+        let msg = err.to_string();
+        assert!(msg.contains("localhost:6379"), "first bad entry: {}", msg);
+        assert!(msg.contains("also-bad:1"), "second bad entry: {}", msg);
+    }
+
+    #[test]
+    fn parse_hosts_line_numbers_count_blanks_and_comments() {
+        // The bad entry is on physical line 4; blanks and comments above it must
+        // not shift the number that gets reported.
+        let err = parse_hosts_str("# comment\n\n\nbad-entry:1\n").expect_err("bad entry");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("line 4"),
+            "should report physical line 4, got: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn parse_hosts_rejects_a_file_with_no_entries() {
+        let err = parse_hosts_str("# only a comment\n\n").expect_err("nothing usable");
+        assert!(err.to_string().contains("no valid URLs"), "{}", err);
+    }
+
+    #[test]
+    fn parse_hosts_label_strips_scheme_auth_and_db() {
+        let hosts = parse_hosts_str("redis://:secret@10.0.0.5:6379/2\n").unwrap();
+        assert_eq!(hosts[0].0, "10.0.0.5:6379");
+    }
+
+    #[test]
+    fn parse_hosts_label_for_a_url_without_auth() {
+        let hosts = parse_hosts_str("redis://127.0.0.1:6379/0\n").unwrap();
+        assert_eq!(hosts[0].0, "127.0.0.1:6379");
     }
 }

--- a/src/redis_client.rs
+++ b/src/redis_client.rs
@@ -43,6 +43,10 @@ pub struct RedisClient {
 /// Returns 0 when the URL carries no usable database component. Query strings and
 /// fragments are stripped first, so `redis://host/3?timeout=5` yields 3 rather than
 /// silently falling back to 0, and a trailing slash (`redis://host/3/`) is tolerated.
+/// Socket timeout used by `RedisClient::connect`. Multi-host startup overrides
+/// this via `connect_with_timeout` so its retry budget stays bounded.
+const DEFAULT_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 fn parse_db_from_url(url: &str) -> i64 {
     // Strip `?query` and `#fragment` before looking at the path.
     let trimmed = url.split(['?', '#']).next().unwrap_or(url);
@@ -89,10 +93,17 @@ fn validate_ttl(ttl: i64, key: &str) -> Result<()> {
 
 impl RedisClient {
     pub fn connect(url: &str) -> Result<Self> {
+        Self::connect_with_timeout(url, DEFAULT_CONNECT_TIMEOUT)
+    }
+
+    /// Connect with an explicit socket timeout. `from_urls` uses this so the
+    /// startup retry budget is actually bounded: with the fixed 10s timeout, a
+    /// host that black-holes packets cost 10s per attempt on top of the sleep.
+    pub fn connect_with_timeout(url: &str, timeout: std::time::Duration) -> Result<Self> {
         let client = redis::Client::open(url)
             .with_context(|| format!("Failed to create Redis client for {}", url))?;
         let connection = client
-            .get_connection_with_timeout(std::time::Duration::from_secs(10))
+            .get_connection_with_timeout(timeout)
             .with_context(|| format!("Failed to connect to {}", url))?;
 
         // Parse db number from URL (e.g., redis://host:port/3)
@@ -551,17 +562,25 @@ impl MultiRedisClient {
         })
     }
 
-    /// Create from multiple URLs with retry logic for hosts that aren't ready yet.
-    pub fn from_urls(urls: &[(String, String)]) -> Result<Self> {
+    /// Create from multiple URLs, retrying hosts that aren't up yet.
+    ///
+    /// `max_retries` and `connect_timeout` are caller-supplied so startup cannot
+    /// stall indefinitely. Entries here are already known to be well-formed -
+    /// `parse_hosts_file` rejects unparseable URLs before this is reached - so
+    /// every retry is against a host that could plausibly come up.
+    pub fn from_urls(
+        urls: &[(String, String)],
+        max_retries: u32,
+        connect_timeout: std::time::Duration,
+    ) -> Result<Self> {
         let mut clients = Vec::new();
         let mut labels = Vec::new();
-        let max_retries = 15;
         let retry_delay = std::time::Duration::from_secs(2);
 
         // First pass: try to connect to all hosts, track failures
         let mut pending: Vec<(usize, String, String)> = Vec::new();
         for (i, (label, url)) in urls.iter().enumerate() {
-            match RedisClient::connect(url) {
+            match RedisClient::connect_with_timeout(url, connect_timeout) {
                 Ok(client) => {
                     clients.push(Some(client));
                     labels.push(label.clone());
@@ -575,7 +594,7 @@ impl MultiRedisClient {
         }
 
         // Retry failed connections
-        let mut attempt = 0;
+        let mut attempt: u32 = 0;
         while !pending.is_empty() && attempt < max_retries {
             attempt += 1;
             eprintln!(
@@ -587,7 +606,7 @@ impl MultiRedisClient {
             std::thread::sleep(retry_delay);
 
             pending.retain(|(i, label, url)| {
-                match RedisClient::connect(url) {
+                match RedisClient::connect_with_timeout(url, connect_timeout) {
                     Ok(client) => {
                         eprintln!("  Connected to {}", label);
                         clients[*i] = Some(client);
@@ -613,9 +632,12 @@ impl MultiRedisClient {
 
         if !failed.is_empty() {
             eprintln!(
-                "Warning: could not connect to {} host(s): {}",
+                "Warning: {} host(s) never came up and are absent from this session: {}",
                 failed.len(),
                 failed.join(", ")
+            );
+            eprintln!(
+                "         Their keys will not appear. Raise --connect-retries or --connect-timeout if they were merely slow to start."
             );
         }
 
@@ -1177,5 +1199,32 @@ mod tests {
     #[test]
     fn db_parses_with_empty_path() {
         assert_eq!(parse_db_from_url("redis://127.0.0.1:6379/"), 0);
+    }
+
+    /// A host that is well-formed but not listening must not hold startup for the
+    /// old 15 x (10s connect + 2s sleep) budget. Uses a port the OS just handed
+    /// back and released, so the connection is refused immediately and what this
+    /// measures is the retry budget rather than network latency.
+    #[test]
+    fn from_urls_gives_up_on_an_unreachable_host_quickly() {
+        let port = match free_port() {
+            Some(p) => p,
+            None => return,
+        };
+        let urls = vec![("dead".to_string(), format!("redis://127.0.0.1:{}", port))];
+
+        let start = std::time::Instant::now();
+        let result = MultiRedisClient::from_urls(&urls, 2, std::time::Duration::from_secs(1));
+        let elapsed = start.elapsed();
+
+        assert!(
+            result.is_err(),
+            "no host connected, so this must be an error"
+        );
+        assert!(
+            elapsed < std::time::Duration::from_secs(10),
+            "gave up after {:?}; the retry budget is not being honoured",
+            elapsed
+        );
     }
 }


### PR DESCRIPTION
Closes #29. Substantially addresses #11 (see the correction below before closing it).

## What was wrong

`parse_hosts_file` did **no validation at all** — every non-blank, non-comment line was pushed through verbatim as a URL. `localhost:6379` with no scheme, or outright garbage, was accepted.

The entry then reached `MultiRedisClient::from_urls`, which could not distinguish *"malformed, will never work"* from *"host is still booting"*, and retried it **15 times at 2s apiece**. The host was then dropped with a terse warning and the TUI started without it — with nothing on screen indicating a host was missing.

Measured rather than assumed. A test against a closed port:

```
before:  gave up after 30.007s
after:   4.00s
```

## Validation

Entries are validated with **`redis::Client::open`** — the same parser `RedisClient::connect` uses, rather than a hand-rolled check that would drift from what redis-rs actually accepts. Every bad line is collected and reported at once, with **physical** line numbers so blanks and comments above an entry don't shift what the user is told:

```
Error: Hosts file 'hosts.txt' has 3 invalid entries:
  line 3: localhost:6379
    Redis URL did not parse - InvalidClientConfig - did you mean redis://localhost:6379 ?
  line 6: !!! junk
    Redis URL did not parse - InvalidClientConfig
  line 7: rediss://secure.example.com:6380
    can't connect with TLS, the feature is not enabled - InvalidClientConfig
```

That's real output, from lines 3, 6 and 7 of a file whose lines 1, 2 and 5 are a comment and two blanks.

## A finding: this build has no TLS

That third line isn't a design choice, it's something the tests surfaced. `Cargo.toml` declares `redis = "1.0"` with **no TLS feature**, so `rediss://` cannot work in this build at all. Previously such an entry was accepted, spent the entire retry budget failing to connect, and then silently vanished. It's now refused immediately, and `MANUAL.md` states the limitation. Enabling TLS is a separate decision — it would also complicate the static musl build in the Dockerfile.

## Bounded retry

`--connect-retries` (default **5**) and `--connect-timeout` (default **3s**). Worst case drops from 15 × (10 + 2) = **180s** to 5 × (3 + 2) = **25s**.

`RedisClient::connect` keeps its signature — 12 call sites, 8 of them in tests — and delegates to a new `connect_with_timeout` that only `from_urls` uses.

The warning for a host that never came up now names the absent hosts, says their keys won't appear, and points at the flags to raise.

## Correction to #11 before it gets closed

The issue claims there is *"no user-visible feedback in the TUI"*. That isn't right: `from_urls` is called at `main.rs:122`, **before** `enable_raw_mode` at `main.rs:145`, so the retry lines print to a normal terminal and are perfectly visible. The defect was the *length* of the block, not its invisibility — and against a host that black-holes packets it was nearer **180s** than the 30s the issue states, because each attempt also carried the 10s connect timeout.

## Testing

Tests first, each watched fail for the right reason. `parse_hosts_file` had **zero** tests; it now has ten:

- valid file with interleaved comments and blanks
- bare `host:port` rejected **with** the scheme hint
- `redis://` with no host
- outright garbage
- several bad lines reported together
- line numbers surviving leading blanks and comments
- file with no entries
- label derivation, with and without auth
- `rediss://` rejected for TLS

The retry test asserts elapsed time against a closed port and was confirmed to fail at 30.007s before the fix — a timing assertion that never failed would prove nothing.

Locally: 109 unit tests, 7 live-Redis tests, `clippy -D warnings`, `fmt --check`, and the `docker-build` job's exact command — all pass. Bumped to 1.3.6.
