### PR TITLE
Publish only after CI passes, and serialise publishes (#99)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,10 +1,31 @@
 name: Build and Push Docker Image
 
+# Publish only after CI has actually passed for the commit being published.
+#
+# This previously fired directly on `push: branches: [main]` with no `needs:`
+# and no `workflow_run:`, so it ran *in parallel* with the main-push CI run
+# rather than after it. A merge that broke the build still published `:latest`
+# and `:<version>` to Harbor, and the publish was frequently the thing that
+# finished first. Branch protection now keeps most breakage off main, but an
+# admin bypass or a merge that goes red only on main would still have shipped.
+#
+# The coupling is by workflow *name*: renaming the CI workflow silently stops
+# publishing. Keep the name here in step with `name:` in ci.yml.
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
+
+# One publish at a time, and queued rather than cancelled. Two merges landing
+# close together used to race their `:latest` pushes with no ordering at all, so
+# `:latest` could end up on the older image. Queueing means the later commit
+# pushes last and wins; cancelling in progress could instead abandon a push
+# part-way through.
+concurrency:
+  group: docker-publish
+  cancel-in-progress: false
 
 env:
   REGISTRY: adregistry.fnal.gov
@@ -12,6 +33,17 @@ env:
 
 jobs:
   build-and-push:
+    # `workflow_run` fires on *completion*, whatever the outcome, so the
+    # conclusion has to be tested explicitly - without this the gate would be
+    # decorative. Restricted to CI runs triggered by a push as well, so that
+    # manually re-running CI on main does not republish; dispatch this workflow
+    # directly for that. A manual dispatch here carries no `workflow_run`
+    # context and is allowed through on its own terms.
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || (github.event.workflow_run.conclusion == 'success'
+          && github.event.workflow_run.event == 'push')
+
     # A cloud runner is enough. An earlier revision of this workflow moved the
     # job to the self-hosted `adlinux3` on the theory that Harbor only grants
     # push from inside the FNAL network - that was wrong. Publishing was failing
@@ -23,8 +55,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # For `workflow_run`, GITHUB_SHA and GITHUB_REF point at the tip of the
+      # default branch rather than at the commit that triggered CI. Publishing
+      # what CI actually tested means taking both from the event payload.
+      - name: Resolve the commit being published
+        id: src
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+            echo "branch=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
+            echo "branch=${{ github.event.workflow_run.head_branch }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.src.outputs.sha }}
 
       - name: Read version from Cargo.toml
         id: version
@@ -36,9 +84,9 @@ jobs:
         id: tags
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          if [ "${{ github.ref_name }}" != "main" ]; then
+          if [ "${{ steps.src.outputs.branch }}" != "main" ]; then
             # Branch-suffixed tags keep dispatch runs off :latest.
-            BRANCH=$(echo "${{ github.ref_name }}" | sed 's|/|-|g')
+            BRANCH=$(echo "${{ steps.src.outputs.branch }}" | sed 's|/|-|g')
             echo "primary=${IMAGE}:${VERSION}-${BRANCH}" >> "$GITHUB_OUTPUT"
             echo "moving=${IMAGE}:latest-${BRANCH}" >> "$GITHUB_OUTPUT"
           else
@@ -83,6 +131,7 @@ jobs:
             echo "- \`$PRIMARY\`"
             echo "- \`$MOVING\`"
             echo "- Digest: \`${DIGEST_REF:-unknown}\`"
+            echo "- Commit: \`${{ steps.src.outputs.sha }}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Docker logout

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "redis-tui"
-version = "1.3.7"
+version = "1.3.8"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-tui"
-version = "1.3.7"
+version = "1.3.8"
 edition = "2021"
 description = "A Redis TUI client inspired by Redis Insight"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Closes #99 (code half). The settings half is already live — see the bottom.

`docker-publish.yml` fired on `push: branches: [main]` with **no `needs:`, no `workflow_run:` and no `concurrency:`**, so it ran *in parallel* with the main-push CI run rather than after it — and was frequently the thing that finished first. A merge that broke the build still published `:latest` and `:<version>` to Harbor.

You can see it in the run list from the last merge (#103): `Build and Push Docker Image` and `CI` both started at the same moment on the same push.

## What changed

**Gated on CI.** Triggers on `workflow_run` against the CI workflow, filtered to `main`. The job tests `conclusion == 'success'` explicitly — `workflow_run` fires on *completion* whatever the outcome, so without that check the gate would be decorative.

It also requires `workflow_run.event == 'push'`, so manually re-running CI on main doesn't republish. Dispatch this workflow directly if that's what you want; `workflow_dispatch` carries no `workflow_run` context and is allowed through on its own terms.

**Two details that forces.** `workflow_run` sets `GITHUB_SHA`/`GITHUB_REF` to the tip of the default branch, *not* the commit that triggered CI. So:

- the checkout now takes its ref from `workflow_run.head_sha` — otherwise a publish could ship something other than what CI tested
- the tag step reads the branch from the same payload, since `github.ref_name` no longer identifies the branch being published

The published commit is now also recorded in the job summary.

**Serialised publishes.** `concurrency: docker-publish` with `cancel-in-progress: false`. Two merges landing close together previously raced their `:latest` pushes with no ordering, so `:latest` could settle on the *older* image. Queueing means the later commit pushes last and wins; cancelling could instead abandon a push part-way through.

## Testing note, and a caveat worth reading

**This cannot be exercised from a branch.** `workflow_run` always uses the workflow file on the default branch, so the gate only takes effect once merged — and the first main-push CI run after that is what actually proves it. Worth watching that run rather than assuming.

Verified locally: all three workflows parse, and `workflows: [CI]` matches `name: CI` in `ci.yml`. That coupling is by *name*, which is a real failure mode — renaming the CI workflow silently stops publishing — so it's called out in a comment next to the trigger.

Gates on this branch: build, 109 unit tests, 10 live-Redis tests, clippy, fmt all green.

## Unrelated thing this turned up

The live tests failed the first time I ran them here — 5 of 10 — and it had nothing to do with this change. `TestRedis` spawns `redis-server` with the repo root as its working directory and never sets `--dir` or disables persistence, so every throwaway server loads whatever `dump.rdb` is sitting there. `start-dev.sh`'s instance writes exactly that file to the repo root, so the live tests break for anyone who has run the dev script.

Filed separately rather than folded in here. CI is unaffected (clean checkout).

## What's left on #99

Branch protection is **already active** and requires `build-and-test`, `docker-build`, `check` and `audit`. `delete_branch_on_merge`, Dependabot alerts and security updates are on.

**Secret scanning and push protection cannot be enabled from here** — the API refuses with `blocked by an enterprise policy`. That needs an org owner, so it's tracked as its own issue rather than left hanging on #99.
