### PR TITLE
Stop the dev servers persisting, and isolate the test data directory (#106)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "redis-tui"
-version = "1.3.8"
+version = "1.3.9"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-tui"
-version = "1.3.8"
+version = "1.3.9"
 edition = "2021"
 description = "A Redis TUI client inspired by Redis Insight"
 license = "BSD-3-Clause"

--- a/src/redis_client.rs
+++ b/src/redis_client.rs
@@ -845,6 +845,7 @@ mod tests {
     use super::*;
 
     use std::net::TcpListener;
+    use std::path::PathBuf;
     use std::process::{Child, Command, Stdio};
 
     /// Ask the OS for a currently-free port, then release it so redis-server can bind.
@@ -865,6 +866,7 @@ mod tests {
     struct TestRedis {
         child: Child,
         port: u16,
+        dir: PathBuf,
     }
 
     impl TestRedis {
@@ -887,9 +889,28 @@ mod tests {
         }
 
         fn try_start(port: u16) -> Result<Self, String> {
+            // Every server gets its own empty directory, and it is not optional.
+            // `--save ""` below stops this server *writing* a dump, but redis
+            // *loads* `dump.rdb` from `dir` at startup regardless, and `dir`
+            // defaults to the working directory - the package root under cargo.
+            // So any dump.rdb lying there is adopted as the server's starting
+            // dataset, and every key-listing assertion in these tests then sees
+            // somebody else's data. `start-dev.sh` used to leave exactly such a
+            // file behind, which made these tests fail on a developer machine
+            // and pass in CI, where the checkout is clean.
+            let dir = std::env::temp_dir().join(format!(
+                "redis-tui-test-{}-{}",
+                std::process::id(),
+                port
+            ));
+            std::fs::create_dir_all(&dir)
+                .map_err(|e| format!("could not create data directory {}: {e}", dir.display()))?;
+            let dir_arg = dir.to_string_lossy().into_owned();
+
             let child = Command::new("redis-server")
                 .args([
                     "--port", &port.to_string(),
+                    "--dir", &dir_arg,
                     "--save", "",
                     "--appendonly", "no",
                     "--loglevel", "warning",
@@ -898,10 +919,11 @@ mod tests {
                 .stderr(Stdio::null())
                 .spawn()
                 .map_err(|e| {
+                    let _ = std::fs::remove_dir_all(&dir);
                     format!("could not spawn redis-server ({e}); it must be installed to run --ignored tests")
                 })?;
 
-            let mut server = TestRedis { child, port };
+            let mut server = TestRedis { child, port, dir };
             let url = server.url();
 
             for _ in 0..100 {
@@ -938,6 +960,9 @@ mod tests {
         fn drop(&mut self) {
             let _ = self.child.kill();
             let _ = self.child.wait();
+            // Only after the child is reaped, so nothing can recreate the
+            // directory between the removal and the process actually exiting.
+            let _ = std::fs::remove_dir_all(&self.dir);
         }
     }
 

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Both nodes run with persistence off (--save '' --appendonly no).
+# Without it redis writes dump.rdb into whatever directory it was launched
+# from, which is the repo root, and the live tests then adopt that file as
+# their starting dataset - `dir` defaults to the working directory and an
+# existing dump.rdb is loaded at boot whether or not saving is enabled.
+# This is throwaway fixture data that FLUSHALL rebuilds on every run, so
+# there is nothing here worth persisting.
 REDIS_PORT_1=6379
 REDIS_PORT_2=6380
 HOSTS_FILE="/tmp/redis-tui-hosts.txt"
@@ -26,7 +33,8 @@ if redis-cli -p "$REDIS_PORT_1" ping &>/dev/null; then
     echo "[*] Redis node 1 already running on port $REDIS_PORT_1"
 else
     echo "[*] Starting redis node 1 on port $REDIS_PORT_1..."
-    redis-server --port "$REDIS_PORT_1" --daemonize yes --loglevel warning
+    redis-server --port "$REDIS_PORT_1" --daemonize yes --loglevel warning \
+        --save '' --appendonly no
     sleep 1
     if ! redis-cli -p "$REDIS_PORT_1" ping &>/dev/null; then
         echo "ERROR: Failed to start redis node 1"
@@ -40,7 +48,8 @@ if redis-cli -p "$REDIS_PORT_2" ping &>/dev/null; then
     echo "[*] Redis node 2 already running on port $REDIS_PORT_2"
 else
     echo "[*] Starting redis node 2 on port $REDIS_PORT_2..."
-    redis-server --port "$REDIS_PORT_2" --daemonize yes --loglevel warning
+    redis-server --port "$REDIS_PORT_2" --daemonize yes --loglevel warning \
+        --save '' --appendonly no
     sleep 1
     if ! redis-cli -p "$REDIS_PORT_2" ping &>/dev/null; then
         echo "ERROR: Failed to start redis node 2"


### PR DESCRIPTION
Closes #106.

The live tests failed 5 of 10 on a developer machine and passed in CI. The cause was outside the tests entirely: `start-dev.sh` leaves a `dump.rdb` in the repo root, and every throwaway server in the harness adopted it as its starting dataset.

```
---- refresh_reloads_the_value_when_the_selected_key_changes stdout ----
assertion `left == right` failed
  left: ["aab", "hash:metrics", "list:events", "shared:collision_test",
         "stream:int8_1000", "zset:temperatures", ...]   # the dev fixture data
 right: ["aab"]
```

Two independent changes, because there are two independent faults.

## 1. The dev servers no longer persist

Both nodes now run with `--save '' --appendonly no`, so no dump is written at all. Measured:

```
=== OLD flags (as start-dev.sh was) ===
-rw-rw-r-- 1 rsantucc rsantucc 103 /tmp/devprobe/dump.rdb
  -> dump.rdb WAS written
=== NEW flags (--save '' --appendonly no) ===
  -> no dump.rdb written
  files left in dir: 0
```

This is throwaway fixture data that `FLUSHALL` rebuilds on every run, so there was never anything worth persisting.

## 2. The test servers get their own data directory

`TestRedis` now passes `--dir` pointing at a per-server temp directory, removed in `Drop` after the child is reaped.

**This is the part that actually makes the tests hermetic, and the reason is worth being precise about** — because #106 as I originally filed it got this detail wrong. The harness *already* passed `--save ""` and `--appendonly no`. Those are not sufficient: they stop the server **writing**, but redis **loads** `dump.rdb` from `dir` at startup regardless, and `dir` defaults to the working directory — the package root under cargo.

Measured directly, same flags both times:

```
dir containing the dev dump  ->  DBSIZE: 17
empty dir                    ->  DBSIZE: 0
```

## Why both

Either change alone fixes the reported symptom. Both are here because they cover different things:

- #1 only governs *our* dev script.
- #2 makes the tests independent of whatever is in the working directory — including the `dump.rdb` already sitting in the tree of anyone who has run the old script, which #1 does nothing about.

## Verification

Restored the offending `dump.rdb` to the repo root and re-ran the live tests:

```
test result: ok. 10 passed; 0 failed; 0 ignored; 109 filtered out
```

Previously 5 of those 10 failed under exactly that condition. No temp directories left behind afterwards.

All gates green: build (debug + release), 109 unit tests, 10 live-Redis tests, clippy, fmt. `bash -n start-dev.sh` clean.

## Merge ordering

Versioned **1.3.9**, deliberately leaving 1.3.8 to #105, so the two don't collide on the version-bump gate. **Merge #105 first.** If this one lands first, #105 will need a re-bump to 1.3.10 before its `check` passes.
