### PR TITLE
Stop the text editor destroying binary string values (#82)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,3 +147,4 @@ There is no `tests/` directory: this is a binary-only crate with no lib target, 
 - Confirmation popups carry their target in `ConfirmAction`; never re-read the live selection when the user answers, since mouse input is not gated by `InputMode`
 - `apply_plot_settings()` handles all field counts (X limits + per-slot Y limits) — no field count checks
 - One flag names where to connect. Connection info is built as `redis::ConnectionInfo`, never by formatting a URL string — a credential interpolated into a URL breaks on `/ # ? @`
+- Never pre-fill the edit popup through `from_utf8_lossy` — it is one-way, and `execute_edit` writes the field straight back. A non-UTF-8 string key opens in binary mode with an empty field instead; gate on `std::str::from_utf8`, never `is_binary()`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "redis-tui"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-tui"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 description = "A Redis TUI client inspired by Redis Insight"
 license = "BSD-3-Clause"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1567,12 +1567,39 @@ impl App {
 
         match key_type {
             "string" => {
-                let current = match &self.current_value {
-                    Some(RedisValue::String(b)) => String::from_utf8_lossy(b).to_string(),
-                    _ => String::new(),
+                // Never pre-fill through `from_utf8_lossy`. It collapses every
+                // invalid byte sequence into U+FFFD, and `execute_edit` writes
+                // that text straight back with SET, so pressing Enter on an
+                // untouched popup destroyed a binary value (#82). The question
+                // is literally "is this UTF-8", so ask that -- not
+                // `is_binary()`, which only looks for control bytes.
+                let text = match &self.current_value {
+                    Some(RedisValue::String(b)) => std::str::from_utf8(b).ok().map(str::to_string),
+                    // No value loaded: an empty text field is the old behaviour
+                    // and cannot lose anything.
+                    _ => Some(String::new()),
                 };
                 self.edit_operation = Some(EditOperation::SetString);
-                self.edit_fields = vec![("Value".to_string(), current)];
+                match text {
+                    Some(t) => {
+                        self.edit_binary_mode = false;
+                        self.edit_fields = vec![("Value".to_string(), t)];
+                    }
+                    None => {
+                        // Binary: open straight into binary mode with an empty
+                        // field, so the value has to be re-entered deliberately
+                        // as numbers. `encode_values` rejects an empty field, so
+                        // Enter without typing reports an error and writes
+                        // nothing, rather than destroying the key.
+                        self.edit_binary_mode = true;
+                        self.edit_fields = vec![("Value".to_string(), String::new())];
+                        self.status_message = format!(
+                            "'{}' holds non-UTF-8 bytes - type new values as {} (Ctrl+T changes type)",
+                            key,
+                            DataType::all()[self.edit_binary_dtype_idx]
+                        );
+                    }
+                }
             }
             "hash" => {
                 self.edit_operation = Some(EditOperation::HSet);
@@ -2226,6 +2253,104 @@ pub fn compute_fft_magnitude(data: &[f64]) -> Vec<f64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ─── #82: editing a binary string must not destroy it ────
+
+    /// An `App` sitting on one selected string key holding `bytes`.
+    fn app_on_string_key(bytes: &[u8]) -> App {
+        let mut app = App::new();
+        app.keys = vec!["blob:float32_1k".to_string()];
+        app.key_list_state.select(Some(0));
+        app.current_key_info = Some(KeyInfo {
+            name: "blob:float32_1k".to_string(),
+            key_type: "string".to_string(),
+            ttl: -1,
+            size: bytes.len() as i64,
+            encoding: "raw".to_string(),
+        });
+        app.current_value = Some(RedisValue::String(bytes.to_vec()));
+        app
+    }
+
+    /// 1000 little-endian float32 samples, as `start-dev.sh` seeds.
+    fn float32_blob() -> Vec<u8> {
+        (0..1000u32)
+            .flat_map(|i| ((i as f32) * 0.01).sin().to_le_bytes())
+            .collect()
+    }
+
+    // The reported bug: `s` then Enter, typing nothing, rewrote the key through
+    // `String::from_utf8_lossy` and grew a 4000-byte blob to 6847 bytes of
+    // U+FFFD. Nothing lossy may reach the edit field.
+    #[test]
+    fn editing_a_non_utf8_string_does_not_prefill_lossy_text() {
+        let blob = float32_blob();
+        assert!(std::str::from_utf8(&blob).is_err(), "blob must be binary");
+
+        let mut app = app_on_string_key(&blob);
+        app.start_edit();
+
+        assert_eq!(app.edit_fields.len(), 1);
+        let field = &app.edit_fields[0].1;
+        assert!(
+            !field.contains('\u{FFFD}'),
+            "replacement chars reached the edit field: {:?}",
+            field
+        );
+        assert!(
+            field.is_empty(),
+            "field should start empty, got {:?}",
+            field
+        );
+    }
+
+    #[test]
+    fn editing_a_non_utf8_string_opens_in_binary_mode() {
+        let mut app = app_on_string_key(&float32_blob());
+        app.start_edit();
+        assert!(
+            app.edit_binary_mode,
+            "binary mode must be on so the write path encodes bytes"
+        );
+        assert_eq!(app.input_mode, InputMode::Edit);
+    }
+
+    #[test]
+    fn editing_a_non_utf8_string_says_why() {
+        let mut app = app_on_string_key(&float32_blob());
+        app.start_edit();
+        assert!(
+            app.status_message.contains("non-UTF-8"),
+            "user needs to know why the field is empty: {:?}",
+            app.status_message
+        );
+    }
+
+    // The ordinary case must be untouched: text keys still pre-fill as text.
+    #[test]
+    fn editing_a_utf8_string_still_prefills_the_text() {
+        let mut app = app_on_string_key(b"hello world");
+        app.start_edit();
+        assert_eq!(app.edit_fields[0].1, "hello world");
+        assert!(!app.edit_binary_mode);
+    }
+
+    // Binary mode is sticky per-edit, so a text key opened after a binary one
+    // must not inherit it.
+    #[test]
+    fn a_text_key_opened_after_a_binary_one_is_not_left_in_binary_mode() {
+        let mut app = app_on_string_key(&float32_blob());
+        app.start_edit();
+        assert!(app.edit_binary_mode);
+
+        app.cancel_edit();
+        app.current_value = Some(RedisValue::String(b"plain text".to_vec()));
+        app.start_edit();
+        assert!(
+            !app.edit_binary_mode,
+            "binary mode leaked from the previous edit"
+        );
+    }
 
     // ---- #31: plot limit validation rejects non-finite values ----
 

--- a/src/redis_client.rs
+++ b/src/redis_client.rs
@@ -1055,6 +1055,51 @@ mod tests {
     }
 
     /// End-to-end: the skipped count must reach the status line the user actually reads.
+    // #82: the exact reported sequence -- select a binary key, press `s`, press
+    // Enter without typing anything -- grew a 4000-byte float32 blob to 6847
+    // bytes of U+FFFD. It must now leave the bytes untouched.
+    #[test]
+    #[ignore = "requires redis-server; run with: cargo test -- --ignored"]
+    fn enter_on_an_untouched_edit_popup_cannot_destroy_a_binary_key() {
+        let server = TestRedis::start();
+
+        // 1000 little-endian float32 samples, as `start-dev.sh` seeds.
+        let blob: Vec<u8> = (0..1000u32)
+            .flat_map(|i| ((i as f32) * 0.01).sin().to_le_bytes())
+            .collect();
+        assert_eq!(blob.len(), 4000);
+
+        let mut seed = RedisClient::connect(&server.url()).unwrap();
+        redis::cmd("SET")
+            .arg("blob:float32_1k")
+            .arg(&blob)
+            .query::<()>(&mut seed.connection)
+            .unwrap();
+        drop(seed);
+
+        let mut multi = connect_multi(&server.url());
+        let mut app = crate::app::App::new();
+        app.refresh_keys(&mut multi);
+        app.key_list_state.select(Some(0));
+        app.load_selected_value(&mut multi);
+
+        app.start_edit();
+        let result = app.execute_edit(&mut multi);
+        assert!(
+            result.is_err(),
+            "an untouched popup must not write, got {:?}",
+            result
+        );
+
+        let mut check = RedisClient::connect(&server.url()).unwrap();
+        let after: Vec<u8> = redis::cmd("GET")
+            .arg("blob:float32_1k")
+            .query(&mut check.connection)
+            .unwrap();
+        assert_eq!(after.len(), blob.len(), "length changed");
+        assert_eq!(after, blob, "the blob was modified");
+    }
+
     /// Regression test for the delete confirmation acting on the live selection.
     ///
     /// The popup is half the frame wide and does not cover the key list, and mouse


### PR DESCRIPTION
Fixes #82.

Pressing `s` on a string key holding non-UTF-8 bytes, then Enter without typing anything, destroyed the key. `start_edit` pre-filled the Value field through `String::from_utf8_lossy` — a one-way transform — and `execute_edit` wrote that text straight back with `SET`. The reported case grew a 4000-byte float32 blob to 6847 bytes, with 1439 of its 1000 samples unrecoverable.

The binary escape hatch existed but could not save you: `edit_binary_mode` is `false` in `App::new` and reset by `cancel_edit` after every edit and every `Esc`, so the destructive branch was always the one selected, and by then the pre-filled U+FFFD text was not parseable anyway.

## The fix

`start_edit`'s `string` arm now branches on `std::str::from_utf8`:

- **Valid UTF-8** — unchanged: pre-fill the text, binary mode off.
- **Not UTF-8** — open straight into binary mode with an **empty** field, and say why in the status line: `'blob:float32_1k' holds non-UTF-8 bytes - type new values as Float32 (Ctrl+T changes type)`.

The value therefore has to be re-entered deliberately as numbers. `encode_values` rejects an empty field (`No values to encode`), so Enter without typing now reports an error and writes nothing instead of destroying the key.

`is_binary()` is deliberately *not* the predicate — it only looks for control bytes, so it misses a lone `0xFF` and false-positives on valid UTF-8 containing `0x00`. `CLAUDE.md` already warned against using it to gate binary handling; this adds the matching note for the edit path.

Opening the popup in binary mode (rather than refusing to open it at all) matters because `Ctrl+B` is handled inside `handle_edit_input` — refusing would have left no route to editing a binary key.

## Tests

`start_edit` had no test coverage at all. Added to `src/app.rs`: a non-UTF-8 value must not put replacement characters in the field, must open in binary mode, must explain itself; a UTF-8 value must still pre-fill as text; and binary mode must not leak into the next edit.

Added to `src/redis_client.rs` as an `#[ignore]`d live test: the reported sequence end to end against a throwaway `redis-server` — seed the 4000-byte blob, `start_edit`, `execute_edit`, assert the write is refused and the bytes are byte-identical afterward. **Verified it fails on the old code**, where `execute_edit` returns `Ok` because it wrote.

## Verification

`cargo build --locked --all-targets`, `--release`, `cargo test --locked` (120 passed, 13 ignored), `cargo test --locked -- --ignored` (13 passed), `cargo clippy --locked --all-targets -- -D warnings`, `cargo fmt --check` — all green.

## Not included

The issue also suggests a red warning line in `draw_edit_popup`. The popup already shows `Binary: ON` and the status line explains the situation, so that is left out to keep this focused; happy to add it if you'd rather have it.

`2.0.0` -> `2.0.1`.