### PR TITLE
Stop non-ASCII key names panicking the TUI (#85)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "redis-tui"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-tui"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 description = "A Redis TUI client inspired by Redis Insight"
 license = "BSD-3-Clause"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1319,11 +1319,7 @@ impl App {
                 let y_max = slot
                     .y_max
                     .unwrap_or(if auto_max.is_finite() { auto_max } else { 1.0 });
-                let short_name = if slot.key_name.len() > 10 {
-                    format!("{}...", &slot.key_name[..10])
-                } else {
-                    slot.key_name.clone()
-                };
+                let short_name = crate::data::truncate_key_name(&slot.key_name, 10);
                 fields.push((format!("{} Y Min", short_name), format!("{:.2}", y_min)));
                 fields.push((format!("{} Y Max", short_name), format!("{:.2}", y_max)));
             }
@@ -2350,6 +2346,60 @@ mod tests {
             !app.edit_binary_mode,
             "binary mode leaked from the previous edit"
         );
+    }
+
+    // ─── #85: multi-byte key names must not panic ────────────
+
+    // `str::len()` is bytes but `str` indexing needs a char boundary, so
+    // `&name[..10]` on a name whose byte 10 lands mid-character panics. These
+    // names are supported input: scan_keys drops only keys that fail UTF-8
+    // decoding, so Japanese and Cyrillic names reach the plot slots intact.
+    #[test]
+    fn plot_settings_survives_a_multi_byte_key_name() {
+        let mut app = App::new();
+        app.toggle_plot_slot("温度センサー");
+        app.plot_slots[0].data = vec![1.0, 2.0, 3.0];
+
+        app.start_plot_settings();
+
+        let labels: Vec<&str> = app.edit_fields.iter().map(|(l, _)| l.as_str()).collect();
+        assert!(
+            labels.iter().any(|l| l.contains("温度")),
+            "the slot's Y limit fields should be labelled with its name: {:?}",
+            labels
+        );
+    }
+
+    // The issue's cheapest repro: `p` then `x` on a key with no plottable data.
+    #[test]
+    fn plot_settings_survives_a_multi_byte_key_name_with_no_data() {
+        let mut app = App::new();
+        app.toggle_plot_slot("温度センサー");
+        app.start_plot_settings();
+    }
+
+    #[test]
+    fn a_long_multi_byte_name_is_shortened_without_splitting_a_character() {
+        let mut app = App::new();
+        app.toggle_plot_slot("温度センサー_ストリーム_データ");
+        app.plot_slots[0].data = vec![1.0];
+
+        app.start_plot_settings();
+
+        // X Min/X Max come first; the per-slot Y limits follow.
+        let label = app
+            .edit_fields
+            .iter()
+            .map(|(l, _)| l.as_str())
+            .find(|l| l.contains("温度"))
+            .expect("the slot should contribute a labelled field");
+        assert!(
+            label.contains("..."),
+            "long name should be elided: {}",
+            label
+        );
+        // Every char must have survived intact -- no replacement or panic.
+        assert!(label.starts_with("温度センサー"), "got {}", label);
     }
 
     // ---- #31: plot limit validation rejects non-finite values ----

--- a/src/data.rs
+++ b/src/data.rs
@@ -308,9 +308,60 @@ pub fn is_binary(bytes: &[u8]) -> bool {
         .any(|&b| b < 0x20 && b != b'\n' && b != b'\r' && b != b'\t')
 }
 
