### PR TITLE
Replace the connection flags with --hosts and add environment configuration (#109)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,12 +30,13 @@ docker run -it --rm --network host redis-tui
 
 ## Architecture
 
-Four source modules in `src/`, single binary:
+Five source modules in `src/`, single binary:
 
 - **`main.rs`** — CLI parsing, terminal setup/teardown (raw mode, mouse capture, bracketed paste), event loop (50ms tick), background thread lifecycle (`StreamListener`, `SignalGenerator`), input routing by `InputMode`, mouse event handling (click-to-select, scroll per-pane, shift-bypass)
 - **`app.rs`** — All application state (`App` struct), Redis data loading, plot/FFT computation, edit operations, multi-key slot management with per-key data types, ingestion rate tracking (`RateTracker`)
 - **`data.rs`** — Binary data encoding/decoding (`DataType` × `Endianness` → `Vec<f64>`), hex formatting, value parsing. `is_binary()` only checks for control chars — do NOT use it to gate binary display for `_`-prefixed stream fields or when a numeric DataType is selected
-- **`redis_client.rs`** — `RedisClient` (single host) and `MultiRedisClient` (aggregated multi-host with collision detection), all Redis commands
+- **`hosts.rs`** — Turns each `--hosts` entry (`host`, `host:port`, or a full `redis://` URL) into a `redis::ConnectionInfo` plus a credential-free display label. Reports every bad entry at once
+- **`redis_client.rs`** — `RedisClient` (one host, carrying its `ConnectionInfo` and label) and `MultiRedisClient` (aggregated multi-host with collision detection), all Redis commands
 - **`ui.rs`** — ratatui rendering: layout (key list / value view / data plot), charts (signal + FFT + ingestion rate), popups (filter, edit, help, confirm, signal gen, plot settings), crosshair drawing, per-key Y-axis labels and hover values
 
 ### Data Flow
@@ -145,3 +146,4 @@ There is no `tests/` directory: this is a binary-only crate with no lib target, 
 - Never include Co-Authored-By lines in commits
 - Confirmation popups carry their target in `ConfirmAction`; never re-read the live selection when the user answers, since mouse input is not gated by `InputMode`
 - `apply_plot_settings()` handles all field counts (X limits + per-slot Y limits) — no field count checks
+- One flag names where to connect. Connection info is built as `redis::ConnectionInfo`, never by formatting a URL string — a credential interpolated into a URL breaks on `/ # ? @`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "redis-tui"
-version = "1.3.10"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-tui"
-version = "1.3.10"
+version = "2.0.0"
 edition = "2021"
 description = "A Redis TUI client inspired by Redis Insight"
 license = "BSD-3-Clause"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "BSD-3-Clause"
 ratatui = "0.30.0"
 crossterm = "0.29"
 redis = "1.0"
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 anyhow = "1"
 serde_json = "1"
 rustfft = "6"

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -26,7 +26,7 @@ redis-tui [OPTIONS]
 
 | Flag | Environment | Description | Default |
 |------|-------------|-------------|---------|
-| `--hosts <HOSTS>...` | `REDIS_TUI_HOSTS` | Hosts: `host`, `host:port`, or a full `redis://` URL. Repeatable. | `127.0.0.1:6379` |
+| `--hosts <HOSTS>...` | `REDIS_TUI_HOSTS` | Hosts: `host`, `host:port`, or a full `redis://` URL. Repeatable. Accepts `--host` as a deprecated alias. | `127.0.0.1:6379` |
 | `--username <USERNAME>` | `REDIS_TUI_USERNAME` | Username for hosts without their own | None |
 | `--password <PASSWORD>` | `REDIS_TUI_PASSWORD` | Password for hosts without their own | None |
 | `-d, --db <DB>` | `REDIS_TUI_DB` | Database for hosts without their own | `0` |
@@ -62,11 +62,17 @@ REDIS_TUI_HOSTS="db1 db2:6380" redis-tui
 
 ### Migrating from 1.x
 
-`--host`, `--port`, `--url` and `--hosts-file` were removed in 2.0.0. One flag
-now names where to connect.
+`--port`, `--url` and `--hosts-file` were removed in 2.0.0. One flag now names
+where to connect.
+
+`--host` survives as a deprecated alias for `--hosts`, so a 1.x command that
+named a single host on the default port keeps working unchanged. Because
+`--port` is gone, anything that set a port must move to the `host:port` form.
+New commands should use `--hosts`; the alias is not shown in `--help`.
 
 | 1.x | 2.0 |
 |-----|-----|
+| `--host db1` | works as-is; `--hosts db1` preferred |
 | `--host db1 --port 6380` | `--hosts db1:6380` |
 | `--url redis://:pw@db1/2` | `--hosts redis://:pw@db1/2` |
 | `--hosts-file hosts.txt` | `--hosts $(grep -v '^#' hosts.txt \| tr '\n' ' ')` |

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -24,18 +24,19 @@
 redis-tui [OPTIONS]
 ```
 
-| Flag | Description | Default |
-|------|-------------|---------|
-| `--host <HOST>` | Redis host | `127.0.0.1` |
-| `-p, --port <PORT>` | Redis port | `6379` |
-| `--password <PASSWORD>` | Redis password | None |
-| `-d, --db <DB>` | Redis database number | `0` |
-| `-u, --url <URL>` | Full Redis URL (overrides host/port/password/db) | None |
-| `--hosts-file <PATH>` | Path to hosts file for multi-host mode | None |
-| `--rate-history <MINUTES>` | Rolling window for the ingestion rate chart | `20` |
-| `--rate-avg-window <SECONDS>` | Sliding average window for the plotted rate line | `2` |
-| `--connect-retries <N>` | Retry attempts for a multi-host entry that is not up yet | `5` |
-| `--connect-timeout <SECONDS>` | Socket timeout per connection attempt in multi-host mode | `3` |
+| Flag | Environment | Description | Default |
+|------|-------------|-------------|---------|
+| `--hosts <HOSTS>...` | `REDIS_TUI_HOSTS` | Hosts: `host`, `host:port`, or a full `redis://` URL. Repeatable. | `127.0.0.1:6379` |
+| `--username <USERNAME>` | `REDIS_TUI_USERNAME` | Username for hosts without their own | None |
+| `--password <PASSWORD>` | `REDIS_TUI_PASSWORD` | Password for hosts without their own | None |
+| `-d, --db <DB>` | `REDIS_TUI_DB` | Database for hosts without their own | `0` |
+| `--rate-history <MINUTES>` | `REDIS_TUI_RATE_HISTORY` | Rolling window for the rate chart | `20` |
+| `--rate-avg-window <SECONDS>` | `REDIS_TUI_RATE_AVG_WINDOW` | Sliding average for the plotted rate line | `2` |
+| `--connect-retries <N>` | `REDIS_TUI_CONNECT_RETRIES` | Retries for a host that is not up yet | `5` |
+| `--connect-timeout <SECONDS>` | `REDIS_TUI_CONNECT_TIMEOUT` | Socket timeout per attempt | `3` |
+
+A flag beats its environment variable, which beats the default. `--help` prints
+each variable next to its flag.
 
 ### Examples
 
@@ -44,52 +45,70 @@ redis-tui [OPTIONS]
 redis-tui
 
 # Remote host with custom port
-redis-tui --host 10.0.0.5 --port 6380
+redis-tui --hosts 10.0.0.5:6380
 
 # Authenticated connection
-redis-tui --host myredis --password secret
+redis-tui --hosts myredis --password secret
 
 # Full URL with database selection
-redis-tui --url redis://:password@host:6379/2
+redis-tui --hosts redis://:password@host:6379/2
 
-# Multi-host aggregation
-redis-tui --hosts-file hosts.txt
+# Several hosts aggregated into one view
+redis-tui --hosts db1 db2:6380 redis://svc:pw@db3/2
+
+# The same, from the environment
+REDIS_TUI_HOSTS="db1 db2:6380" redis-tui
 ```
+
+### Migrating from 1.x
+
+`--host`, `--port`, `--url` and `--hosts-file` were removed in 2.0.0. One flag
+now names where to connect.
+
+| 1.x | 2.0 |
+|-----|-----|
+| `--host db1 --port 6380` | `--hosts db1:6380` |
+| `--url redis://:pw@db1/2` | `--hosts redis://:pw@db1/2` |
+| `--hosts-file hosts.txt` | `--hosts $(grep -v '^#' hosts.txt \| tr '\n' ' ')` |
+
+Entries mix freely, and `--username`/`--password`/`--db` apply to any entry that
+does not carry its own:
+
+    redis-tui --hosts db1 db2:6380 redis://svc:pw@db3/2 \
+              --username admin --password s3cret --db 1
 
 ---
 
 ## Connecting to Redis
 
-### Single Host
+### Host Entries
 
-By default, redis-tui connects to `127.0.0.1:6379`. Use `--host`, `--port`, and `--password` flags, or provide a full URL with `--url`.
+`--hosts` takes one or more entries. It is repeatable, and several entries may
+follow it at once. Each entry is one of three forms:
 
-The URL format is: `redis://[:password@]host:port[/db]`
+| Form | Example | Port | Credentials and database |
+|------|---------|------|--------------------------|
+| Bare host | `db1` | `6379` | From `--username`/`--password`/`--db` |
+| `host:port` | `db1:6380` | As given | From `--username`/`--password`/`--db` |
+| Full URL | `redis://svc:pw@db1:6380/2` | As given | Self-contained; the flags are ignored |
 
-### Multi-Host Mode
+A URL entry carries everything it needs, so hosts with different credentials can
+sit side by side in one list.
 
-Create a hosts file with one Redis URL per line. Lines starting with `#` are comments. Blank lines are skipped.
+Connection details are built programmatically rather than by formatting a URL
+string, so a password containing `/`, `#`, `?` or `@` connects verbatim instead
+of being mangled.
 
-```
-# hosts.txt
-redis://127.0.0.1:6379/0
-redis://127.0.0.1:6380/0
-redis://:password@10.0.0.5:6379/0
-```
-
-Run with: `redis-tui --hosts-file hosts.txt`
-
-Every entry is validated before any connection is attempted, using the same URL
-parser the client itself uses. If any line is unparseable the run stops and lists
-all of them at once, with physical line numbers, so one run tells you everything
-to fix:
+Every entry is validated before any connection is attempted. If any entry is
+unparseable the run stops and lists all of them at once, so one run tells you
+everything to fix:
 
 ```
-Error: Hosts file 'hosts.txt' has 2 invalid entries:
-  line 3: localhost:6379
-    Redis URL did not parse - InvalidClientConfig - did you mean redis://localhost:6379 ?
-  line 7: !!! junk
-    Redis URL did not parse - InvalidClientConfig
+Error: 2 invalid host entries:
+  localhost:70000
+    invalid port '70000'
+  !!!
+    '!!!' is not a valid host
 ```
 
 **TLS is not supported.** This build declares `redis = "1.0"` with no TLS
@@ -434,7 +453,8 @@ Press `a` to reset to auto-fit limits after manual panning/zooming.
 
 ## Multi-Host Mode
 
-When using `--hosts-file`, redis-tui connects to all listed hosts and aggregates their keys into a single view.
+When `--hosts` names more than one host, redis-tui connects to all of them and
+aggregates their keys into a single view.
 
 ### Key Collision Handling
 
@@ -444,4 +464,4 @@ If the same key name exists on multiple hosts:
 
 ### Host Labels
 
-Host labels are derived from the URL (the `host:port` portion, with auth stripped). These appear in the status bar and collision warnings to identify which host a key belongs to.
+Host labels are derived from the entry (the `host:port` portion, with auth stripped). These appear in the status bar and collision warnings to identify which host a key belongs to.

--- a/README.md
+++ b/README.md
@@ -47,13 +47,22 @@ To build it yourself instead:
 
 ```bash
 docker build -t redis-tui .
-docker run -it --rm redis-tui --host <redis-host>
+docker run -it --rm redis-tui --hosts <redis-host>
 ```
 
 To connect to Redis running on the host machine:
 
 ```bash
 docker run -it --rm --network host redis-tui
+```
+
+Passing the connection through the environment avoids a long argument list:
+
+```bash
+docker run -it --rm --network host \
+  -e REDIS_TUI_HOSTS="db1 db2:6380" \
+  -e REDIS_TUI_DB=1 \
+  adregistry.fnal.gov/instrumentation/redis-tui
 ```
 
 ### Dev environment
@@ -73,19 +82,26 @@ Requires `redis-server`, `redis-cli`, and `python3` to be installed.
 redis-tui
 
 # Connect to a remote host
-redis-tui --host 10.0.0.5 --port 6380
+redis-tui --hosts 10.0.0.5:6380
 
 # Connect with a full URL
-redis-tui --url redis://:password@host:6379/2
+redis-tui --hosts redis://:password@host:6379/2
 
-# Connect to multiple hosts
-redis-tui --hosts-file hosts.txt
+# Connect to several hosts at once, mixing the forms
+redis-tui --hosts db1 db2:6380 redis://svc:pw@db3/2
 
 # Widen the ingestion rate chart to an hour, averaged over 5s
 redis-tui --rate-history 60 --rate-avg-window 5
 
-# Wait longer for multi-host entries that are still booting
-redis-tui --hosts-file hosts.txt --connect-retries 10 --connect-timeout 5
+# Wait longer for hosts that are still booting
+redis-tui --hosts db1 db2 --connect-retries 10 --connect-timeout 5
+```
+
+Every option can be set from the environment instead, with the flag winning if
+both are given:
+
+```bash
+REDIS_TUI_HOSTS="db1 db2:6380" REDIS_TUI_DB=1 redis-tui
 ```
 
 See [MANUAL.md](MANUAL.md#command-line-options) for the full flag reference.

--- a/docs/superpowers/plans/2026-08-31-hosts-flag-and-env-config.md
+++ b/docs/superpowers/plans/2026-08-31-hosts-flag-and-env-config.md
@@ -1,0 +1,1143 @@
+# `--hosts` and Environment Configuration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `--host`/`--port`/`--url`/`--hosts-file` with a single repeatable `--hosts` list, add `--username`, and make every option settable from the environment as `REDIS_TUI_*`.
+
+**Architecture:** A new `src/hosts.rs` turns each `--hosts` entry into a `redis::ConnectionInfo` built programmatically, never by formatting a URL string — which is what structurally fixes #42. `RedisClient` and `MultiRedisClient` are changed to carry `ConnectionInfo` plus a display label instead of a URL string, which collapses the single-host and multi-host connection paths into one. `clap`'s `env` feature supplies the environment layer with CLI > env > default precedence for free.
+
+**Tech Stack:** Rust 1.97 (pinned in `rust-toolchain.toml`), edition 2021, clap 4.6 (derive + env), redis 1.6, anyhow 1.
+
+**Spec:** https://github.com/fermi-ad/redis-tui/issues/109 — the design, the decisions and their rationale live on the issue and in its comments. Read it alongside this plan.
+
+## Global Constraints
+
+- **This is a breaking change. Target version `2.0.0`.** Set in Task 4, not before — every PR must bump `Cargo.toml`, and CI compares against the live tip of `main`.
+- **Every commit must leave CI green.** CI runs `cargo build --locked --all-targets`, `cargo build --locked --release`, `cargo test --locked`, `cargo test --locked -- --ignored`, `cargo clippy --locked --all-targets -- -D warnings`, `cargo fmt --check`. The live tests need `redis-server` on `PATH`.
+- **`clippy -D warnings` includes `dead_code`.** An item added but not yet called fails the build on the binary target even when tests use it. This is why the task order below wires each piece in as it lands rather than building bottom-up.
+- **Never include Claude Code attribution or `Co-Authored-By` lines in commits.** (`CLAUDE.md`)
+- **Never push directly to `main`.** Work on a feature branch; `main` requires a PR and the checks `build-and-test`, `docker-build`, `check`, `audit`.
+- **TLS is not compiled in.** `rediss://` must be rejected at parse time with a clear message, never passed to a connect attempt.
+- **Version tests use `env!("CARGO_PKG_VERSION")`** — never hardcode version strings.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `src/hosts.rs` | **New.** Parses one `--hosts` entry into a `HostEntry { label, info }`. Owns the shorthand grammar, the defaults, the rejections and their messages. All parsing tests live here. |
+| `src/redis_client.rs` | `RedisClient` holds a `ConnectionInfo` and a label instead of a URL string. `MultiRedisClient::from_entries` replaces `from_urls` and `from_single`. `parse_db_from_url` is deleted — the db comes from `ConnectionInfo`. |
+| `src/main.rs` | `Args` gains `--hosts`/`--username` and `env` attributes, loses `--host`/`--port`/`--url`/`--hosts-file`. `parse_hosts_file`, `scheme_hint` and `Args::redis_url` are deleted. Background threads take a `ConnectionInfo`. |
+| `README.md`, `MANUAL.md`, `CLAUDE.md` | Documentation of the new surface. |
+
+`src/hosts.rs` is a new fifth module. `CLAUDE.md` currently says "Four source modules in `src/`" and is updated in Task 4. The parser is ~130 lines with ~200 lines of tests; putting it in `main.rs` would push that file past 2,000 lines for logic that has one clear responsibility and no coupling to the event loop.
+
+---
+
+### Task 1: `src/hosts.rs` — the entry parser
+
+Lands the parser and immediately routes the existing `--hosts-file` through it, so nothing is dead and the tree stays green. `--hosts-file` still works after this task; it is removed in Task 3.
+
+**Files:**
+- Create: `src/hosts.rs`
+- Modify: `src/main.rs` — add `mod hosts;`, rewrite `parse_hosts_file` to delegate, delete `scheme_hint`
+- Test: `src/hosts.rs` (`#[cfg(test)] mod tests` at the bottom, matching the codebase convention)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `pub const DEFAULT_PORT: u16 = 6379`
+  - `pub struct HostDefaults { pub username: Option<String>, pub password: Option<String>, pub db: u16 }` — derives `Debug, Clone, Default`
+  - `pub struct HostEntry { pub label: String, pub info: redis::ConnectionInfo }` — derives `Debug, Clone`
+  - `pub fn parse_host_entry(entry: &str, defaults: &HostDefaults) -> Result<HostEntry, String>`
+  - `pub fn parse_host_entries(entries: &[String], defaults: &HostDefaults) -> anyhow::Result<Vec<HostEntry>>`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/hosts.rs` containing only the test module for now:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn defaults() -> HostDefaults {
+        HostDefaults {
+            username: Some("admin".to_string()),
+            password: Some("s3cret".to_string()),
+            db: 1,
+        }
+    }
+
+    fn tcp(entry: &HostEntry) -> (String, u16) {
+        match entry.info.addr() {
+            redis::ConnectionAddr::Tcp(h, p) => (h.clone(), *p),
+            other => panic!("expected Tcp, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn bare_host_takes_the_default_port_and_defaults() {
+        let e = parse_host_entry("db1", &defaults()).unwrap();
+        assert_eq!(tcp(&e), ("db1".to_string(), 6379));
+        assert_eq!(e.info.redis_settings().db(), 1);
+        assert_eq!(e.info.redis_settings().username(), Some("admin"));
+        assert_eq!(e.info.redis_settings().password(), Some("s3cret"));
+        assert_eq!(e.label, "db1:6379");
+    }
+
+    #[test]
+    fn host_port_overrides_only_the_port() {
+        let e = parse_host_entry("db2:6380", &defaults()).unwrap();
+        assert_eq!(tcp(&e), ("db2".to_string(), 6380));
+        assert_eq!(e.info.redis_settings().db(), 1);
+        assert_eq!(e.label, "db2:6380");
+    }
+
+    #[test]
+    fn a_url_entry_is_self_contained_and_ignores_the_defaults() {
+        let e = parse_host_entry("redis://svc:pw@db3:6390/2", &defaults()).unwrap();
+        assert_eq!(tcp(&e), ("db3".to_string(), 6390));
+        assert_eq!(e.info.redis_settings().db(), 2);
+        assert_eq!(e.info.redis_settings().username(), Some("svc"));
+        assert_eq!(e.info.redis_settings().password(), Some("pw"));
+    }
+
+    // This is #42. Building the URL by string concatenation mangled these
+    // characters; building ConnectionInfo directly never encodes them at all.
+    #[test]
+    fn a_password_with_url_metacharacters_survives_verbatim() {
+        let d = HostDefaults {
+            username: None,
+            password: Some("p/a:s#s?w@rd".to_string()),
+            db: 0,
+        };
+        let e = parse_host_entry("db1", &d).unwrap();
+        assert_eq!(e.info.redis_settings().password(), Some("p/a:s#s?w@rd"));
+    }
+
+    #[test]
+    fn the_label_never_leaks_credentials() {
+        let e = parse_host_entry("redis://svc:hunter2@db3:6390/2", &defaults()).unwrap();
+        assert_eq!(e.label, "db3:6390");
+        assert!(!e.label.contains("hunter2"));
+    }
+
+    #[test]
+    fn rediss_is_rejected_because_tls_is_not_compiled_in() {
+        let err = parse_host_entry("rediss://db1:6379", &defaults()).unwrap_err();
+        assert!(err.to_lowercase().contains("tls"), "got: {}", err);
+    }
+
+    #[test]
+    fn an_invalid_port_is_rejected() {
+        let err = parse_host_entry("db1:notaport", &defaults()).unwrap_err();
+        assert!(err.contains("notaport"), "got: {}", err);
+    }
+
+    #[test]
+    fn port_zero_is_rejected() {
+        let err = parse_host_entry("db1:0", &defaults()).unwrap_err();
+        assert!(err.contains('0'), "got: {}", err);
+    }
+
+    #[test]
+    fn an_empty_entry_is_rejected() {
+        assert!(parse_host_entry("   ", &defaults()).is_err());
+    }
+
+    #[test]
+    fn a_url_with_no_host_is_rejected() {
+        assert!(parse_host_entry("redis://", &defaults()).is_err());
+    }
+
+    #[test]
+    fn outright_garbage_is_rejected() {
+        assert!(parse_host_entry("!!! not a host !!!", &defaults()).is_err());
+    }
+
+    #[test]
+    fn ipv6_shorthand_points_at_the_url_form() {
+        let err = parse_host_entry("::1", &defaults()).unwrap_err();
+        assert!(err.contains("redis://"), "got: {}", err);
+    }
+
+    #[test]
+    fn every_bad_entry_is_reported_not_just_the_first() {
+        let entries = vec![
+            "good1".to_string(),
+            "bad:one".to_string(),
+            "good2".to_string(),
+            "rediss://bad2".to_string(),
+        ];
+        let err = parse_host_entries(&entries, &defaults()).unwrap_err().to_string();
+        assert!(err.contains("bad:one"), "got: {}", err);
+        assert!(err.contains("rediss://bad2"), "got: {}", err);
+        assert!(err.contains('2'), "should say how many were bad: {}", err);
+    }
+
+    #[test]
+    fn an_empty_list_is_rejected() {
+        assert!(parse_host_entries(&[], &defaults()).is_err());
+    }
+
+    #[test]
+    fn a_valid_list_keeps_its_order() {
+        let entries = vec!["db1".to_string(), "db2:6380".to_string()];
+        let parsed = parse_host_entries(&entries, &defaults()).unwrap();
+        assert_eq!(
+            parsed.iter().map(|e| e.label.clone()).collect::<Vec<_>>(),
+            vec!["db1:6379".to_string(), "db2:6380".to_string()]
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test --locked hosts::`
+Expected: compile failure — `cannot find type HostDefaults`, `cannot find function parse_host_entry`. The module is not declared yet either.
+
+- [ ] **Step 3: Write the implementation**
+
+Prepend to `src/hosts.rs`, above the test module:
+
+```rust
+//! Parsing of `--hosts` entries into Redis connection info.
+//!
+//! An entry is either shorthand (`db1`, `db1:6380`) or a full Redis URL
+//! (`redis://user:pw@db1:6380/2`). Shorthand takes its port from
+//! `DEFAULT_PORT` and its credentials and database from the CLI defaults; a
+//! URL is self-contained and the defaults are not applied to it.
+//!
+//! The connection info is built programmatically rather than by formatting a
+//! URL string. That is deliberate: the previous `Args::redis_url` interpolated
+//! the password into a URL with `format!`, so a password containing `/`, `#`,
+//! `?` or `@` produced something unparseable (#42). Nothing here ever encodes
+//! a credential, so nothing can mis-encode one.
+
+use anyhow::{bail, Result};
+use redis::{ConnectionAddr, ConnectionInfo, IntoConnectionInfo, RedisConnectionInfo};
+
+/// Port used by an entry that does not name one.
+pub const DEFAULT_PORT: u16 = 6379;
+
+/// Applied to shorthand entries. A URL entry supplies its own and ignores these.
+#[derive(Debug, Clone, Default)]
+pub struct HostDefaults {
+    pub username: Option<String>,
+    pub password: Option<String>,
+    pub db: u16,
+}
+
+/// A resolved endpoint: how to display it, and how to connect to it.
+#[derive(Debug, Clone)]
+pub struct HostEntry {
+    /// `host:port`, shown in the host column and in status messages. Never
+    /// contains credentials.
+    pub label: String,
+    pub info: ConnectionInfo,
+}
+
+/// Parse one entry. The error is a bare phrase; `parse_host_entries` supplies
+/// the surrounding context so a single message reads well in a list.
+pub fn parse_host_entry(entry: &str, defaults: &HostDefaults) -> Result<HostEntry, String> {
+    let entry = entry.trim();
+    if entry.is_empty() {
+        return Err("empty entry".to_string());
+    }
+
+    let info = if entry.contains("://") {
+        // Validated by redis-rs's own parser, so what parses here and what
+        // connects later cannot disagree.
+        entry
+            .into_connection_info()
+            .map_err(|e| e.to_string())?
+    } else {
+        let (host, port) = parse_shorthand(entry)?;
+        let mut redis = RedisConnectionInfo::default().set_db(i64::from(defaults.db));
+        if let Some(u) = &defaults.username {
+            redis = redis.set_username(u);
+        }
+        if let Some(p) = &defaults.password {
+            redis = redis.set_password(p);
+        }
+        ConnectionAddr::Tcp(host, port)
+            .into_connection_info()
+            .map_err(|e| e.to_string())?
+            .set_redis_settings(redis)
+    };
+
+    // Deriving the label from the parsed address rather than from the input
+    // string means credentials cannot reach it by construction.
+    let label = match info.addr() {
+        ConnectionAddr::Tcp(host, port) => format!("{}:{}", host, port),
+        ConnectionAddr::TcpTls { .. } => {
+            return Err(
+                "TLS is not compiled in, so a rediss:// entry can never connect".to_string(),
+            )
+        }
+        _ => return Err("only TCP redis:// entries are supported".to_string()),
+    };
+
+    Ok(HostEntry { label, info })
+}
+
+/// Parse every entry, reporting all the bad ones at once.
+pub fn parse_host_entries(entries: &[String], defaults: &HostDefaults) -> Result<Vec<HostEntry>> {
+    if entries.is_empty() {
+        bail!("No hosts given");
+    }
+
+    let mut parsed = Vec::with_capacity(entries.len());
+    let mut problems: Vec<String> = Vec::new();
+
+    for entry in entries {
+        match parse_host_entry(entry, defaults) {
+            Ok(host) => parsed.push(host),
+            Err(e) => problems.push(format!("  {}\n    {}", entry.trim(), e)),
+        }
+    }
+
+    if !problems.is_empty() {
+        bail!(
+            "{} invalid host {}:\n{}",
+            problems.len(),
+            if problems.len() == 1 { "entry" } else { "entries" },
+            problems.join("\n")
+        );
+    }
+
+    Ok(parsed)
+}
+
+/// `host` or `host:port`.
+///
+/// A bare IPv6 address is refused rather than guessed at: `::1` would split on
+/// its last colon into a host of `:` and a port of `1`, which is wrong and
+/// would fail confusingly at connect time instead of here.
+fn parse_shorthand(entry: &str) -> Result<(String, u16), String> {
+    if entry.starts_with('[') || entry.matches(':').count() > 1 {
+        return Err(format!(
+            "looks like an IPv6 address - write it as a URL, e.g. redis://[{}]:{}",
+            entry.trim_start_matches('[').trim_end_matches(']'),
+            DEFAULT_PORT
+        ));
+    }
+
+    match entry.split_once(':') {
+        None => Ok((entry.to_string(), DEFAULT_PORT)),
+        Some((host, port)) => {
+            if host.is_empty() {
+                return Err("no host before ':'".to_string());
+            }
+            let parsed: u16 = port
+                .parse()
+                .map_err(|_| format!("invalid port '{}'", port))?;
+            if parsed == 0 {
+                return Err("port must not be 0".to_string());
+            }
+            Ok((host.to_string(), parsed))
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Declare the module and route `parse_hosts_file` through it**
+
+In `src/main.rs`, add alongside the other `mod` declarations:
+
+```rust
+mod hosts;
+```
+
+Replace the body of `parse_hosts_file` (currently `src/main.rs:90`) so the file reader keeps its per-line reporting but delegates every entry to the new parser, and delete `scheme_hint` (currently `src/main.rs:160`) — its "did you mean redis://…?" advice is wrong now that bare `host:port` is valid input:
+
+```rust
+/// Read a hosts file, one entry per line, `#` for comments.
+///
+/// Temporary: `--hosts-file` is removed in favour of `--hosts` in a later
+/// commit. Until then this keeps working, delegating each line to the shared
+/// entry parser so there is only one grammar.
+fn parse_hosts_file(path: &str, defaults: &hosts::HostDefaults) -> Result<Vec<hosts::HostEntry>> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read hosts file: {}", path))?;
+
+    let mut entries = Vec::new();
+    let mut problems: Vec<String> = Vec::new();
+
+    for (i, line) in content.lines().enumerate() {
+        let lineno = i + 1;
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        match hosts::parse_host_entry(trimmed, defaults) {
+            Ok(entry) => entries.push(entry),
+            Err(e) => problems.push(format!("  line {}: {}\n    {}", lineno, trimmed, e)),
+        }
+    }
+
+    if !problems.is_empty() {
+        anyhow::bail!(
+            "Hosts file '{}' has {} invalid {}:\n{}",
+            path,
+            problems.len(),
+            if problems.len() == 1 { "entry" } else { "entries" },
+            problems.join("\n")
+        );
+    }
+
+    if entries.is_empty() {
+        anyhow::bail!("Hosts file '{}' contains no valid URLs", path);
+    }
+
+    Ok(entries)
+}
+```
+
+Update the single call site (currently `src/main.rs:179`) to build defaults from the existing flags and to convert the entries back to the `(label, url)` pairs `from_urls` still expects:
+
+```rust
+    let mut client = if let Some(ref hosts_path) = args.hosts_file {
+        let defaults = hosts::HostDefaults {
+            username: None,
+            password: args.password.clone(),
+            db: args.db,
+        };
+        let entries = parse_hosts_file(hosts_path, &defaults)?;
+        eprintln!("Connecting to {} hosts...", entries.len());
+        let urls: Vec<(String, String)> = entries
+            .iter()
+            .map(|e| (e.label.clone(), format!("redis://{}", e.label)))
+            .collect();
+        MultiRedisClient::from_urls(
+            &urls,
+            args.connect_retries,
+            Duration::from_secs(args.connect_timeout),
+        )?
+    } else {
+        let url = args.redis_url();
+        MultiRedisClient::from_single(&url)
+            .with_context(|| format!("Failed to connect to Redis at {}", url))?
+    };
+```
+
+Then delete the `parse_hosts_file` tests in `src/main.rs` that assert on messages this parser no longer produces — `parse_hosts_rejects_bare_host_port_with_a_scheme_hint` (bare `host:port` is now valid) and the two label tests `parse_hosts_label_strips_scheme_auth_and_db` and `parse_hosts_label_for_a_url_without_auth` (labels are asserted in `hosts.rs` now). Keep the rest; update `parse_hosts_str` to pass `&hosts::HostDefaults::default()`.
+
+> This step is deliberately transitional and its awkwardness — rebuilding URLs from labels — is temporary. Task 2 removes it by making the client take `HostEntry` directly. It exists so this task can land green and be reviewed on its own.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test --locked && cargo test --locked -- --ignored`
+Expected: PASS. The `hosts::tests` module adds 15 tests.
+
+- [ ] **Step 6: Verify the whole gate**
+
+Run: `cargo clippy --locked --all-targets -- -D warnings && cargo fmt --check`
+Expected: clean, no `dead_code`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/hosts.rs src/main.rs
+git commit -m "Add a shared host-entry parser building ConnectionInfo directly
+
+An entry is shorthand (db1, db1:6380) or a full URL. Connection info is built
+programmatically rather than by formatting a URL string, so a password
+containing / # ? or @ is carried verbatim instead of being interpolated into
+something unparseable - the defect in #42.
+
+parse_hosts_file keeps its per-line reporting but delegates each line to the
+parser, so there is one grammar rather than two. scheme_hint is deleted: it
+advised 'did you mean redis://host:port?' for input that is now valid."
+```
+
+---
+
+### Task 2: `ConnectionInfo` through the client, one connection path
+
+**Files:**
+- Modify: `src/redis_client.rs` — `RedisClient` fields, `connect_with_info`, `from_entries`, `info_for_key`; delete `parse_db_from_url`, `from_single`, `from_urls`, `url_for_key`, `DEFAULT_CONNECT_TIMEOUT`
+- Modify: `src/main.rs` — call `from_entries`; background threads take `ConnectionInfo`
+- Test: `src/redis_client.rs`
+
+**Interfaces:**
+- Consumes: `hosts::HostEntry`, `hosts::HostDefaults`, `hosts::parse_host_entry` from Task 1.
+- Produces:
+  - `RedisClient { connection: redis::Connection, pub label: String, pub db: i64 }`
+  - `pub fn RedisClient::connect_with_info(info: redis::ConnectionInfo, label: &str, timeout: std::time::Duration) -> Result<Self>`
+  - `pub fn RedisClient::connect(url: &str) -> Result<Self>` — retained for tests and background threads; delegates via `into_connection_info()` with a 10s timeout
+  - `pub fn MultiRedisClient::from_entries(entries: &[hosts::HostEntry], max_retries: u32, connect_timeout: std::time::Duration) -> Result<Self>`
+  - `pub fn MultiRedisClient::info_for_key(&self, key: &str) -> redis::ConnectionInfo`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)] mod tests` in `src/redis_client.rs`:
+
+```rust
+    /// #42: a password containing URL metacharacters must actually authenticate.
+    /// Building a URL string mangled these; ConnectionInfo carries them verbatim.
+    #[test]
+    #[ignore = "requires redis-server; run with: cargo test -- --ignored"]
+    fn connects_with_a_password_containing_url_metacharacters() {
+        let server = TestRedis::start();
+        let password = "p/a:s#s?w@rd";
+
+        let mut admin = RedisClient::connect(&server.url()).unwrap();
+        redis::cmd("CONFIG")
+            .arg("SET")
+            .arg("requirepass")
+            .arg(password)
+            .exec(&mut admin.connection)
+            .unwrap();
+        drop(admin);
+
+        let defaults = crate::hosts::HostDefaults {
+            username: None,
+            password: Some(password.to_string()),
+            db: 0,
+        };
+        let entry =
+            crate::hosts::parse_host_entry(&format!("127.0.0.1:{}", server.port), &defaults)
+                .unwrap();
+
+        let mut client = RedisClient::connect_with_info(
+            entry.info,
+            &entry.label,
+            std::time::Duration::from_secs(3),
+        )
+        .expect("a password with / : # ? @ in it must authenticate");
+
+        let pong: String = redis::cmd("PING").query(&mut client.connection).unwrap();
+        assert_eq!(pong, "PONG");
+    }
+
+    /// The db comes from the parsed connection info, not from re-parsing a URL.
+    #[test]
+    #[ignore = "requires redis-server; run with: cargo test -- --ignored"]
+    fn from_entries_reports_the_db_from_the_entry() {
+        let server = TestRedis::start();
+        let defaults = crate::hosts::HostDefaults {
+            username: None,
+            password: None,
+            db: 3,
+        };
+        let entry =
+            crate::hosts::parse_host_entry(&format!("127.0.0.1:{}", server.port), &defaults)
+                .unwrap();
+
+        let multi = MultiRedisClient::from_entries(
+            std::slice::from_ref(&entry),
+            0,
+            std::time::Duration::from_secs(3),
+        )
+        .unwrap();
+
+        assert_eq!(multi.db, 3);
+        assert_eq!(multi.host_count(), 1);
+    }
+```
+
+`TestRedis` needs its port readable by the test; if `port` is private, make it `pub(crate)` or add an accessor in this step.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test --locked -- --ignored connects_with_a_password`
+Expected: compile failure — `no function connect_with_info`, `no function from_entries`.
+
+- [ ] **Step 3: Change `RedisClient` to carry connection info**
+
+In `src/redis_client.rs`, replace the struct's `url` field with `label`, delete `parse_db_from_url` and its eight tests, delete `DEFAULT_CONNECT_TIMEOUT`, and replace `connect`/`connect_with_timeout`:
+
+```rust
+pub struct RedisClient {
+    connection: redis::Connection,
+    /// `host:port`. Display only, and never contains credentials.
+    pub label: String,
+    pub db: i64,
+}
+
+impl RedisClient {
+    /// Connect using a URL. Retained for the background threads and the live
+    /// tests, both of which have a URL and no defaults to apply.
+    pub fn connect(url: &str) -> Result<Self> {
+        let info = url
+            .into_connection_info()
+            .with_context(|| format!("Failed to parse Redis URL {}", url))?;
+        let label = match info.addr() {
+            redis::ConnectionAddr::Tcp(h, p) => format!("{}:{}", h, p),
+            _ => url.to_string(),
+        };
+        Self::connect_with_info(info, &label, std::time::Duration::from_secs(10))
+    }
+
+    /// Connect with an explicit socket timeout, so the startup retry budget is
+    /// actually bounded: a host that black-holes packets costs one timeout per
+    /// attempt on top of the sleep.
+    pub fn connect_with_info(
+        info: redis::ConnectionInfo,
+        label: &str,
+        timeout: std::time::Duration,
+    ) -> Result<Self> {
+        let db = info.redis_settings().db();
+        let client = redis::Client::open(info)
+            .with_context(|| format!("Failed to create Redis client for {}", label))?;
+        let connection = client
+            .get_connection_with_timeout(timeout)
+            .with_context(|| format!("Failed to connect to {}", label))?;
+
+        Ok(Self {
+            connection,
+            label: label.to_string(),
+            db,
+        })
+    }
+```
+
+Add `use redis::IntoConnectionInfo;` to the imports at the top of the file.
+
+- [ ] **Step 4: Replace `from_single` and `from_urls` with `from_entries`**
+
+Delete both, and add `from_entries` with the same retry structure `from_urls` had — first pass, bounded retries, then drop whatever never came up:
+
+```rust
+    /// Connect to every entry, retrying the ones that are not up yet.
+    ///
+    /// `max_retries` and `connect_timeout` are caller-supplied so startup
+    /// cannot stall indefinitely. Entries are already known to be well-formed:
+    /// `hosts::parse_host_entry` rejects unparseable ones before this is
+    /// reached, so every retry is against a host that could plausibly come up.
+    pub fn from_entries(
+        entries: &[crate::hosts::HostEntry],
+        max_retries: u32,
+        connect_timeout: std::time::Duration,
+    ) -> Result<Self> {
+        let mut clients: Vec<Option<RedisClient>> = Vec::new();
+        let mut labels: Vec<String> = Vec::new();
+        let retry_delay = std::time::Duration::from_secs(2);
+
+        let mut pending: Vec<usize> = Vec::new();
+        for (i, entry) in entries.iter().enumerate() {
+            labels.push(entry.label.clone());
+            match RedisClient::connect_with_info(
+                entry.info.clone(),
+                &entry.label,
+                connect_timeout,
+            ) {
+                Ok(client) => clients.push(Some(client)),
+                Err(_) => {
+                    clients.push(None);
+                    pending.push(i);
+                }
+            }
+        }
+
+        let mut attempt: u32 = 0;
+        while !pending.is_empty() && attempt < max_retries {
+            attempt += 1;
+            eprintln!(
+                "Retrying {} host(s) (attempt {}/{})...",
+                pending.len(),
+                attempt,
+                max_retries
+            );
+            std::thread::sleep(retry_delay);
+
+            pending.retain(|&i| {
+                match RedisClient::connect_with_info(
+                    entries[i].info.clone(),
+                    &entries[i].label,
+                    connect_timeout,
+                ) {
+                    Ok(client) => {
+                        eprintln!("  Connected to {}", entries[i].label);
+                        clients[i] = Some(client);
+                        false
+                    }
+                    Err(_) => true,
+                }
+            });
+        }
+
+        let mut final_clients = Vec::new();
+        let mut final_labels = Vec::new();
+        let mut failed = Vec::new();
+        for (i, opt) in clients.into_iter().enumerate() {
+            match opt {
+                Some(client) => {
+                    final_clients.push(client);
+                    final_labels.push(labels[i].clone());
+                }
+                None => failed.push(labels[i].clone()),
+            }
+        }
+
+        if !failed.is_empty() {
+            eprintln!(
+                "Warning: {} host(s) never came up and are absent from this session: {}",
+                failed.len(),
+                failed.join(", ")
+            );
+            eprintln!(
+                "         Their keys will not appear. Raise --connect-retries or --connect-timeout if they were merely slow to start."
+            );
+        }
+
+        if final_clients.is_empty() {
+            anyhow::bail!("Could not connect to any of the {} host(s) given", entries.len());
+        }
+
+        let db = final_clients[0].db;
+        Ok(Self {
+            labels: final_labels,
+            clients: final_clients,
+            key_owner: HashMap::new(),
+            collisions: Vec::new(),
+            db,
+        })
+    }
+
+    /// Connection info for the host owning `key`, for a background thread to
+    /// open its own connection with.
+    pub fn info_for_key(&self, key: &str) -> redis::ConnectionInfo {
+        let idx = self.key_owner.get(key).copied().unwrap_or(0);
+        self.clients[idx].connection_info()
+    }
+```
+
+`RedisClient` must be able to hand back its `ConnectionInfo`. Store it alongside the connection — add a `info: redis::ConnectionInfo` field set in `connect_with_info`, and:
+
+```rust
+    pub fn connection_info(&self) -> redis::ConnectionInfo {
+        self.info.clone()
+    }
+```
+
+Replace the two `&self.clients[..].url` reads (currently `src/redis_client.rs:829` and `:835`) with `.label`.
+
+- [ ] **Step 5: Wire `main.rs` to the new API**
+
+Replace the connection block so both branches produce `Vec<HostEntry>` and there is one connect call:
+
+```rust
+    let defaults = hosts::HostDefaults {
+        username: None,
+        password: args.password.clone(),
+        db: args.db,
+    };
+    let entries = if let Some(ref hosts_path) = args.hosts_file {
+        parse_hosts_file(hosts_path, &defaults)?
+    } else {
+        let entry = hosts::parse_host_entry(&format!("{}:{}", args.host, args.port), &defaults)
+            .map_err(|e| anyhow::anyhow!("{}", e))?;
+        vec![entry]
+    };
+    eprintln!("Connecting to {} host(s)...", entries.len());
+    let mut client = MultiRedisClient::from_entries(
+        &entries,
+        args.connect_retries,
+        Duration::from_secs(args.connect_timeout),
+    )?;
+```
+
+`Args::redis_url` and the `--url` flag are now unused — leave both in place until Task 3, but mark the flag's help text so nothing is silently misleading:
+
+```rust
+    /// Full Redis URL. Deprecated: pass it to --hosts instead.
+    #[arg(short, long)]
+    url: Option<String>,
+```
+
+If `redis_url` is now dead, delete it in this step rather than adding an `allow` — `clippy -D warnings` will fail otherwise.
+
+Change the two background-thread constructors to take a `ConnectionInfo`. In `StreamListener::start` (currently `src/main.rs:256`) and `SignalGenerator::start` (`:325`):
+
+```rust
+    fn start(
+        info: redis::ConnectionInfo,
+        label: &str,
+        key: &str,
+        last_id: &str,
+        db: i64,
+    ) -> Option<Self> {
+        let mut client =
+            RedisClient::connect_with_info(info, label, std::time::Duration::from_secs(10)).ok()?;
+```
+
+and update the two call sites (`:534` and `:614`) to pass `client.info_for_key(&k)` and the owning label instead of `client.url_for_key(&k)`.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `cargo test --locked && cargo test --locked -- --ignored`
+Expected: PASS, including the two new live tests. Live test count rises from 10 to 12.
+
+- [ ] **Step 7: Verify the whole gate**
+
+Run: `cargo clippy --locked --all-targets -- -D warnings && cargo fmt --check`
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/redis_client.rs src/main.rs
+git commit -m "Carry ConnectionInfo through the client and collapse to one connect path
+
+RedisClient holds parsed connection info and a host:port label instead of a URL
+string, so the database number comes from the parsed info rather than from
+re-parsing a URL - parse_db_from_url and its eight tests are deleted.
+
+from_single and from_urls become from_entries. There is now one connection path
+for one host and for many, which also means --connect-timeout applies to the
+single-host case; it previously went through RedisClient::connect and silently
+used a hardcoded 10s constant instead.
+
+Background threads take a ConnectionInfo from info_for_key rather than
+rebuilding a URL, so credentials never round-trip through a string."
+```
+
+---
+
+### Task 3: The new flag surface and the environment
+
+**Files:**
+- Modify: `Cargo.toml` — clap `env` feature
+- Modify: `src/main.rs` — `Args`, delete `parse_hosts_file` and `Args::redis_url`
+- Test: `src/main.rs`
+
+**Interfaces:**
+- Consumes: `hosts::parse_host_entries`, `MultiRedisClient::from_entries`.
+- Produces: `Args { hosts: Vec<String>, username: Option<String>, password: Option<String>, db: u16, rate_history: u64, rate_avg_window: u64, connect_retries: u32, connect_timeout: u64 }`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `#[cfg(test)] mod tests` in `src/main.rs`:
+
+```rust
+    // Environment variables are process-global and cargo runs tests as threads,
+    // so these drive the parser with an explicit argv rather than mutating the
+    // real environment, which would make them order-dependent.
+    #[test]
+    fn hosts_defaults_to_localhost() {
+        let a = Args::try_parse_from(["redis-tui"]).unwrap();
+        assert_eq!(a.hosts, vec!["127.0.0.1:6379".to_string()]);
+        assert_eq!(a.db, 0);
+        assert_eq!(a.username, None);
+    }
+
+    #[test]
+    fn hosts_accepts_several_space_separated_values() {
+        let a = Args::try_parse_from(["redis-tui", "--hosts", "db1", "db2:6380"]).unwrap();
+        assert_eq!(a.hosts, vec!["db1".to_string(), "db2:6380".to_string()]);
+    }
+
+    #[test]
+    fn hosts_is_repeatable() {
+        let a =
+            Args::try_parse_from(["redis-tui", "--hosts", "db1", "--hosts", "db2"]).unwrap();
+        assert_eq!(a.hosts, vec!["db1".to_string(), "db2".to_string()]);
+    }
+
+    #[test]
+    fn a_following_flag_is_not_swallowed_by_the_hosts_list() {
+        let a =
+            Args::try_parse_from(["redis-tui", "--hosts", "db1", "db2", "--db", "4"]).unwrap();
+        assert_eq!(a.hosts, vec!["db1".to_string(), "db2".to_string()]);
+        assert_eq!(a.db, 4);
+    }
+
+    #[test]
+    fn the_removed_flags_are_rejected() {
+        for flag in ["--host", "--port", "--url", "--hosts-file"] {
+            assert!(
+                Args::try_parse_from(["redis-tui", flag, "x"]).is_err(),
+                "{} should no longer be accepted",
+                flag
+            );
+        }
+    }
+
+    #[test]
+    fn username_and_password_are_accepted() {
+        let a = Args::try_parse_from([
+            "redis-tui", "--hosts", "db1", "--username", "admin", "--password", "s3cret",
+        ])
+        .unwrap();
+        assert_eq!(a.username.as_deref(), Some("admin"));
+        assert_eq!(a.password.as_deref(), Some("s3cret"));
+    }
+
+    #[test]
+    fn numeric_ranges_are_still_enforced() {
+        assert!(Args::try_parse_from(["redis-tui", "--connect-timeout", "0"]).is_err());
+        assert!(Args::try_parse_from(["redis-tui", "--rate-history", "0"]).is_err());
+        assert!(Args::try_parse_from(["redis-tui", "--rate-avg-window", "0"]).is_err());
+    }
+
+    #[test]
+    fn help_advertises_the_environment_variables() {
+        let help = Args::command().render_help().to_string();
+        for var in [
+            "REDIS_TUI_HOSTS",
+            "REDIS_TUI_USERNAME",
+            "REDIS_TUI_PASSWORD",
+            "REDIS_TUI_DB",
+            "REDIS_TUI_RATE_HISTORY",
+            "REDIS_TUI_RATE_AVG_WINDOW",
+            "REDIS_TUI_CONNECT_RETRIES",
+            "REDIS_TUI_CONNECT_TIMEOUT",
+        ] {
+            assert!(help.contains(var), "--help should mention {}", var);
+        }
+    }
+```
+
+Add `use clap::CommandFactory;` to that test module for `Args::command()`.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test --locked hosts_defaults_to_localhost the_removed_flags_are_rejected`
+Expected: FAIL — `--hosts` is not a recognised flag and `no field hosts on Args`.
+
+- [ ] **Step 3: Enable clap's `env` feature**
+
+In `Cargo.toml`:
+
+```toml
+clap = { version = "4", features = ["derive", "env"] }
+```
+
+- [ ] **Step 4: Replace the `Args` struct**
+
+In `src/main.rs`, replace the whole struct (currently `src/main.rs:32`) and delete `impl Args`'s `redis_url`:
+
+```rust
+#[derive(Parser, Debug)]
+#[command(
+    name = "redis-tui",
+    about = "A Redis TUI client inspired by Redis Insight"
+)]
+struct Args {
+    /// Redis hosts: `host`, `host:port`, or a full `redis://` URL.
+    /// Repeatable, and several may be given at once.
+    #[arg(
+        long,
+        num_args = 1..,
+        action = clap::ArgAction::Append,
+        value_delimiter = ' ',
+        default_value = "127.0.0.1:6379",
+        env = "REDIS_TUI_HOSTS"
+    )]
+    hosts: Vec<String>,
+
+    /// Username for hosts that do not carry their own
+    #[arg(long, env = "REDIS_TUI_USERNAME")]
+    username: Option<String>,
+
+    /// Password for hosts that do not carry their own
+    #[arg(long, env = "REDIS_TUI_PASSWORD")]
+    password: Option<String>,
+
+    /// Database number for hosts that do not carry their own
+    #[arg(short, long, default_value_t = 0, env = "REDIS_TUI_DB")]
+    db: u16,
+
+    /// Rolling window for ingestion rate chart history (minutes)
+    #[arg(long, default_value_t = 20, env = "REDIS_TUI_RATE_HISTORY",
+          value_parser = clap::value_parser!(u64).range(1..))]
+    rate_history: u64,
+
+    /// Sliding window for the plotted ingestion rate line (seconds)
+    #[arg(long, default_value_t = 2, env = "REDIS_TUI_RATE_AVG_WINDOW",
+          value_parser = clap::value_parser!(u64).range(1..))]
+    rate_avg_window: u64,
+
+    /// Retry attempts for a host that is not up yet
+    #[arg(long, default_value_t = 5, env = "REDIS_TUI_CONNECT_RETRIES",
+          value_parser = clap::value_parser!(u32).range(0..))]
+    connect_retries: u32,
+
+    /// Socket timeout per connection attempt (seconds)
+    #[arg(long, default_value_t = 3, env = "REDIS_TUI_CONNECT_TIMEOUT",
+          value_parser = clap::value_parser!(u64).range(1..))]
+    connect_timeout: u64,
+}
+```
+
+- [ ] **Step 5: Delete `parse_hosts_file` and wire `main()` to the list**
+
+Delete `parse_hosts_file` and every test of it that remains in `src/main.rs` — `hosts.rs` covers the grammar, and there is no file to read any more. Replace the connection block:
+
+```rust
+    let defaults = hosts::HostDefaults {
+        username: args.username.clone(),
+        password: args.password.clone(),
+        db: args.db,
+    };
+    let entries = hosts::parse_host_entries(&args.hosts, &defaults)?;
+    eprintln!("Connecting to {} host(s)...", entries.len());
+    let mut client = MultiRedisClient::from_entries(
+        &entries,
+        args.connect_retries,
+        Duration::from_secs(args.connect_timeout),
+    )?;
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `cargo test --locked && cargo test --locked -- --ignored`
+Expected: PASS.
+
+- [ ] **Step 7: Verify the whole gate and the real binary**
+
+Run:
+```bash
+cargo clippy --locked --all-targets -- -D warnings && cargo fmt --check
+cargo run -- --help
+REDIS_TUI_HOSTS="db1 db2:6380" cargo run -- --help
+```
+Expected: clippy and fmt clean. `--help` shows `--hosts`, `--username`, and `[env: REDIS_TUI_*]` annotations, and no `--host`, `--port`, `--url` or `--hosts-file`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Cargo.toml src/main.rs
+git commit -m "Replace --host/--port/--url/--hosts-file with --hosts, and read the environment
+
+One flag now names where to connect. --hosts takes one or more space-separated
+entries and is repeatable; an entry is a bare host, host:port, or a full URL.
+--username is new, since Redis 6 ACLs mean a password alone is not enough.
+
+Every option is also settable as REDIS_TUI_*, via clap's env feature, which
+gives CLI > environment > default precedence and prints the variable names in
+--help so the documentation cannot drift from the code.
+
+This removes two silent behaviours rather than patching them. --hosts-file used
+to win over --host/--port/--password/--db/--url with no warning and no mention
+in the docs; and with one connection path there is no second source of truth to
+override anything."
+```
+
+---
+
+### Task 4: Documentation and the 2.0.0 release
+
+**Files:**
+- Modify: `README.md`, `MANUAL.md`, `CLAUDE.md`, `Cargo.toml`, `start-dev.sh`
+
+- [ ] **Step 1: Update `MANUAL.md`**
+
+Replace the options table (currently `MANUAL.md:26-37`) with the eight options and their variables, and rewrite the examples at `MANUAL.md:47-56`, the connection paragraph at `:65`, the hosts-file section at `:80`, and the multi-host note at `:437`:
+
+```markdown
+| Flag | Environment | Description | Default |
+|------|-------------|-------------|---------|
+| `--hosts <HOSTS>...` | `REDIS_TUI_HOSTS` | Hosts: `host`, `host:port`, or a full `redis://` URL. Repeatable. | `127.0.0.1:6379` |
+| `--username <USERNAME>` | `REDIS_TUI_USERNAME` | Username for hosts without their own | None |
+| `--password <PASSWORD>` | `REDIS_TUI_PASSWORD` | Password for hosts without their own | None |
+| `-d, --db <DB>` | `REDIS_TUI_DB` | Database for hosts without their own | `0` |
+| `--rate-history <MINUTES>` | `REDIS_TUI_RATE_HISTORY` | Rolling window for the rate chart | `20` |
+| `--rate-avg-window <SECONDS>` | `REDIS_TUI_RATE_AVG_WINDOW` | Sliding average for the plotted rate line | `2` |
+| `--connect-retries <N>` | `REDIS_TUI_CONNECT_RETRIES` | Retries for a host that is not up yet | `5` |
+| `--connect-timeout <SECONDS>` | `REDIS_TUI_CONNECT_TIMEOUT` | Socket timeout per attempt | `3` |
+```
+
+Add a migration section:
+
+```markdown
+### Migrating from 1.x
+
+`--host`, `--port`, `--url` and `--hosts-file` were removed in 2.0.0. One flag
+now names where to connect.
+
+| 1.x | 2.0 |
+|-----|-----|
+| `--host db1 --port 6380` | `--hosts db1:6380` |
+| `--url redis://:pw@db1/2` | `--hosts redis://:pw@db1/2` |
+| `--hosts-file hosts.txt` | `--hosts $(grep -v '^#' hosts.txt \| tr '\n' ' ')` |
+
+Entries mix freely, and `--username`/`--password`/`--db` apply to any entry that
+does not carry its own:
+
+    redis-tui --hosts db1 db2:6380 redis://svc:pw@db3/2 \
+              --username admin --password s3cret --db 1
+```
+
+- [ ] **Step 2: Update `README.md`**
+
+Rewrite the usage examples at `README.md:76-88` and the Docker example at `:50` — `docker run -it --rm redis-tui --host <redis-host>` becomes `--hosts <redis-host>`. Add a short environment example, since it is the reason the image is easier to use now:
+
+```markdown
+Every option can be set from the environment instead:
+
+```bash
+docker run -it --rm --network host \
+  -e REDIS_TUI_HOSTS="db1 db2:6380" \
+  -e REDIS_TUI_DB=1 \
+  adregistry.fnal.gov/instrumentation/redis-tui
+```
+```
+
+- [ ] **Step 3: Update `CLAUDE.md`**
+
+- "Four source modules in `src/`" becomes five, with a line for `hosts.rs`.
+- Under Conventions, record: *"One flag names where to connect. Connection info is built as `redis::ConnectionInfo`, never by formatting a URL string — a credential interpolated into a URL breaks on `/ # ? @`."*
+
+- [ ] **Step 4: Update `start-dev.sh`**
+
+Its final line passes `--hosts-file`. Replace with the list form:
+
+```bash
+cargo run -- --hosts "127.0.0.1:${REDIS_PORT_1}" "127.0.0.1:${REDIS_PORT_2}"
+```
+
+and delete the `HOSTS_FILE` variable and the block that writes it.
+
+- [ ] **Step 5: Bump to 2.0.0**
+
+In `Cargo.toml`, set `version = "2.0.0"`, then run `cargo build` to refresh `Cargo.lock`.
+
+- [ ] **Step 6: Verify everything**
+
+Run:
+```bash
+cargo build --locked --all-targets && cargo build --locked --release
+cargo test --locked && cargo test --locked -- --ignored
+cargo clippy --locked --all-targets -- -D warnings && cargo fmt --check
+grep -rn -- '--host \|--port \|--url \|--hosts-file' README.md MANUAL.md start-dev.sh
+```
+Expected: all green, and the final `grep` finds only the migration table in `MANUAL.md`.
+
+- [ ] **Step 7: Commit and open the PR**
+
+```bash
+git add README.md MANUAL.md CLAUDE.md start-dev.sh Cargo.toml Cargo.lock
+git commit -m "Document the 2.0 connection surface and bump to 2.0.0
+
+--host, --port, --url and --hosts-file are gone; MANUAL.md carries a migration
+table for each. Every option is documented alongside its REDIS_TUI_ variable,
+and start-dev.sh uses the list form.
+
+Breaking, so 1.3.x -> 2.0.0."
+git push -u origin <branch>
+gh pr create --title "Replace the connection flags with --hosts and add environment configuration (#109)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** Every decision recorded on #109 maps to a task: clean break and removals (Task 3), space-separated repeatable `--hosts` (Task 3), the three entry forms and their defaults (Task 1), `--username` (Task 3), URL entries self-contained (Task 1), the eight `REDIS_TUI_*` variables (Task 3), #42 fixed as part of the work (Tasks 1 and 2), `parse_hosts_file`'s validation and label derivation preserved in the entry parser (Task 1), documentation (Task 4).
+
+**Deliberately out of scope**, both recorded on #109 rather than silently dropped:
+- `REDIS_TUI_PASSWORD_FILE` for mounted secrets. Purely additive and can land later without another breaking change.
+- The socket *read* timeout, which is the larger half of #44. This work fixes only the connect-timeout half, by removing the path that ignored the flag.
+
+**Known gaps to raise rather than paper over.**
+- Background threads still connect with a hardcoded 10s timeout inside `RedisClient::connect`. Threading the configured value through `StreamListener`/`SignalGenerator` is a change to their signatures and their call sites, and belongs with #44 rather than here. Task 2's comment should say so.
+- `MultiRedisClient::info_for_key` falls back to host 0 for an unknown key, matching what `url_for_key` did. That is existing behaviour, not a new decision.
+
+**Type consistency.** `HostEntry`/`HostDefaults`/`parse_host_entry`/`parse_host_entries` are used with the same names and signatures in Tasks 1, 2 and 3. `connect_with_info(info, label, timeout)` has the same argument order everywhere. `from_entries(entries, max_retries, connect_timeout)` matches the `from_urls` signature it replaces.
+
+**One risk worth stating.** Task 2 changes `RedisClient`'s public shape while `app.rs` and `ui.rs` also read from it. Step 4 lists the two `.url` reads found by `grep -n '\.url\b' src/`, but the implementer should re-run that grep across all of `src/` before assuming the list is complete.

--- a/src/hosts.rs
+++ b/src/hosts.rs
@@ -31,10 +31,8 @@ pub struct HostEntry {
     /// `host:port`, shown in the host column and in status messages. Never
     /// contains credentials.
     pub label: String,
-    // Read by the client construction that consumes `HostEntry` starting in
-    // the next commit. The transitional `parse_hosts_file` in main.rs only
-    // needs `label` for now, so rustc sees this field as dead in this build.
-    #[allow(dead_code)]
+    /// Built programmatically, never by formatting a URL, so a password
+    /// containing URL metacharacters survives to the connection verbatim.
     pub info: ConnectionInfo,
 }
 

--- a/src/hosts.rs
+++ b/src/hosts.rs
@@ -78,13 +78,8 @@ pub fn parse_host_entry(entry: &str, defaults: &HostDefaults) -> Result<HostEntr
     Ok(HostEntry { label, info })
 }
 
-/// Parse every entry, reporting all the bad ones at once.
-///
-/// Unreachable from `main()` in this commit: `--hosts-file` validates line by
-/// line through `parse_host_entry` directly, so each error can be tagged with
-/// its physical line number, which this batch entry point has no way to know.
-/// It is wired up to the `--hosts` flag in a later commit.
-#[allow(dead_code)]
+/// Parse every entry, reporting all the bad ones at once, so one run tells the
+/// user everything to fix rather than one problem per attempt.
 pub fn parse_host_entries(entries: &[String], defaults: &HostDefaults) -> Result<Vec<HostEntry>> {
     if entries.is_empty() {
         bail!("No hosts given");

--- a/src/hosts.rs
+++ b/src/hosts.rs
@@ -1,0 +1,303 @@
+//! Parsing of `--hosts` entries into Redis connection info.
+//!
+//! An entry is either shorthand (`db1`, `db1:6380`) or a full Redis URL
+//! (`redis://user:pw@db1:6380/2`). Shorthand takes its port from
+//! `DEFAULT_PORT` and its credentials and database from the CLI defaults; a
+//! URL is self-contained and the defaults are not applied to it.
+//!
+//! The connection info is built programmatically rather than by formatting a
+//! URL string. That is deliberate: the previous `Args::redis_url` interpolated
+//! the password into a URL with `format!`, so a password containing `/`, `#`,
+//! `?` or `@` produced something unparseable (#42). Nothing here ever encodes
+//! a credential, so nothing can mis-encode one.
+
+use anyhow::{bail, Result};
+use redis::{ConnectionAddr, ConnectionInfo, IntoConnectionInfo, RedisConnectionInfo};
+
+/// Port used by an entry that does not name one.
+pub const DEFAULT_PORT: u16 = 6379;
+
+/// Applied to shorthand entries. A URL entry supplies its own and ignores these.
+#[derive(Debug, Clone, Default)]
+pub struct HostDefaults {
+    pub username: Option<String>,
+    pub password: Option<String>,
+    pub db: u16,
+}
+
+/// A resolved endpoint: how to display it, and how to connect to it.
+#[derive(Debug, Clone)]
+pub struct HostEntry {
+    /// `host:port`, shown in the host column and in status messages. Never
+    /// contains credentials.
+    pub label: String,
+    // Read by the client construction that consumes `HostEntry` starting in
+    // the next commit. The transitional `parse_hosts_file` in main.rs only
+    // needs `label` for now, so rustc sees this field as dead in this build.
+    #[allow(dead_code)]
+    pub info: ConnectionInfo,
+}
+
+/// Parse one entry. The error is a bare phrase; `parse_host_entries` supplies
+/// the surrounding context so a single message reads well in a list.
+pub fn parse_host_entry(entry: &str, defaults: &HostDefaults) -> Result<HostEntry, String> {
+    let entry = entry.trim();
+    if entry.is_empty() {
+        return Err("empty entry".to_string());
+    }
+
+    let info = if entry.contains("://") {
+        // Validated by redis-rs's own parser, so what parses here and what
+        // connects later cannot disagree.
+        entry.into_connection_info().map_err(|e| e.to_string())?
+    } else {
+        let (host, port) = parse_shorthand(entry)?;
+        let mut redis = RedisConnectionInfo::default().set_db(i64::from(defaults.db));
+        if let Some(u) = &defaults.username {
+            redis = redis.set_username(u);
+        }
+        if let Some(p) = &defaults.password {
+            redis = redis.set_password(p);
+        }
+        ConnectionAddr::Tcp(host, port)
+            .into_connection_info()
+            .map_err(|e| e.to_string())?
+            .set_redis_settings(redis)
+    };
+
+    // Deriving the label from the parsed address rather than from the input
+    // string means credentials cannot reach it by construction.
+    let label = match info.addr() {
+        ConnectionAddr::Tcp(host, port) => format!("{}:{}", host, port),
+        ConnectionAddr::TcpTls { .. } => {
+            return Err(
+                "TLS is not compiled in, so a rediss:// entry can never connect".to_string(),
+            )
+        }
+        _ => return Err("only TCP redis:// entries are supported".to_string()),
+    };
+
+    Ok(HostEntry { label, info })
+}
+
+/// Parse every entry, reporting all the bad ones at once.
+///
+/// Unreachable from `main()` in this commit: `--hosts-file` validates line by
+/// line through `parse_host_entry` directly, so each error can be tagged with
+/// its physical line number, which this batch entry point has no way to know.
+/// It is wired up to the `--hosts` flag in a later commit.
+#[allow(dead_code)]
+pub fn parse_host_entries(entries: &[String], defaults: &HostDefaults) -> Result<Vec<HostEntry>> {
+    if entries.is_empty() {
+        bail!("No hosts given");
+    }
+
+    let mut parsed = Vec::with_capacity(entries.len());
+    let mut problems: Vec<String> = Vec::new();
+
+    for entry in entries {
+        match parse_host_entry(entry, defaults) {
+            Ok(host) => parsed.push(host),
+            Err(e) => problems.push(format!("  {}\n    {}", entry.trim(), e)),
+        }
+    }
+
+    if !problems.is_empty() {
+        bail!(
+            "{} invalid host {}:\n{}",
+            problems.len(),
+            if problems.len() == 1 {
+                "entry"
+            } else {
+                "entries"
+            },
+            problems.join("\n")
+        );
+    }
+
+    Ok(parsed)
+}
+
+/// `host` or `host:port`.
+///
+/// A bare IPv6 address is refused rather than guessed at: `::1` would split on
+/// its last colon into a host of `:` and a port of `1`, which is wrong and
+/// would fail confusingly at connect time instead of here.
+fn parse_shorthand(entry: &str) -> Result<(String, u16), String> {
+    if entry.starts_with('[') || entry.matches(':').count() > 1 {
+        return Err(format!(
+            "looks like an IPv6 address - write it as a URL, e.g. redis://[{}]:{}",
+            entry.trim_start_matches('[').trim_end_matches(']'),
+            DEFAULT_PORT
+        ));
+    }
+
+    let (host, port) = match entry.split_once(':') {
+        None => (entry, DEFAULT_PORT),
+        Some((host, port)) => {
+            if host.is_empty() {
+                return Err("no host before ':'".to_string());
+            }
+            let parsed: u16 = port
+                .parse()
+                .map_err(|_| format!("invalid port '{}'", port))?;
+            if parsed == 0 {
+                return Err("port must not be 0".to_string());
+            }
+            (host, parsed)
+        }
+    };
+
+    if !is_valid_host(host) {
+        return Err(format!("'{}' is not a valid host", host));
+    }
+
+    Ok((host.to_string(), port))
+}
+
+/// Restricts a shorthand host to the character set a real hostname or IPv4
+/// address can use. Without this, a typo like `!!! not a host !!!` would be
+/// accepted here and only fail later, confusingly, at connect time.
+fn is_valid_host(host: &str) -> bool {
+    !host.is_empty()
+        && host
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn defaults() -> HostDefaults {
+        HostDefaults {
+            username: Some("admin".to_string()),
+            password: Some("s3cret".to_string()),
+            db: 1,
+        }
+    }
+
+    fn tcp(entry: &HostEntry) -> (String, u16) {
+        match entry.info.addr() {
+            redis::ConnectionAddr::Tcp(h, p) => (h.clone(), *p),
+            other => panic!("expected Tcp, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn bare_host_takes_the_default_port_and_defaults() {
+        let e = parse_host_entry("db1", &defaults()).unwrap();
+        assert_eq!(tcp(&e), ("db1".to_string(), 6379));
+        assert_eq!(e.info.redis_settings().db(), 1);
+        assert_eq!(e.info.redis_settings().username(), Some("admin"));
+        assert_eq!(e.info.redis_settings().password(), Some("s3cret"));
+        assert_eq!(e.label, "db1:6379");
+    }
+
+    #[test]
+    fn host_port_overrides_only_the_port() {
+        let e = parse_host_entry("db2:6380", &defaults()).unwrap();
+        assert_eq!(tcp(&e), ("db2".to_string(), 6380));
+        assert_eq!(e.info.redis_settings().db(), 1);
+        assert_eq!(e.label, "db2:6380");
+    }
+
+    #[test]
+    fn a_url_entry_is_self_contained_and_ignores_the_defaults() {
+        let e = parse_host_entry("redis://svc:pw@db3:6390/2", &defaults()).unwrap();
+        assert_eq!(tcp(&e), ("db3".to_string(), 6390));
+        assert_eq!(e.info.redis_settings().db(), 2);
+        assert_eq!(e.info.redis_settings().username(), Some("svc"));
+        assert_eq!(e.info.redis_settings().password(), Some("pw"));
+    }
+
+    // This is #42. Building the URL by string concatenation mangled these
+    // characters; building ConnectionInfo directly never encodes them at all.
+    #[test]
+    fn a_password_with_url_metacharacters_survives_verbatim() {
+        let d = HostDefaults {
+            username: None,
+            password: Some("p/a:s#s?w@rd".to_string()),
+            db: 0,
+        };
+        let e = parse_host_entry("db1", &d).unwrap();
+        assert_eq!(e.info.redis_settings().password(), Some("p/a:s#s?w@rd"));
+    }
+
+    #[test]
+    fn the_label_never_leaks_credentials() {
+        let e = parse_host_entry("redis://svc:hunter2@db3:6390/2", &defaults()).unwrap();
+        assert_eq!(e.label, "db3:6390");
+        assert!(!e.label.contains("hunter2"));
+    }
+
+    #[test]
+    fn rediss_is_rejected_because_tls_is_not_compiled_in() {
+        let err = parse_host_entry("rediss://db1:6379", &defaults()).unwrap_err();
+        assert!(err.to_lowercase().contains("tls"), "got: {}", err);
+    }
+
+    #[test]
+    fn an_invalid_port_is_rejected() {
+        let err = parse_host_entry("db1:notaport", &defaults()).unwrap_err();
+        assert!(err.contains("notaport"), "got: {}", err);
+    }
+
+    #[test]
+    fn port_zero_is_rejected() {
+        let err = parse_host_entry("db1:0", &defaults()).unwrap_err();
+        assert!(err.contains('0'), "got: {}", err);
+    }
+
+    #[test]
+    fn an_empty_entry_is_rejected() {
+        assert!(parse_host_entry("   ", &defaults()).is_err());
+    }
+
+    #[test]
+    fn a_url_with_no_host_is_rejected() {
+        assert!(parse_host_entry("redis://", &defaults()).is_err());
+    }
+
+    #[test]
+    fn outright_garbage_is_rejected() {
+        assert!(parse_host_entry("!!! not a host !!!", &defaults()).is_err());
+    }
+
+    #[test]
+    fn ipv6_shorthand_points_at_the_url_form() {
+        let err = parse_host_entry("::1", &defaults()).unwrap_err();
+        assert!(err.contains("redis://"), "got: {}", err);
+    }
+
+    #[test]
+    fn every_bad_entry_is_reported_not_just_the_first() {
+        let entries = vec![
+            "good1".to_string(),
+            "bad:one".to_string(),
+            "good2".to_string(),
+            "rediss://bad2".to_string(),
+        ];
+        let err = parse_host_entries(&entries, &defaults())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("bad:one"), "got: {}", err);
+        assert!(err.contains("rediss://bad2"), "got: {}", err);
+        assert!(err.contains('2'), "should say how many were bad: {}", err);
+    }
+
+    #[test]
+    fn an_empty_list_is_rejected() {
+        assert!(parse_host_entries(&[], &defaults()).is_err());
+    }
+
+    #[test]
+    fn a_valid_list_keeps_its_order() {
+        let entries = vec!["db1".to_string(), "db2:6380".to_string()];
+        let parsed = parse_host_entries(&entries, &defaults()).unwrap();
+        assert_eq!(
+            parsed.iter().map(|e| e.label.clone()).collect::<Vec<_>>(),
+            vec!["db1:6379".to_string(), "db2:6380".to_string()]
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,8 +33,13 @@ use std::time::Duration;
 struct Args {
     /// Redis hosts: `host`, `host:port`, or a full `redis://` URL.
     /// Repeatable, and several may be given at once.
+    // `--host` is an alias, not a doc line: a 1.x command naming a single host
+    // keeps working, but advertising it in --help would undercut the point of
+    // there being one flag. `--port` is gone, so the alias only covers hosts on
+    // the default port, or the `host:port` form.
     #[arg(
         long,
+        alias = "host",
         num_args = 1..,
         action = clap::ArgAction::Append,
         value_delimiter = ' ',
@@ -1595,9 +1600,40 @@ mod tests {
         assert_eq!(a.db, 4);
     }
 
+    // 1.x scripts that named a single host keep working: `--host` stays as a
+    // hidden alias for `--hosts`. `--port` is gone, so anything that also set a
+    // port has to move to the `host:port` form.
+    #[test]
+    fn host_is_accepted_as_a_deprecated_alias_for_hosts() {
+        let a = Args::try_parse_from(["redis-tui", "--host", "db1"]).unwrap();
+        assert_eq!(a.hosts, vec!["db1".to_string()]);
+    }
+
+    #[test]
+    fn the_host_alias_carries_a_port_like_any_other_entry() {
+        let a = Args::try_parse_from(["redis-tui", "--host", "db1:6380"]).unwrap();
+        assert_eq!(a.hosts, vec!["db1:6380".to_string()]);
+    }
+
+    // The alias exists for scripts, not for discovery: advertising it in --help
+    // would undercut the point of there being one flag. Stripping `--hosts`
+    // first keeps this from matching the real flag's own name.
+    #[test]
+    fn the_host_alias_is_not_advertised_in_help() {
+        // `--help` renders the long form, which is where a doc comment's extra
+        // paragraphs land, so short help alone would not catch a leak.
+        let help = Args::command().render_long_help().to_string();
+        let without_the_real_flag = help.replace("--hosts", "");
+        assert!(
+            !without_the_real_flag.contains("--host"),
+            "--help should not mention the deprecated alias:\n{}",
+            help
+        );
+    }
+
     #[test]
     fn the_removed_flags_are_rejected() {
-        for flag in ["--host", "--port", "--url", "--hosts-file"] {
+        for flag in ["--port", "--url", "--hosts-file"] {
             assert!(
                 Args::try_parse_from(["redis-tui", flag, "x"]).is_err(),
                 "{} should no longer be accepted",

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,10 +47,6 @@ struct Args {
     #[arg(short, long, default_value_t = 0)]
     db: u16,
 
-    /// Full Redis URL (overrides host/port/password/db)
-    #[arg(short, long)]
-    url: Option<String>,
-
     /// Path to hosts file (one Redis URL per line, # for comments).
     /// Connects to all listed hosts and aggregates keys.
     #[arg(long)]
@@ -73,25 +69,12 @@ struct Args {
     connect_timeout: u64,
 }
 
-impl Args {
-    fn redis_url(&self) -> String {
-        if let Some(url) = &self.url {
-            return url.clone();
-        }
-        let auth = match &self.password {
-            Some(pw) => format!(":{}@", pw),
-            None => String::new(),
-        };
-        format!("redis://{}{}:{}/{}", auth, self.host, self.port, self.db)
-    }
-}
-
 /// Read a hosts file, one entry per line, `#` for comments.
 ///
 /// Temporary: `--hosts-file` is removed in favour of `--hosts` in a later
 /// commit. Until then this keeps working, delegating each line to the shared
-/// entry parser so there is only one grammar. Returns (label, url) pairs.
-fn parse_hosts_file(path: &str) -> Result<Vec<(String, String)>> {
+/// entry parser so there is only one grammar.
+fn parse_hosts_file(path: &str) -> Result<Vec<hosts::HostEntry>> {
     let content = std::fs::read_to_string(path)
         .with_context(|| format!("Failed to read hosts file: {}", path))?;
 
@@ -109,26 +92,24 @@ fn parse_hosts_file(path: &str) -> Result<Vec<(String, String)>> {
         }
 
         match hosts::parse_host_entry(trimmed, &defaults) {
-            // A hosts file entry is pushed to `from_urls` verbatim, unparsed - so
-            // it must already be a URL `redis::Client::open` can connect with.
+            // A hosts file entry is pushed to `from_entries` verbatim - so it
+            // must already be a URL `redis::Client::open` can connect with.
             // Bare shorthand (e.g. `127.0.0.1:6379`) passes `parse_host_entry`
             // (it is valid for `--hosts`), but pushing it here as-is would make
-            // `from_urls` reject it, and that failure is indistinguishable from
-            // the host being unreachable: it burns the whole retry budget and
-            // reports a live host as never having come up. Building a URL from
-            // the parsed entry instead would mean formatting credentials back
-            // into a string - the exact bug (#42) this parser exists to delete.
-            // So: reject bare shorthand here, with a message pointing at the URL
-            // form. This is temporary and restores exactly what 1.x did (the
-            // old `scheme_hint`); it disappears when `--hosts-file` is deleted
-            // in favour of `--hosts` (which does accept shorthand) in Task 3.
+            // `from_entries` reject it, and that failure is indistinguishable
+            // from the host being unreachable: it burns the whole retry budget
+            // and reports a live host as never having come up. So: reject bare
+            // shorthand here, with a message pointing at the URL form. This is
+            // temporary and restores exactly what 1.x did (the old
+            // `scheme_hint`); it disappears when `--hosts-file` is deleted in
+            // favour of `--hosts` (which does accept shorthand) in Task 3.
             Ok(entry) if !trimmed.contains("://") => {
                 problems.push(format!(
                     "  line {}: {}\n    hosts file entries must be full URLs - did you mean redis://{} ?",
                     lineno, trimmed, entry.label
                 ));
             }
-            Ok(entry) => entries.push((entry.label, trimmed.to_string())),
+            Ok(entry) => entries.push(entry),
             Err(e) => problems.push(format!("  line {}: {}\n    {}", lineno, trimmed, e)),
         }
     }
@@ -157,20 +138,26 @@ fn parse_hosts_file(path: &str) -> Result<Vec<(String, String)>> {
 fn main() -> Result<()> {
     let args = Args::parse();
 
-    // Connect to Redis (single or multi-host)
-    let mut client = if let Some(ref hosts_path) = args.hosts_file {
-        let hosts = parse_hosts_file(hosts_path)?;
-        eprintln!("Connecting to {} hosts...", hosts.len());
-        MultiRedisClient::from_urls(
-            &hosts,
-            args.connect_retries,
-            Duration::from_secs(args.connect_timeout),
-        )?
-    } else {
-        let url = args.redis_url();
-        MultiRedisClient::from_single(&url)
-            .with_context(|| format!("Failed to connect to Redis at {}", url))?
+    // Connect to Redis (single or multi-host). Both cases become a list of
+    // `HostEntry` and go through the one connection path.
+    let defaults = hosts::HostDefaults {
+        username: None,
+        password: args.password.clone(),
+        db: args.db,
     };
+    let entries = if let Some(ref hosts_path) = args.hosts_file {
+        parse_hosts_file(hosts_path)?
+    } else {
+        let entry = hosts::parse_host_entry(&format!("{}:{}", args.host, args.port), &defaults)
+            .map_err(|e| anyhow::anyhow!("{}", e))?;
+        vec![entry]
+    };
+    eprintln!("Connecting to {} host(s)...", entries.len());
+    let mut client = MultiRedisClient::from_entries(
+        &entries,
+        args.connect_retries,
+        Duration::from_secs(args.connect_timeout),
+    )?;
 
     // Install panic hook that restores the terminal before printing the panic.
     // Only run cleanup on the main thread — a background thread panic should not
@@ -236,8 +223,15 @@ struct StreamListener {
 }
 
 impl StreamListener {
-    fn start(url: &str, key: &str, last_id: &str, db: i64) -> Option<Self> {
-        let mut client = RedisClient::connect(url).ok()?;
+    fn start(
+        info: redis::ConnectionInfo,
+        label: &str,
+        key: &str,
+        last_id: &str,
+        db: i64,
+    ) -> Option<Self> {
+        let mut client =
+            RedisClient::connect_with_info(info, label, std::time::Duration::from_secs(10)).ok()?;
         if db != 0 {
             client.select_db(db).ok()?;
         }
@@ -305,8 +299,15 @@ struct SignalGenerator {
 }
 
 impl SignalGenerator {
-    fn start(url: &str, key: &str, db: i64, config: app::SignalGenConfig) -> Option<Self> {
-        let mut client = RedisClient::connect(url).ok()?;
+    fn start(
+        info: redis::ConnectionInfo,
+        label: &str,
+        key: &str,
+        db: i64,
+        config: app::SignalGenConfig,
+    ) -> Option<Self> {
+        let mut client =
+            RedisClient::connect_with_info(info, label, std::time::Duration::from_secs(10)).ok()?;
         if db != 0 {
             client.select_db(db).ok()?;
         }
@@ -512,10 +513,11 @@ fn run_app(
                                         .unwrap_or(10.0),
                                 };
                                 if let Some(k) = app.selected_key_name().map(|s| s.to_string()) {
-                                    let key_url = client.url_for_key(&k).to_string();
-                                    if let Some(sg) =
-                                        SignalGenerator::start(&key_url, &k, app.db, config)
-                                    {
+                                    let key_info = client.info_for_key(&k);
+                                    let key_label = client.host_label_for_key(&k).to_string();
+                                    if let Some(sg) = SignalGenerator::start(
+                                        key_info, &key_label, &k, app.db, config,
+                                    ) {
                                         // Evict oldest if at capacity (non-blocking)
                                         if signal_generators.len() >= app::MAX_PLOT_SLOTS {
                                             let mut oldest = signal_generators.remove(0);
@@ -592,10 +594,11 @@ fn run_app(
                                             .last_stream_id
                                             .clone()
                                             .unwrap_or_else(|| "$".to_string());
-                                        let key_url = client.url_for_key(&k).to_string();
-                                        if let Some(sl) =
-                                            StreamListener::start(&key_url, &k, &lid, app.db)
-                                        {
+                                        let key_info = client.info_for_key(&k);
+                                        let key_label = client.host_label_for_key(&k).to_string();
+                                        if let Some(sl) = StreamListener::start(
+                                            key_info, &key_label, &k, &lid, app.db,
+                                        ) {
                                             // Evict oldest if at capacity (non-blocking)
                                             if stream_listeners.len() >= app::MAX_PLOT_SLOTS {
                                                 let mut oldest = stream_listeners.remove(0);
@@ -1630,7 +1633,7 @@ mod tests {
 
     /// Write `content` to a temp file and parse it. Returns the parse result so a
     /// test can assert on either the hosts or the error text.
-    fn parse_hosts_str(content: &str) -> Result<Vec<(String, String)>> {
+    fn parse_hosts_str(content: &str) -> Result<Vec<hosts::HostEntry>> {
         let dir = std::env::temp_dir();
         let path = dir.join(format!(
             "redis-tui-hosts-test-{}-{:?}.txt",
@@ -1650,11 +1653,11 @@ mod tests {
         )
         .expect("valid file should parse");
         assert_eq!(hosts.len(), 2);
-        assert_eq!(hosts[0].1, "redis://127.0.0.1:6379/0");
-        assert_eq!(hosts[1].1, "redis://127.0.0.1:6380/1");
+        assert_eq!(hosts[0].label, "127.0.0.1:6379");
+        assert_eq!(hosts[1].label, "127.0.0.1:6380");
     }
 
-    // Regression: a hosts file entry is pushed to `from_urls` as the original
+    // Regression: a hosts file entry is pushed to `from_entries` as the original
     // string, unparsed. Bare shorthand is valid for `--hosts` (parse_host_entry
     // accepts it) but `redis::Client::open` cannot connect with it, and that
     // failure looks exactly like an unreachable host - it burns the whole

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,6 +109,25 @@ fn parse_hosts_file(path: &str) -> Result<Vec<(String, String)>> {
         }
 
         match hosts::parse_host_entry(trimmed, &defaults) {
+            // A hosts file entry is pushed to `from_urls` verbatim, unparsed - so
+            // it must already be a URL `redis::Client::open` can connect with.
+            // Bare shorthand (e.g. `127.0.0.1:6379`) passes `parse_host_entry`
+            // (it is valid for `--hosts`), but pushing it here as-is would make
+            // `from_urls` reject it, and that failure is indistinguishable from
+            // the host being unreachable: it burns the whole retry budget and
+            // reports a live host as never having come up. Building a URL from
+            // the parsed entry instead would mean formatting credentials back
+            // into a string - the exact bug (#42) this parser exists to delete.
+            // So: reject bare shorthand here, with a message pointing at the URL
+            // form. This is temporary and restores exactly what 1.x did (the
+            // old `scheme_hint`); it disappears when `--hosts-file` is deleted
+            // in favour of `--hosts` (which does accept shorthand) in Task 3.
+            Ok(entry) if !trimmed.contains("://") => {
+                problems.push(format!(
+                    "  line {}: {}\n    hosts file entries must be full URLs - did you mean redis://{} ?",
+                    lineno, trimmed, entry.label
+                ));
+            }
             Ok(entry) => entries.push((entry.label, trimmed.to_string())),
             Err(e) => problems.push(format!("  line {}: {}\n    {}", lineno, trimmed, e)),
         }
@@ -1633,6 +1652,29 @@ mod tests {
         assert_eq!(hosts.len(), 2);
         assert_eq!(hosts[0].1, "redis://127.0.0.1:6379/0");
         assert_eq!(hosts[1].1, "redis://127.0.0.1:6380/1");
+    }
+
+    // Regression: a hosts file entry is pushed to `from_urls` as the original
+    // string, unparsed. Bare shorthand is valid for `--hosts` (parse_host_entry
+    // accepts it) but `redis::Client::open` cannot connect with it, and that
+    // failure looks exactly like an unreachable host - it burns the whole
+    // retry budget and reports a live host as never having come up. A hosts
+    // file entry must be a full URL until `--hosts-file` is removed.
+    #[test]
+    fn parse_hosts_rejects_bare_host_port_and_points_at_the_url_form() {
+        let err = parse_hosts_str("127.0.0.1:16399\n").expect_err("bare shorthand is not a URL");
+        let msg = err.to_string();
+        assert!(msg.contains("line 1"), "should name the line: {}", msg);
+        assert!(
+            msg.contains("127.0.0.1:16399"),
+            "should quote the entry: {}",
+            msg
+        );
+        assert!(
+            msg.contains("redis://127.0.0.1:16399"),
+            "should point at the URL form: {}",
+            msg
+        );
     }
 
     /// This build has no TLS: Cargo.toml declares `redis = "1.0"` with no TLS

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod app;
 mod data;
+mod hosts;
 mod redis_client;
 mod ui;
 
@@ -85,13 +86,17 @@ impl Args {
     }
 }
 
-/// Parse a hosts file. Each line is a Redis URL. Lines starting with # are comments.
-/// Blank lines are skipped. Returns (label, url) pairs.
+/// Read a hosts file, one entry per line, `#` for comments.
+///
+/// Temporary: `--hosts-file` is removed in favour of `--hosts` in a later
+/// commit. Until then this keeps working, delegating each line to the shared
+/// entry parser so there is only one grammar. Returns (label, url) pairs.
 fn parse_hosts_file(path: &str) -> Result<Vec<(String, String)>> {
     let content = std::fs::read_to_string(path)
         .with_context(|| format!("Failed to read hosts file: {}", path))?;
 
-    let mut hosts = Vec::new();
+    let defaults = hosts::HostDefaults::default();
+    let mut entries = Vec::new();
     let mut problems: Vec<String> = Vec::new();
 
     for (i, line) in content.lines().enumerate() {
@@ -103,35 +108,10 @@ fn parse_hosts_file(path: &str) -> Result<Vec<(String, String)>> {
             continue;
         }
 
-        // Validate with the same parser `RedisClient::connect` uses, rather than
-        // a hand-rolled check that could drift from what redis-rs accepts. An
-        // entry that fails here can never connect, so it must not reach the
-        // retry loop in `MultiRedisClient::from_urls`.
-        if let Err(e) = redis::Client::open(trimmed) {
-            problems.push(format!(
-                "  line {}: {}\n    {}{}",
-                lineno,
-                trimmed,
-                e,
-                scheme_hint(trimmed)
-            ));
-            continue;
+        match hosts::parse_host_entry(trimmed, &defaults) {
+            Ok(entry) => entries.push((entry.label, trimmed.to_string())),
+            Err(e) => problems.push(format!("  line {}: {}\n    {}", lineno, trimmed, e)),
         }
-
-        // Use the host:port portion as a label, or fallback to line number
-        let label = trimmed
-            .strip_prefix("redis://")
-            .and_then(|s| s.split('/').next())
-            .map(|s| {
-                // Remove auth portion for label
-                if let Some(at_pos) = s.rfind('@') {
-                    s[at_pos + 1..].to_string()
-                } else {
-                    s.to_string()
-                }
-            })
-            .unwrap_or_else(|| format!("host-{}", lineno));
-        hosts.push((label, trimmed.to_string()));
     }
 
     if !problems.is_empty() {
@@ -148,27 +128,11 @@ fn parse_hosts_file(path: &str) -> Result<Vec<(String, String)>> {
         );
     }
 
-    if hosts.is_empty() {
+    if entries.is_empty() {
         anyhow::bail!("Hosts file '{}' contains no valid URLs", path);
     }
 
-    Ok(hosts)
-}
-
-/// Suggest the scheme-prefixed form when an entry looks like a bare `host:port`.
-/// That is the likeliest typo, and the raw redis-rs error for it does not say so.
-fn scheme_hint(entry: &str) -> String {
-    if entry.contains("://") {
-        return String::new();
-    }
-    match entry.split_once(':') {
-        Some((host, port))
-            if !host.is_empty() && !port.is_empty() && port.chars().all(|c| c.is_ascii_digit()) =>
-        {
-            format!(" - did you mean redis://{} ?", entry)
-        }
-        _ => String::new(),
-    }
+    Ok(entries)
 }
 
 fn main() -> Result<()> {
@@ -1689,23 +1653,6 @@ mod tests {
     }
 
     #[test]
-    fn parse_hosts_rejects_bare_host_port_with_a_scheme_hint() {
-        let err = parse_hosts_str("localhost:6379\n").expect_err("bare host:port is not a URL");
-        let msg = err.to_string();
-        assert!(msg.contains("line 1"), "should name the line: {}", msg);
-        assert!(
-            msg.contains("localhost:6379"),
-            "should quote the entry: {}",
-            msg
-        );
-        assert!(
-            msg.contains("redis://localhost:6379"),
-            "should suggest the scheme-prefixed form: {}",
-            msg
-        );
-    }
-
-    #[test]
     fn parse_hosts_rejects_a_url_with_no_host() {
         let err = parse_hosts_str("redis://\n").expect_err("no host is not usable");
         assert!(err.to_string().contains("line 1"), "{}", err);
@@ -1719,18 +1666,27 @@ mod tests {
 
     #[test]
     fn parse_hosts_reports_every_bad_line_not_just_the_first() {
-        let err = parse_hosts_str("localhost:6379\nredis://127.0.0.1:6379\nalso-bad:1\n")
-            .expect_err("two bad lines");
+        let err =
+            parse_hosts_str("localhost:notaport\nredis://127.0.0.1:6379\nalso-bad:notaport\n")
+                .expect_err("two bad lines");
         let msg = err.to_string();
-        assert!(msg.contains("localhost:6379"), "first bad entry: {}", msg);
-        assert!(msg.contains("also-bad:1"), "second bad entry: {}", msg);
+        assert!(
+            msg.contains("localhost:notaport"),
+            "first bad entry: {}",
+            msg
+        );
+        assert!(
+            msg.contains("also-bad:notaport"),
+            "second bad entry: {}",
+            msg
+        );
     }
 
     #[test]
     fn parse_hosts_line_numbers_count_blanks_and_comments() {
         // The bad entry is on physical line 4; blanks and comments above it must
         // not shift the number that gets reported.
-        let err = parse_hosts_str("# comment\n\n\nbad-entry:1\n").expect_err("bad entry");
+        let err = parse_hosts_str("# comment\n\n\nbad-entry:notaport\n").expect_err("bad entry");
         let msg = err.to_string();
         assert!(
             msg.contains("line 4"),
@@ -1743,17 +1699,5 @@ mod tests {
     fn parse_hosts_rejects_a_file_with_no_entries() {
         let err = parse_hosts_str("# only a comment\n\n").expect_err("nothing usable");
         assert!(err.to_string().contains("no valid URLs"), "{}", err);
-    }
-
-    #[test]
-    fn parse_hosts_label_strips_scheme_auth_and_db() {
-        let hosts = parse_hosts_str("redis://:secret@10.0.0.5:6379/2\n").unwrap();
-        assert_eq!(hosts[0].0, "10.0.0.5:6379");
-    }
-
-    #[test]
-    fn parse_hosts_label_for_a_url_without_auth() {
-        let hosts = parse_hosts_str("redis://127.0.0.1:6379/0\n").unwrap();
-        assert_eq!(hosts[0].0, "127.0.0.1:6379");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,127 +31,60 @@ use std::time::Duration;
     about = "A Redis TUI client inspired by Redis Insight"
 )]
 struct Args {
-    /// Redis host
-    #[arg(long, default_value = "127.0.0.1")]
-    host: String,
+    /// Redis hosts: `host`, `host:port`, or a full `redis://` URL.
+    /// Repeatable, and several may be given at once.
+    #[arg(
+        long,
+        num_args = 1..,
+        action = clap::ArgAction::Append,
+        value_delimiter = ' ',
+        default_value = "127.0.0.1:6379",
+        env = "REDIS_TUI_HOSTS"
+    )]
+    hosts: Vec<String>,
 
-    /// Redis port
-    #[arg(short, long, default_value_t = 6379)]
-    port: u16,
+    /// Username for hosts that do not carry their own
+    #[arg(long, env = "REDIS_TUI_USERNAME")]
+    username: Option<String>,
 
-    /// Redis password
-    #[arg(long)]
+    /// Password for hosts that do not carry their own
+    #[arg(long, env = "REDIS_TUI_PASSWORD")]
     password: Option<String>,
 
-    /// Redis database number
-    #[arg(short, long, default_value_t = 0)]
+    /// Database number for hosts that do not carry their own
+    #[arg(short, long, default_value_t = 0, env = "REDIS_TUI_DB")]
     db: u16,
 
-    /// Path to hosts file (one Redis URL per line, # for comments).
-    /// Connects to all listed hosts and aggregates keys.
-    #[arg(long)]
-    hosts_file: Option<String>,
-
     /// Rolling window for ingestion rate chart history (minutes)
-    #[arg(long, default_value_t = 20, value_parser = clap::value_parser!(u64).range(1..))]
+    #[arg(long, default_value_t = 20, env = "REDIS_TUI_RATE_HISTORY",
+          value_parser = clap::value_parser!(u64).range(1..))]
     rate_history: u64,
 
     /// Sliding window for the plotted ingestion rate line (seconds)
-    #[arg(long, default_value_t = 2, value_parser = clap::value_parser!(u64).range(1..))]
+    #[arg(long, default_value_t = 2, env = "REDIS_TUI_RATE_AVG_WINDOW",
+          value_parser = clap::value_parser!(u64).range(1..))]
     rate_avg_window: u64,
 
-    /// Retry attempts for a multi-host entry that is not up yet
-    #[arg(long, default_value_t = 5, value_parser = clap::value_parser!(u32).range(0..))]
+    /// Retry attempts for a host that is not up yet
+    #[arg(long, default_value_t = 5, env = "REDIS_TUI_CONNECT_RETRIES",
+          value_parser = clap::value_parser!(u32).range(0..))]
     connect_retries: u32,
 
-    /// Socket timeout per connection attempt in multi-host mode (seconds)
-    #[arg(long, default_value_t = 3, value_parser = clap::value_parser!(u64).range(1..))]
+    /// Socket timeout per connection attempt (seconds)
+    #[arg(long, default_value_t = 3, env = "REDIS_TUI_CONNECT_TIMEOUT",
+          value_parser = clap::value_parser!(u64).range(1..))]
     connect_timeout: u64,
-}
-
-/// Read a hosts file, one entry per line, `#` for comments.
-///
-/// Temporary: `--hosts-file` is removed in favour of `--hosts` in a later
-/// commit. Until then this keeps working, delegating each line to the shared
-/// entry parser so there is only one grammar.
-fn parse_hosts_file(path: &str) -> Result<Vec<hosts::HostEntry>> {
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Failed to read hosts file: {}", path))?;
-
-    let defaults = hosts::HostDefaults::default();
-    let mut entries = Vec::new();
-    let mut problems: Vec<String> = Vec::new();
-
-    for (i, line) in content.lines().enumerate() {
-        // Physical line number, so blanks and comments above a bad entry do not
-        // shift what gets reported back to the user.
-        let lineno = i + 1;
-        let trimmed = line.trim();
-        if trimmed.is_empty() || trimmed.starts_with('#') {
-            continue;
-        }
-
-        match hosts::parse_host_entry(trimmed, &defaults) {
-            // A hosts file entry is pushed to `from_entries` verbatim - so it
-            // must already be a URL `redis::Client::open` can connect with.
-            // Bare shorthand (e.g. `127.0.0.1:6379`) passes `parse_host_entry`
-            // (it is valid for `--hosts`), but pushing it here as-is would make
-            // `from_entries` reject it, and that failure is indistinguishable
-            // from the host being unreachable: it burns the whole retry budget
-            // and reports a live host as never having come up. So: reject bare
-            // shorthand here, with a message pointing at the URL form. This is
-            // temporary and restores exactly what 1.x did (the old
-            // `scheme_hint`); it disappears when `--hosts-file` is deleted in
-            // favour of `--hosts` (which does accept shorthand) in Task 3.
-            Ok(entry) if !trimmed.contains("://") => {
-                problems.push(format!(
-                    "  line {}: {}\n    hosts file entries must be full URLs - did you mean redis://{} ?",
-                    lineno, trimmed, entry.label
-                ));
-            }
-            Ok(entry) => entries.push(entry),
-            Err(e) => problems.push(format!("  line {}: {}\n    {}", lineno, trimmed, e)),
-        }
-    }
-
-    if !problems.is_empty() {
-        anyhow::bail!(
-            "Hosts file '{}' has {} invalid {}:\n{}",
-            path,
-            problems.len(),
-            if problems.len() == 1 {
-                "entry"
-            } else {
-                "entries"
-            },
-            problems.join("\n")
-        );
-    }
-
-    if entries.is_empty() {
-        anyhow::bail!("Hosts file '{}' contains no valid URLs", path);
-    }
-
-    Ok(entries)
 }
 
 fn main() -> Result<()> {
     let args = Args::parse();
 
-    // Connect to Redis (single or multi-host). Both cases become a list of
-    // `HostEntry` and go through the one connection path.
     let defaults = hosts::HostDefaults {
-        username: None,
+        username: args.username.clone(),
         password: args.password.clone(),
         db: args.db,
     };
-    let entries = if let Some(ref hosts_path) = args.hosts_file {
-        parse_hosts_file(hosts_path)?
-    } else {
-        let entry = hosts::parse_host_entry(&format!("{}:{}", args.host, args.port), &defaults)
-            .map_err(|e| anyhow::anyhow!("{}", e))?;
-        vec![entry]
-    };
+    let entries = hosts::parse_host_entries(&args.hosts, &defaults)?;
     eprintln!("Connecting to {} host(s)...", entries.len());
     let mut client = MultiRedisClient::from_entries(
         &entries,
@@ -1353,6 +1286,7 @@ fn handle_mouse_event(app: &mut App, mouse: MouseEvent) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::CommandFactory;
 
     fn make_app_with_fields(freq: &str, amp: &str, noise: &str, samples: &str, rate: &str) -> App {
         let mut app = App::new();
@@ -1629,120 +1563,86 @@ mod tests {
         );
     }
 
-    // ─── parse_hosts_file ────────────────────────────────────
+    // ─── CLI parsing ─────────────────────────────────────────
 
-    /// Write `content` to a temp file and parse it. Returns the parse result so a
-    /// test can assert on either the hosts or the error text.
-    fn parse_hosts_str(content: &str) -> Result<Vec<hosts::HostEntry>> {
-        let dir = std::env::temp_dir();
-        let path = dir.join(format!(
-            "redis-tui-hosts-test-{}-{:?}.txt",
-            std::process::id(),
-            std::thread::current().id()
-        ));
-        std::fs::write(&path, content).unwrap();
-        let result = parse_hosts_file(path.to_str().unwrap());
-        let _ = std::fs::remove_file(&path);
-        result
+    // Environment variables are process-global and cargo runs tests as threads,
+    // so these drive the parser with an explicit argv rather than mutating the
+    // real environment, which would make them order-dependent.
+    #[test]
+    fn hosts_defaults_to_localhost() {
+        let a = Args::try_parse_from(["redis-tui"]).unwrap();
+        assert_eq!(a.hosts, vec!["127.0.0.1:6379".to_string()]);
+        assert_eq!(a.db, 0);
+        assert_eq!(a.username, None);
     }
 
     #[test]
-    fn parse_hosts_accepts_a_valid_file_with_comments_and_blanks() {
-        let hosts = parse_hosts_str(
-            "# leading comment\n\nredis://127.0.0.1:6379/0\n\n# another\nredis://127.0.0.1:6380/1\n",
-        )
-        .expect("valid file should parse");
-        assert_eq!(hosts.len(), 2);
-        assert_eq!(hosts[0].label, "127.0.0.1:6379");
-        assert_eq!(hosts[1].label, "127.0.0.1:6380");
-    }
-
-    // Regression: a hosts file entry is pushed to `from_entries` as the original
-    // string, unparsed. Bare shorthand is valid for `--hosts` (parse_host_entry
-    // accepts it) but `redis::Client::open` cannot connect with it, and that
-    // failure looks exactly like an unreachable host - it burns the whole
-    // retry budget and reports a live host as never having come up. A hosts
-    // file entry must be a full URL until `--hosts-file` is removed.
-    #[test]
-    fn parse_hosts_rejects_bare_host_port_and_points_at_the_url_form() {
-        let err = parse_hosts_str("127.0.0.1:16399\n").expect_err("bare shorthand is not a URL");
-        let msg = err.to_string();
-        assert!(msg.contains("line 1"), "should name the line: {}", msg);
-        assert!(
-            msg.contains("127.0.0.1:16399"),
-            "should quote the entry: {}",
-            msg
-        );
-        assert!(
-            msg.contains("redis://127.0.0.1:16399"),
-            "should point at the URL form: {}",
-            msg
-        );
-    }
-
-    /// This build has no TLS: Cargo.toml declares `redis = "1.0"` with no TLS
-    /// feature, so redis-rs refuses a `rediss://` URL outright. Reporting that at
-    /// parse time is the point - previously the entry was accepted, then spent the
-    /// whole retry budget failing to connect before being silently dropped.
-    #[test]
-    fn parse_hosts_rejects_rediss_because_tls_is_not_compiled_in() {
-        let err = parse_hosts_str("rediss://example.com:6380/0\n")
-            .expect_err("this build has no TLS support");
-        let msg = err.to_string();
-        assert!(msg.contains("line 1"), "should name the line: {}", msg);
-        assert!(
-            msg.to_lowercase().contains("tls"),
-            "should say why, mentioning TLS: {}",
-            msg
-        );
+    fn hosts_accepts_several_space_separated_values() {
+        let a = Args::try_parse_from(["redis-tui", "--hosts", "db1", "db2:6380"]).unwrap();
+        assert_eq!(a.hosts, vec!["db1".to_string(), "db2:6380".to_string()]);
     }
 
     #[test]
-    fn parse_hosts_rejects_a_url_with_no_host() {
-        let err = parse_hosts_str("redis://\n").expect_err("no host is not usable");
-        assert!(err.to_string().contains("line 1"), "{}", err);
+    fn hosts_is_repeatable() {
+        let a = Args::try_parse_from(["redis-tui", "--hosts", "db1", "--hosts", "db2"]).unwrap();
+        assert_eq!(a.hosts, vec!["db1".to_string(), "db2".to_string()]);
     }
 
     #[test]
-    fn parse_hosts_rejects_outright_garbage() {
-        let err = parse_hosts_str("!!! not a url at all\n").expect_err("garbage is not a URL");
-        assert!(err.to_string().contains("line 1"), "{}", err);
+    fn a_following_flag_is_not_swallowed_by_the_hosts_list() {
+        let a = Args::try_parse_from(["redis-tui", "--hosts", "db1", "db2", "--db", "4"]).unwrap();
+        assert_eq!(a.hosts, vec!["db1".to_string(), "db2".to_string()]);
+        assert_eq!(a.db, 4);
     }
 
     #[test]
-    fn parse_hosts_reports_every_bad_line_not_just_the_first() {
-        let err =
-            parse_hosts_str("localhost:notaport\nredis://127.0.0.1:6379\nalso-bad:notaport\n")
-                .expect_err("two bad lines");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("localhost:notaport"),
-            "first bad entry: {}",
-            msg
-        );
-        assert!(
-            msg.contains("also-bad:notaport"),
-            "second bad entry: {}",
-            msg
-        );
+    fn the_removed_flags_are_rejected() {
+        for flag in ["--host", "--port", "--url", "--hosts-file"] {
+            assert!(
+                Args::try_parse_from(["redis-tui", flag, "x"]).is_err(),
+                "{} should no longer be accepted",
+                flag
+            );
+        }
     }
 
     #[test]
-    fn parse_hosts_line_numbers_count_blanks_and_comments() {
-        // The bad entry is on physical line 4; blanks and comments above it must
-        // not shift the number that gets reported.
-        let err = parse_hosts_str("# comment\n\n\nbad-entry:notaport\n").expect_err("bad entry");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("line 4"),
-            "should report physical line 4, got: {}",
-            msg
-        );
+    fn username_and_password_are_accepted() {
+        let a = Args::try_parse_from([
+            "redis-tui",
+            "--hosts",
+            "db1",
+            "--username",
+            "admin",
+            "--password",
+            "s3cret",
+        ])
+        .unwrap();
+        assert_eq!(a.username.as_deref(), Some("admin"));
+        assert_eq!(a.password.as_deref(), Some("s3cret"));
     }
 
     #[test]
-    fn parse_hosts_rejects_a_file_with_no_entries() {
-        let err = parse_hosts_str("# only a comment\n\n").expect_err("nothing usable");
-        assert!(err.to_string().contains("no valid URLs"), "{}", err);
+    fn numeric_ranges_are_still_enforced() {
+        assert!(Args::try_parse_from(["redis-tui", "--connect-timeout", "0"]).is_err());
+        assert!(Args::try_parse_from(["redis-tui", "--rate-history", "0"]).is_err());
+        assert!(Args::try_parse_from(["redis-tui", "--rate-avg-window", "0"]).is_err());
+    }
+
+    #[test]
+    fn help_advertises_the_environment_variables() {
+        let help = Args::command().render_help().to_string();
+        for var in [
+            "REDIS_TUI_HOSTS",
+            "REDIS_TUI_USERNAME",
+            "REDIS_TUI_PASSWORD",
+            "REDIS_TUI_DB",
+            "REDIS_TUI_RATE_HISTORY",
+            "REDIS_TUI_RATE_AVG_WINDOW",
+            "REDIS_TUI_CONNECT_RETRIES",
+            "REDIS_TUI_CONNECT_TIMEOUT",
+        ] {
+            assert!(help.contains(var), "--help should mention {}", var);
+        }
     }
 }

--- a/src/redis_client.rs
+++ b/src/redis_client.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use redis::{Commands, ConnectionLike};
+use redis::{Commands, ConnectionLike, IntoConnectionInfo};
 use std::collections::HashMap;
 
 /// Information about a Redis key
@@ -31,44 +31,12 @@ pub enum RedisValue {
     Unknown(String),
 }
 
-#[allow(dead_code)]
 pub struct RedisClient {
     connection: redis::Connection,
-    pub url: String,
+    info: redis::ConnectionInfo,
+    /// `host:port`. Display only, and never contains credentials.
+    pub label: String,
     pub db: i64,
-}
-
-/// Extract the database number from a Redis URL, e.g. `redis://host:6379/3` -> 3.
-///
-/// Returns 0 when the URL carries no usable database component. Query strings and
-/// fragments are stripped first, so `redis://host/3?timeout=5` yields 3 rather than
-/// silently falling back to 0, and a trailing slash (`redis://host/3/`) is tolerated.
-/// Socket timeout used by `RedisClient::connect`. Multi-host startup overrides
-/// this via `connect_with_timeout` so its retry budget stays bounded.
-const DEFAULT_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
-
-fn parse_db_from_url(url: &str) -> i64 {
-    // Strip `?query` and `#fragment` before looking at the path.
-    let trimmed = url.split(['?', '#']).next().unwrap_or(url);
-
-    // Skip past `scheme://` so the authority's own separators aren't read as a path.
-    let after_scheme = match trimmed.find("://") {
-        Some(i) => &trimmed[i + 3..],
-        None => trimmed,
-    };
-
-    // The path begins at the first '/' after the authority. No '/' means no db given.
-    let Some((_, path)) = after_scheme.split_once('/') else {
-        return 0;
-    };
-
-    // Take the last *non-empty* segment: a trailing slash ("/3/") would otherwise
-    // yield an empty final segment and look like no db was given at all.
-    path.rsplit('/')
-        .find(|segment| !segment.is_empty())
-        .and_then(|s| s.parse::<i64>().ok())
-        .filter(|db| *db >= 0)
-        .unwrap_or(0)
 }
 
 /// Validate a TTL before any command is sent to Redis.
@@ -92,28 +60,55 @@ fn validate_ttl(ttl: i64, key: &str) -> Result<()> {
 }
 
 impl RedisClient {
+    /// Connect using a URL. Retained for the unit tests here and the
+    /// `#[ignore]`d live tests, which have a URL and no defaults to apply.
+    ///
+    /// Nothing in the production binary calls this any more: `StreamListener`
+    /// and `SignalGenerator` take a `ConnectionInfo` directly and go through
+    /// `connect_with_info`, each with a hardcoded 10s timeout rather than the
+    /// user's `--connect-timeout` - threading that through is a separate
+    /// change (#44) alongside the socket *read* timeout, which is out of
+    /// scope here too. So rustc sees this as dead code in a plain
+    /// `cargo build`; it is exercised by `cargo test`.
+    #[allow(dead_code)]
     pub fn connect(url: &str) -> Result<Self> {
-        Self::connect_with_timeout(url, DEFAULT_CONNECT_TIMEOUT)
+        let info = url
+            .into_connection_info()
+            .with_context(|| format!("Failed to parse Redis URL {}", url))?;
+        let label = match info.addr() {
+            redis::ConnectionAddr::Tcp(h, p) => format!("{}:{}", h, p),
+            _ => url.to_string(),
+        };
+        Self::connect_with_info(info, &label, std::time::Duration::from_secs(10))
     }
 
-    /// Connect with an explicit socket timeout. `from_urls` uses this so the
-    /// startup retry budget is actually bounded: with the fixed 10s timeout, a
-    /// host that black-holes packets cost 10s per attempt on top of the sleep.
-    pub fn connect_with_timeout(url: &str, timeout: std::time::Duration) -> Result<Self> {
-        let client = redis::Client::open(url)
-            .with_context(|| format!("Failed to create Redis client for {}", url))?;
+    /// Connect with an explicit socket timeout, so the startup retry budget is
+    /// actually bounded: a host that black-holes packets costs one timeout per
+    /// attempt on top of the sleep.
+    pub fn connect_with_info(
+        info: redis::ConnectionInfo,
+        label: &str,
+        timeout: std::time::Duration,
+    ) -> Result<Self> {
+        let db = info.redis_settings().db();
+        let client = redis::Client::open(info.clone())
+            .with_context(|| format!("Failed to create Redis client for {}", label))?;
         let connection = client
             .get_connection_with_timeout(timeout)
-            .with_context(|| format!("Failed to connect to {}", url))?;
-
-        // Parse db number from URL (e.g., redis://host:port/3)
-        let db = parse_db_from_url(url);
+            .with_context(|| format!("Failed to connect to {}", label))?;
 
         Ok(Self {
             connection,
-            url: url.to_string(),
+            info,
+            label: label.to_string(),
             db,
         })
+    }
+
+    /// The parsed connection info this client was built from, for a
+    /// background thread to open its own connection with.
+    pub fn connection_info(&self) -> redis::ConnectionInfo {
+        self.info.clone()
     }
 
     pub fn select_db(&mut self, db: i64) -> Result<()> {
@@ -549,51 +544,36 @@ pub struct MultiRedisClient {
 }
 
 impl MultiRedisClient {
-    /// Create from a single URL (backwards-compatible).
-    pub fn from_single(url: &str) -> Result<Self> {
-        let client = RedisClient::connect(url)?;
-        let db = client.db;
-        Ok(Self {
-            labels: vec![url.to_string()],
-            clients: vec![client],
-            key_owner: HashMap::new(),
-            collisions: Vec::new(),
-            db,
-        })
-    }
-
-    /// Create from multiple URLs, retrying hosts that aren't up yet.
+    /// Connect to every entry, retrying the ones that are not up yet.
     ///
-    /// `max_retries` and `connect_timeout` are caller-supplied so startup cannot
-    /// stall indefinitely. Entries here are already known to be well-formed -
-    /// `parse_hosts_file` rejects unparseable URLs before this is reached - so
-    /// every retry is against a host that could plausibly come up.
-    pub fn from_urls(
-        urls: &[(String, String)],
+    /// `max_retries` and `connect_timeout` are caller-supplied so startup
+    /// cannot stall indefinitely. Entries are already known to be well-formed:
+    /// `hosts::parse_host_entry` rejects unparseable ones before this is
+    /// reached, so every retry is against a host that could plausibly come up.
+    pub fn from_entries(
+        entries: &[crate::hosts::HostEntry],
         max_retries: u32,
         connect_timeout: std::time::Duration,
     ) -> Result<Self> {
-        let mut clients = Vec::new();
-        let mut labels = Vec::new();
-        let retry_delay = std::time::Duration::from_secs(2);
+        let mut clients: Vec<Option<RedisClient>> = Vec::new();
+        let mut labels: Vec<String> = Vec::new();
 
         // First pass: try to connect to all hosts, track failures
-        let mut pending: Vec<(usize, String, String)> = Vec::new();
-        for (i, (label, url)) in urls.iter().enumerate() {
-            match RedisClient::connect_with_timeout(url, connect_timeout) {
-                Ok(client) => {
-                    clients.push(Some(client));
-                    labels.push(label.clone());
-                }
+        let mut pending: Vec<usize> = Vec::new();
+        for (i, entry) in entries.iter().enumerate() {
+            labels.push(entry.label.clone());
+            match RedisClient::connect_with_info(entry.info.clone(), &entry.label, connect_timeout)
+            {
+                Ok(client) => clients.push(Some(client)),
                 Err(_) => {
                     clients.push(None);
-                    labels.push(label.clone());
-                    pending.push((i, label.clone(), url.clone()));
+                    pending.push(i);
                 }
             }
         }
 
         // Retry failed connections
+        let retry_delay = std::time::Duration::from_secs(2);
         let mut attempt: u32 = 0;
         while !pending.is_empty() && attempt < max_retries {
             attempt += 1;
@@ -605,11 +585,15 @@ impl MultiRedisClient {
             );
             std::thread::sleep(retry_delay);
 
-            pending.retain(|(i, label, url)| {
-                match RedisClient::connect_with_timeout(url, connect_timeout) {
+            pending.retain(|&i| {
+                match RedisClient::connect_with_info(
+                    entries[i].info.clone(),
+                    &entries[i].label,
+                    connect_timeout,
+                ) {
                     Ok(client) => {
-                        eprintln!("  Connected to {}", label);
-                        clients[*i] = Some(client);
+                        eprintln!("  Connected to {}", entries[i].label);
+                        clients[i] = Some(client);
                         false // remove from pending
                     }
                     Err(_) => true, // keep retrying
@@ -623,8 +607,12 @@ impl MultiRedisClient {
         let mut failed = Vec::new();
         for (i, opt) in clients.into_iter().enumerate() {
             if let Some(client) = opt {
+                // Read from the client itself rather than the `labels` array
+                // tracked above - the two always agree (both trace back to
+                // `entries[i].label`), but this way there is one source of
+                // truth instead of two copies that merely happen to match.
+                final_labels.push(client.label.clone());
                 final_clients.push(client);
-                final_labels.push(labels[i].clone());
             } else {
                 failed.push(labels[i].clone());
             }
@@ -642,15 +630,19 @@ impl MultiRedisClient {
         }
 
         if final_clients.is_empty() {
-            anyhow::bail!("Failed to connect to any Redis host");
+            anyhow::bail!(
+                "Could not connect to any of the {} host(s) given",
+                entries.len()
+            );
         }
 
+        let db = final_clients[0].db;
         Ok(Self {
             clients: final_clients,
             labels: final_labels,
             key_owner: HashMap::new(),
             collisions: Vec::new(),
-            db: 0,
+            db,
         })
     }
 
@@ -823,16 +815,11 @@ impl MultiRedisClient {
         self.client_for_key(old_key).rename_key(old_key, new_key)
     }
 
-    /// Get the first URL (used for stream listener/signal generator connections).
-    #[allow(dead_code)]
-    pub fn first_url(&self) -> &str {
-        &self.clients[0].url
-    }
-
-    /// Get the URL for the host that owns a key.
-    pub fn url_for_key(&self, key: &str) -> &str {
+    /// Connection info for the host owning `key`, for a background thread to
+    /// open its own connection with.
+    pub fn info_for_key(&self, key: &str) -> redis::ConnectionInfo {
         let idx = self.host_index_for_key(key);
-        &self.clients[idx].url
+        self.clients[idx].connection_info()
     }
 
     pub fn host_count(&self) -> usize {
@@ -1026,6 +1013,19 @@ mod tests {
             .unwrap()
     }
 
+    /// A single-host `MultiRedisClient` for tests that just need a live
+    /// connection, not any particular entry defaults or retry behaviour.
+    fn connect_multi(url: &str) -> MultiRedisClient {
+        let entry =
+            crate::hosts::parse_host_entry(url, &crate::hosts::HostDefaults::default()).unwrap();
+        MultiRedisClient::from_entries(
+            std::slice::from_ref(&entry),
+            0,
+            std::time::Duration::from_secs(3),
+        )
+        .unwrap()
+    }
+
     #[test]
     #[ignore = "requires redis-server; run with: cargo test -- --ignored"]
     fn reported_db_matches_actual_db_with_query_string() {
@@ -1069,7 +1069,7 @@ mod tests {
         set_key(&mut seed, "beta", "keep-me-too");
         drop(seed);
 
-        let mut multi = MultiRedisClient::from_single(&server.url()).unwrap();
+        let mut multi = connect_multi(&server.url());
         let mut app = crate::app::App::new();
         app.refresh_keys(&mut multi);
         assert_eq!(app.keys, vec!["alpha".to_string(), "beta".to_string()]);
@@ -1131,7 +1131,7 @@ mod tests {
         set_key(&mut seed, "aaa", "value-of-aaa");
         drop(seed);
 
-        let mut multi = MultiRedisClient::from_single(&url).unwrap();
+        let mut multi = connect_multi(&url);
         let mut app = crate::app::App::new();
         app.refresh_keys(&mut multi);
         app.key_list_state.select(Some(0));
@@ -1172,7 +1172,7 @@ mod tests {
         let mut seed = RedisClient::connect(&server.url()).unwrap();
         set_key(&mut seed, "aaa", "value-of-aaa");
 
-        let mut multi = MultiRedisClient::from_single(&server.url()).unwrap();
+        let mut multi = connect_multi(&server.url());
         let mut app = crate::app::App::new();
         app.refresh_keys(&mut multi);
         app.key_list_state.select(Some(0));
@@ -1214,7 +1214,7 @@ mod tests {
             .unwrap();
         drop(seed);
 
-        let mut multi = MultiRedisClient::from_single(&server.url()).unwrap();
+        let mut multi = connect_multi(&server.url());
         let mut app = crate::app::App::new();
         app.refresh_keys(&mut multi);
 
@@ -1314,77 +1314,28 @@ mod tests {
         assert!(ttl > 0 && ttl <= 120, "expected a live ttl, got {}", ttl);
     }
 
-    // ---- #9: DB number parsing from URL ----
-
-    #[test]
-    fn db_parses_from_plain_path() {
-        assert_eq!(parse_db_from_url("redis://127.0.0.1:6379/3"), 3);
-    }
-
-    #[test]
-    fn db_parses_with_query_string() {
-        // The original bug: rsplit('/') yields "3?timeout=5", which fails to parse.
-        assert_eq!(parse_db_from_url("redis://127.0.0.1:6379/3?timeout=5"), 3);
-    }
-
-    #[test]
-    fn db_parses_with_fragment() {
-        assert_eq!(parse_db_from_url("redis://127.0.0.1:6379/7#frag"), 7);
-    }
-
-    #[test]
-    fn db_defaults_to_zero_without_path() {
-        // No path component at all - must be 0 deliberately, not by parse failure.
-        assert_eq!(parse_db_from_url("redis://127.0.0.1:6379"), 0);
-    }
-
-    #[test]
-    fn db_defaults_to_zero_for_non_numeric_path() {
-        assert_eq!(parse_db_from_url("redis://127.0.0.1:6379/notanumber"), 0);
-    }
-
-    #[test]
-    fn db_parses_with_auth_in_url() {
-        assert_eq!(parse_db_from_url("redis://user:pw@127.0.0.1:6379/5"), 5);
-    }
-
-    #[test]
-    fn db_parses_with_trailing_slash() {
-        // rsplit('/') on "3/" yields an empty final segment, which must not be
-        // mistaken for "no db given".
-        assert_eq!(parse_db_from_url("redis://127.0.0.1:6379/3/"), 3);
-    }
-
-    #[test]
-    fn db_parses_with_query_string_after_trailing_slash() {
-        assert_eq!(parse_db_from_url("redis://127.0.0.1:6379/3/?timeout=5"), 3);
-    }
-
-    #[test]
-    fn db_rejects_negative_number() {
-        // A negative DB is nonsense and would only fail later at SELECT.
-        assert_eq!(parse_db_from_url("redis://127.0.0.1:6379/-1"), 0);
-    }
-
-    #[test]
-    fn db_parses_with_empty_path() {
-        assert_eq!(parse_db_from_url("redis://127.0.0.1:6379/"), 0);
-    }
-
     /// A host that is well-formed but not listening must not hold startup for the
     /// old 15 x (10s connect + 2s sleep) budget. Uses a port the OS just handed
     /// back and released, so the connection is refused immediately and what this
     /// measures is the retry budget rather than network latency.
     #[test]
-    fn from_urls_gives_up_on_an_unreachable_host_quickly() {
+    fn from_entries_gives_up_on_an_unreachable_host_quickly() {
         let port = match free_port() {
             Some(p) => p,
             None => return,
         };
-        let urls = vec![("dead".to_string(), format!("redis://127.0.0.1:{}", port))];
+        let entry = crate::hosts::parse_host_entry(
+            &format!("127.0.0.1:{}", port),
+            &crate::hosts::HostDefaults::default(),
+        )
+        .unwrap();
 
         let start = std::time::Instant::now();
-        let result = MultiRedisClient::from_urls(&urls, 2, std::time::Duration::from_secs(1));
+        let result = MultiRedisClient::from_entries(
+            std::slice::from_ref(&entry),
+            2,
+            std::time::Duration::from_secs(1),
+        );
         let elapsed = start.elapsed();
 
         assert!(
@@ -1396,5 +1347,67 @@ mod tests {
             "gave up after {:?}; the retry budget is not being honoured",
             elapsed
         );
+    }
+
+    /// #42: a password containing URL metacharacters must actually authenticate.
+    /// Building a URL string mangled these; ConnectionInfo carries them verbatim.
+    #[test]
+    #[ignore = "requires redis-server; run with: cargo test -- --ignored"]
+    fn connects_with_a_password_containing_url_metacharacters() {
+        let server = TestRedis::start();
+        let password = "p/a:s#s?w@rd";
+
+        let mut admin = RedisClient::connect(&server.url()).unwrap();
+        redis::cmd("CONFIG")
+            .arg("SET")
+            .arg("requirepass")
+            .arg(password)
+            .exec(&mut admin.connection)
+            .unwrap();
+        drop(admin);
+
+        let defaults = crate::hosts::HostDefaults {
+            username: None,
+            password: Some(password.to_string()),
+            db: 0,
+        };
+        let entry =
+            crate::hosts::parse_host_entry(&format!("127.0.0.1:{}", server.port), &defaults)
+                .unwrap();
+
+        let mut client = RedisClient::connect_with_info(
+            entry.info,
+            &entry.label,
+            std::time::Duration::from_secs(3),
+        )
+        .expect("a password with / : # ? @ in it must authenticate");
+
+        let pong: String = redis::cmd("PING").query(&mut client.connection).unwrap();
+        assert_eq!(pong, "PONG");
+    }
+
+    /// The db comes from the parsed connection info, not from re-parsing a URL.
+    #[test]
+    #[ignore = "requires redis-server; run with: cargo test -- --ignored"]
+    fn from_entries_reports_the_db_from_the_entry() {
+        let server = TestRedis::start();
+        let defaults = crate::hosts::HostDefaults {
+            username: None,
+            password: None,
+            db: 3,
+        };
+        let entry =
+            crate::hosts::parse_host_entry(&format!("127.0.0.1:{}", server.port), &defaults)
+                .unwrap();
+
+        let multi = MultiRedisClient::from_entries(
+            std::slice::from_ref(&entry),
+            0,
+            std::time::Duration::from_secs(3),
+        )
+        .unwrap();
+
+        assert_eq!(multi.db, 3);
+        assert_eq!(multi.host_count(), 1);
     }
 }

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -10,7 +10,6 @@ set -euo pipefail
 # there is nothing here worth persisting.
 REDIS_PORT_1=6379
 REDIS_PORT_2=6380
-HOSTS_FILE="/tmp/redis-tui-hosts.txt"
 
 echo "=== Redis TUI Dev Environment (Multi-Host) ==="
 
@@ -265,22 +264,14 @@ echo "  shared:active_users"
 $CLI2 -n 1 SET "db1:node2_key" "This is in database 1 on node 2" >/dev/null
 $CLI2 -n 1 HSET "db1:info" description "DB 1 on node 2" purpose "collision test" >/dev/null
 
-# ─── Write hosts file ────────────────────────────────────
-cat > "$HOSTS_FILE" <<EOF
-# Redis TUI multi-host dev config
-redis://127.0.0.1:${REDIS_PORT_1}/0
-redis://127.0.0.1:${REDIS_PORT_2}/0
-EOF
-
 # ─── Summary ──────────────────────────────────────────────
 echo ""
 echo "=== Test Data Loaded ==="
 echo "Node 1 (port $REDIS_PORT_1) keys in DB 0: $($CLI1 DBSIZE | tr -d '\r')"
 echo "Node 2 (port $REDIS_PORT_2) keys in DB 0: $($CLI2 DBSIZE | tr -d '\r')"
 echo "Collision keys: shared:collision_test, shared:status, shared:active_users"
-echo "Hosts file: $HOSTS_FILE"
 echo ""
 echo "=== Starting Redis TUI (multi-host) ==="
 echo ""
 
-cargo run -- --hosts-file "$HOSTS_FILE"
+cargo run -- --hosts "127.0.0.1:${REDIS_PORT_1}" "127.0.0.1:${REDIS_PORT_2}"


### PR DESCRIPTION
Closes #109. Fixes #42.

`--port`, `--url` and `--hosts-file` are replaced by a single repeatable `--hosts` list, `--username` is added, and every option is settable from the environment as `REDIS_TUI_*`. `--host` is kept as a deprecated, unadvertised alias for `--hosts`, so a 1.x command naming a single host keeps working.

**Breaking, so `1.3.10` -> `2.0.0`.** `MANUAL.md` carries a migration table for each removed flag.

## What changed

- **`src/hosts.rs` (new)** — turns each entry into a `redis::ConnectionInfo` built programmatically, never by formatting a URL string. That is what structurally fixes #42: a password containing `/ # ? @` now reaches the connection verbatim instead of being mangled by interpolation. An entry is a bare host, `host:port`, or a full `redis://` URL; a URL entry is self-contained and ignores the flag defaults. Every bad entry is reported at once rather than one per run.
- **`src/redis_client.rs`** — `RedisClient` carries `ConnectionInfo` plus a credential-free display label instead of a URL string, which collapses the single-host and multi-host paths into one connection path. There is no longer a second source of truth to override anything.
- **`src/main.rs`** — the new flag surface, via clap's `env` feature, giving CLI > environment > default precedence. `--help` prints each variable next to its flag, so the docs cannot drift from the code.

This removes two silent behaviours rather than patching them: `--hosts-file` used to win over `--host`/`--port`/`--password`/`--db` with no warning and no mention in the docs, and the connect-timeout flag was ignored on the single-host path.

## Migration

| 1.x | 2.0 |
|-----|-----|
| `--host db1` | works as-is; `--hosts db1` preferred |
| `--host db1 --port 6380` | `--hosts db1:6380` |
| `--url redis://:pw@db1/2` | `--hosts redis://:pw@db1/2` |
| `--hosts-file hosts.txt` | `--hosts $(grep -v '^#' hosts.txt \| tr '\n' ' ')` |

## Deliberately out of scope

Both recorded on #109 rather than silently dropped:

- `REDIS_TUI_PASSWORD_FILE` for mounted secrets — purely additive, lands later without another breaking change.
- The socket *read* timeout, the larger half of #44. This fixes only the connect-timeout half, by removing the path that ignored the flag. Background threads still connect with a hardcoded 10s timeout inside `RedisClient::connect`; threading the configured value through `StreamListener`/`SignalGenerator` changes their signatures and belongs with #44.

## Verification

`cargo build --locked --all-targets`, `--release`, `cargo test --locked` (115 passed), `cargo test --locked -- --ignored` (12 passed, live `redis-server`), `cargo clippy --locked --all-targets -- -D warnings`, `cargo fmt --check` — all green.

Beyond the suite, checked against real servers: the environment layer end to end (`REDIS_TUI_HOSTS="db1 db2:6380"` splits and connects, and an explicit `--hosts` overrides it), and the two-host shorthand form `start-dev.sh` now uses.