+/// Truncate to at most `max_chars` characters, appending "..." if shortened.
+///
+/// `str::len()` is a byte count but `str` indexing requires a char boundary, so
+/// the old `if name.len() > N { &name[..N] }` pattern panicked on any name whose
+/// byte N landed inside a multi-byte character (#85). Testing and cutting in one
+/// operation removes the mismatch, so the bug cannot come back by copying the
+/// pattern to a fifth site.
+///
+/// `max_chars` counts characters, not terminal columns: 12 CJK characters still
+/// occupy roughly 24 columns.
+pub fn truncate_key_name(name: &str, max_chars: usize) -> String {
+    match name.char_indices().nth(max_chars) {
+        Some((byte_idx, _)) => format!("{}...", &name[..byte_idx]),
+        None => name.to_string(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ─── #85: char-safe truncation ───────────────────────────
+
+    #[test]
+    fn a_short_name_is_returned_unchanged() {
+        assert_eq!(truncate_key_name("temp", 10), "temp");
+    }
+
+    #[test]
+    fn a_name_of_exactly_the_limit_is_not_elided() {
+        assert_eq!(truncate_key_name("0123456789", 10), "0123456789");
+    }
+
+    #[test]
+    fn a_long_ascii_name_is_elided() {
+        assert_eq!(truncate_key_name("0123456789abc", 10), "0123456789...");
+    }
+
+    // The regression: byte 10 of this name is inside 'ン', so `&name[..10]`
+    // panicked. Cutting at a character index cannot split a character.
+    #[test]
+    fn a_long_multi_byte_name_is_cut_on_a_character_boundary() {
+        assert_eq!(
+            truncate_key_name("温度センサー_データ", 10),
+            "温度センサー_データ"
+        );
+        assert_eq!(truncate_key_name("温度センサー_データ", 5), "温度センサ...");
+    }
+
+    #[test]
+    fn counts_characters_not_bytes() {
+        // Six characters, eighteen bytes: under a six-character limit it stays.
+        assert_eq!(truncate_key_name("温度センサー", 6), "温度センサー");
+    }
 
     // ---- decode_blob: normal decoding ----
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -813,11 +813,7 @@ fn draw_signal_chart(
                 let mut parts = vec![format!(" x:{:.0}", hx)];
                 for slot in &app.plot_slots {
                     if let Some(&val) = slot.data.get(x_idx) {
-                        let short = if slot.key_name.len() > 8 {
-                            format!("{}...", &slot.key_name[..8])
-                        } else {
-                            slot.key_name.clone()
-                        };
+                        let short = crate::data::truncate_key_name(&slot.key_name, 8);
                         parts.push(format!("{}:{:.2}", short, val));
                     }
                 }
@@ -854,11 +850,7 @@ fn draw_signal_chart(
             if !slot.data.is_empty() {
                 let sr = &slot_renders[i];
                 // Truncate key name to keep legend compact
-                let short_name = if slot.key_name.len() > 12 {
-                    format!("{}...", &slot.key_name[..12])
-                } else {
-                    slot.key_name.clone()
-                };
+                let short_name = crate::data::truncate_key_name(&slot.key_name, 12);
                 let legend_name = format!(
                     "{} {} [{:.0}..{:.0}]",
                     short_name, slot.data_type, sr.y_min, sr.y_max
@@ -1091,11 +1083,7 @@ fn draw_fft_chart(frame: &mut Frame, app: &mut App, area: Rect, _border_color: C
     } else {
         for (i, slot) in app.plot_slots.iter().enumerate() {
             if i < slot_fft_points.len() && !slot_fft_points[i].is_empty() {
-                let short_name = if slot.key_name.len() > 12 {
-                    format!("{}...", &slot.key_name[..12])
-                } else {
-                    slot.key_name.clone()
-                };
+                let short_name = crate::data::truncate_key_name(&slot.key_name, 12);
                 datasets.push(
                     Dataset::default()
                         .name(short_name)
@@ -1995,6 +1983,55 @@ impl App {
 mod tests {
     use super::*;
     use ratatui::{backend::TestBackend, Terminal};
+
+    // ─── #85: multi-byte key names must not panic ────────────
+
+    /// A slot named with 3-byte characters, chosen so byte 8 (the hover label
+    /// cut) and byte 12 (the legend cut) both land inside a character.
+    const MULTI_BYTE_KEY: &str = "テスト_ストリーム";
+
+    fn app_with_multi_byte_slot() -> App {
+        let mut app = App::new();
+        app.toggle_plot_slot(MULTI_BYTE_KEY);
+        app.plot_slots[0].data = (0..64).map(|i| (i as f64 * 0.1).sin()).collect();
+        app
+    }
+
+    // Covers both cuts in draw_signal_chart: the hover readout (>8) and the
+    // legend entry (>12). Three of the four sites run inside terminal.draw on
+    // the 50ms tick, so a panic here kills the process on the next frame.
+    #[test]
+    fn signal_chart_renders_a_multi_byte_key_name() {
+        let mut app = app_with_multi_byte_slot();
+        app.hover_data_x = Some(3.0);
+        app.hover_data_y = Some(0.5);
+
+        let backend = TestBackend::new(80, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = Rect::new(0, 0, 80, 20);
+                draw_signal_chart(frame, &mut app, area, " Signal ", Color::Cyan);
+            })
+            .unwrap();
+    }
+
+    // draw_fft_chart is only reachable after draw_signal_chart in the real
+    // layout, so it is called directly or the third site stays uncovered.
+    #[test]
+    fn fft_chart_renders_a_multi_byte_key_name() {
+        let mut app = app_with_multi_byte_slot();
+        app.fft_enabled = true;
+
+        let backend = TestBackend::new(80, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = Rect::new(0, 0, 80, 20);
+                draw_fft_chart(frame, &mut app, area, Color::Cyan);
+            })
+            .unwrap();
+    }
 
     #[test]
     fn title_bar_contains_version() {


### PR DESCRIPTION
Fixes #85.

Four sites shortened a plotted key's name with `&slot.key_name[..N]` after testing `key_name.len() > N`. `str::len()` counts **bytes**; `str` indexing requires a **char boundary**. Any name whose byte N lands inside a multi-byte character panicked:

```
end byte index 10 is not a char boundary; it is inside 'ン' (bytes 9..12 of string)
end byte index 8 is not a char boundary; it is inside 'ト' (bytes 6..9 of string)
end byte index 12 is not a char boundary; it is inside 'ス' (bytes 10..13 of string)
```

These are supported inputs, not an edge case — `scan_keys` drops only keys that fail UTF-8 *decoding*, so Japanese, Cyrillic and emoji names reach the plot slots by design. Three of the four sites run inside `terminal.draw()` on the 50ms tick, so the panic unwound out of `run_app` and killed the process on the next frame, before the user could press a key. The fourth fires on `x`, and `start_plot_settings` has no empty-data guard, so `p` then `x` on a plain string key was enough.

## The fix

One helper in `src/data.rs`, which both `app.rs` and `ui.rs` already import:

```rust
pub fn truncate_key_name(name: &str, max_chars: usize) -> String {
    match name.char_indices().nth(max_chars) {
        Some((byte_idx, _)) => format!("{}...", &name[..byte_idx]),
        None => name.to_string(),
    }
}
```

Testing and cutting in a single operation on a character index is the point: it removes the byte-count/char-boundary mismatch, so the bug cannot be reintroduced by copying the old pattern to a fifth site. All four call sites — `draw_signal_chart` hover readout (8) and legend (12), `draw_fft_chart` (12), `start_plot_settings` (10) — now call it. `grep -rn 'key_name\[\.\.' src/` returns nothing.

## Tests

Ten new tests: five on the helper in `data.rs`, three in `app.rs` (including the issue's cheapest repro — a slot with no data at all), and two `TestBackend` render tests in `ui.rs`. `draw_fft_chart` is only reachable after `draw_signal_chart` in the real layout, so it is called directly or that site stays uncovered.

**Each site was verified to panic without its fix, one at a time.** That mattered here: the legend cut is only reached *after* the hover cut, so fixing both together would have left the legend site unproven. I fixed three sites, re-ran, and confirmed the test then panicked at the fourth.

The key name in the render tests is chosen so byte 8 and byte 12 both land mid-character, covering both cuts in one render.

## Verification

`cargo build --locked --all-targets`, `--release`, `cargo test --locked` (125 passed, 12 ignored), `cargo test --locked -- --ignored` (12 passed), `cargo clippy --locked --all-targets -- -D warnings`, `cargo fmt --check` — all green.

## Note

`max_chars` counts characters, not terminal columns, so 12 CJK characters still occupy roughly 24 columns and the legend renders wider than the constant suggests. That is cosmetic width, not a crash, so it is left alone; `unicode-truncate` is already in the dependency graph transitively via ratatui if width-accurate trimming is wanted later.

## Merge order

`2.0.0` -> `2.0.2`, because #112 already claims `2.0.1`. **Merge #112 first** — if this lands first, #112 fails the version gate and needs a re-bump.