### PR TITLE
Cap collection fetches and make the cap configurable (#87, #43)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ The main thread owns all `App` state and renders UI. Background threads communic
 |----------|-------|---------|
 | `MAX_PLOT_SLOTS` | 4 | Simultaneous plotted keys |
 | `MAX_STREAM_ENTRIES` | 10 | In-memory stream entries (only last 5 displayed, last entry plotted) |
+| `DEFAULT_MAX_VALUE_ITEMS` | 1,000 | Collection elements fetched per value load (`--max-value-items`) |
 | `PLOT_WINDOW` | 2,000 | Auto-range visible data points |
 | `RATE_WINDOWS` | `[(1,"1s"),(5,"5s"),(10,"10s"),(20,"20s"),(30,"30s")]` | Multi-window averages shown in rate view header and value view |
 
@@ -148,3 +149,4 @@ There is no `tests/` directory: this is a binary-only crate with no lib target, 
 - `apply_plot_settings()` handles all field counts (X limits + per-slot Y limits) — no field count checks
 - One flag names where to connect. Connection info is built as `redis::ConnectionInfo`, never by formatting a URL string — a credential interpolated into a URL breaks on `/ # ? @`
 - Never pre-fill the edit popup through `from_utf8_lossy` — it is one-way, and `execute_edit` writes the field straight back. A non-UTF-8 string key opens in binary mode with an empty field instead; gate on `std::str::from_utf8`, never `is_binary()`
+- No value fetch may be unbounded: `get_value` caps collections at `max_value_items` and returns the true total in `LoadedValue`, so the pane can report what is hidden. Sets and hashes go through `SSCAN`/`HSCAN`, never `SMEMBERS`/`HGETALL`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "redis-tui"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-tui"
-version = "2.0.2"
+version = "2.0.3"
 edition = "2021"
 description = "A Redis TUI client inspired by Redis Insight"
 license = "BSD-3-Clause"

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -30,6 +30,7 @@ redis-tui [OPTIONS]
 | `--username <USERNAME>` | `REDIS_TUI_USERNAME` | Username for hosts without their own | None |
 | `--password <PASSWORD>` | `REDIS_TUI_PASSWORD` | Password for hosts without their own | None |
 | `-d, --db <DB>` | `REDIS_TUI_DB` | Database for hosts without their own | `0` |
+| `--max-value-items <N>` | `REDIS_TUI_MAX_VALUE_ITEMS` | Most list/set/zset/hash elements fetched per value load | `1000` |
 | `--rate-history <MINUTES>` | `REDIS_TUI_RATE_HISTORY` | Rolling window for the rate chart | `20` |
 | `--rate-avg-window <SECONDS>` | `REDIS_TUI_RATE_AVG_WINDOW` | Sliding average for the plotted rate line | `2` |
 | `--connect-retries <N>` | `REDIS_TUI_CONNECT_RETRIES` | Retries for a host that is not up yet | `5` |
@@ -126,6 +127,25 @@ attempt bounded by `--connect-timeout`. Hosts that never come up are reported an
 the session continues without them; if none come up at all, the run fails.
 
 In multi-host mode, keys from all hosts are aggregated into a single list. If the same key exists on multiple hosts, a collision warning is displayed when selecting it. The status bar shows which host each key belongs to.
+
+### Large Collections
+
+Lists, sets, sorted sets and hashes are read up to `--max-value-items` elements
+(1000 by default) rather than whole. Arrow-key navigation loads the selected
+key automatically, so without a cap, scrolling onto a large key pulls all of it
+into memory on the main thread and the interface stops responding.
+
+When a collection is larger than the cap the value pane says so:
+
+```
+Showing first 1000 of 5000000 — raise --max-value-items to see more
+```
+
+Sets and hashes are read with `SSCAN`/`HSCAN` and stopped at the cap, so the
+server never assembles the whole reply either. Lists and sorted sets take their
+first N in order, so the same elements appear on every load.
+
+Strings are never truncated: a partial binary value is a corrupt one.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ redis-tui --hosts redis://:password@host:6379/2
 # Connect to several hosts at once, mixing the forms
 redis-tui --hosts db1 db2:6380 redis://svc:pw@db3/2
 
+# Load more of each large collection (default 1000 elements)
+redis-tui --max-value-items 5000
+
 # Widen the ingestion rate chart to an hour, averaged over 5s
 redis-tui --rate-history 60 --rate-avg-window 5
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,6 +13,9 @@ pub const MAX_PLOT_SLOTS: usize = 4;
 /// Only the newest entries are needed for display (last 5 shown)
 /// and plot extraction (last entry's waveform).
 pub const MAX_STREAM_ENTRIES: usize = 10;
+/// Default cap on collection elements fetched per value load. Overridable with
+/// --max-value-items / REDIS_TUI_MAX_VALUE_ITEMS.
+pub const DEFAULT_MAX_VALUE_ITEMS: usize = 1_000;
 
 /// Colors assigned to each plot slot
 pub const PLOT_COLORS: [Color; MAX_PLOT_SLOTS] =
@@ -366,6 +369,11 @@ pub struct App {
     pub new_key_type_idx: usize,      // index into KEY_TYPES for new key creation
     pub edit_binary_mode: bool,       // encode values as binary blobs
     pub edit_binary_dtype_idx: usize, // index into DataType::all() for binary encoding
+    /// Most collection elements fetched per value load (--max-value-items)
+    pub max_value_items: usize,
+    /// True length of the loaded collection, when it is one. Compared against
+    /// what was actually loaded to report how much is hidden.
+    pub value_total_items: Option<usize>,
 
     // Signal generator state
     pub signal_gen_fields: Vec<(String, String)>,
@@ -466,6 +474,8 @@ impl App {
             new_key_type_idx: 0,
             edit_binary_mode: false,
             edit_binary_dtype_idx: 6, // Float32 default
+            max_value_items: DEFAULT_MAX_VALUE_ITEMS,
+            value_total_items: None,
 
             signal_gen_fields: Vec::new(),
             signal_gen_focus: 0,
@@ -835,6 +845,25 @@ impl App {
         }
     }
 
+    /// `(shown, total)` when the loaded collection is larger than what was
+    /// loaded, so the pane can say so. Truncation the user cannot see is the
+    /// same quiet wrongness as showing a mangled value: partial data reads as
+    /// complete.
+    pub fn value_truncation(&self) -> Option<(usize, usize)> {
+        let total = self.value_total_items?;
+        let shown = match self.current_value.as_ref()? {
+            RedisValue::List(v) | RedisValue::Set(v) => v.len(),
+            RedisValue::ZSet(v) => v.len(),
+            RedisValue::Hash(v) => v.len(),
+            _ => return None,
+        };
+        if total > shown {
+            Some((shown, total))
+        } else {
+            None
+        }
+    }
+
     pub fn load_selected_value(&mut self, client: &mut MultiRedisClient) {
         if let Some(idx) = self.key_list_state.selected() {
             if idx < self.keys.len() {
@@ -860,8 +889,10 @@ impl App {
                     }
                 }
 
-                match client.get_value(key) {
-                    Ok(mut value) => {
+                match client.get_value(key, self.max_value_items) {
+                    Ok(loaded) => {
+                        self.value_total_items = loaded.total_items;
+                        let mut value = loaded.value;
                         // Cap stream entries to prevent OOM on large streams
                         cap_stream_entries(&mut value);
                         // Track last stream ID for XREAD polling
@@ -877,6 +908,7 @@ impl App {
                     Err(e) => {
                         self.status_message = format!("Error reading value: {}", e);
                         self.current_value = None;
+                        self.value_total_items = None;
                         self.plot_data.clear();
                         self.last_stream_id = None;
                     }
@@ -2346,6 +2378,42 @@ mod tests {
             !app.edit_binary_mode,
             "binary mode leaked from the previous edit"
         );
+    }
+
+    // ─── #87: truncation must be visible, not silent ─────────
+
+    fn app_with_loaded_list(shown: usize, total: usize) -> App {
+        let mut app = App::new();
+        app.current_value = Some(RedisValue::List(
+            (0..shown)
+                .map(|i| format!("item-{}", i).into_bytes())
+                .collect(),
+        ));
+        app.value_total_items = Some(total);
+        app
+    }
+
+    // Showing 1000 of 5,000,000 without saying so is the same class of quiet
+    // wrongness as #82: the user reads partial data as complete.
+    #[test]
+    fn a_capped_collection_reports_what_is_hidden() {
+        let app = app_with_loaded_list(1000, 5_000_000);
+        assert_eq!(app.value_truncation(), Some((1000, 5_000_000)));
+    }
+
+    #[test]
+    fn a_whole_collection_reports_no_truncation() {
+        let app = app_with_loaded_list(7, 7);
+        assert_eq!(app.value_truncation(), None);
+    }
+
+    // A string has no item count, so nothing may claim it was truncated.
+    #[test]
+    fn a_string_never_reports_truncation() {
+        let mut app = App::new();
+        app.current_value = Some(RedisValue::String(b"hello".to_vec()));
+        app.value_total_items = None;
+        assert_eq!(app.value_truncation(), None);
     }
 
     // ─── #85: multi-byte key names must not panic ────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,12 @@ struct Args {
           value_parser = clap::value_parser!(u64).range(1..))]
     rate_avg_window: u64,
 
+    /// Most collection elements fetched per value load. Guards against a
+    /// single large list or hash stalling the UI.
+    #[arg(long, default_value_t = app::DEFAULT_MAX_VALUE_ITEMS as u64, env = "REDIS_TUI_MAX_VALUE_ITEMS",
+          value_parser = clap::value_parser!(u64).range(1..))]
+    max_value_items: u64,
+
     /// Retry attempts for a host that is not up yet
     #[arg(long, default_value_t = 5, env = "REDIS_TUI_CONNECT_RETRIES",
           value_parser = clap::value_parser!(u32).range(0..))]
@@ -132,6 +138,7 @@ fn main() -> Result<()> {
         &mut client,
         args.rate_history * 60,
         args.rate_avg_window,
+        args.max_value_items as usize,
     );
 
     // Restore terminal
@@ -301,12 +308,14 @@ fn run_app(
     client: &mut MultiRedisClient,
     rate_history_secs: u64,
     rate_avg_window_secs: u64,
+    max_value_items: usize,
 ) -> Result<()> {
     let mut app = App::new();
     app.db = client.db;
     app.host_count = client.host_count();
     app.rate_history_secs = rate_history_secs;
     app.rate_avg_window_secs = rate_avg_window_secs;
+    app.max_value_items = max_value_items;
 
     // Initial key load
     app.refresh_keys(client);
@@ -489,8 +498,10 @@ fn run_app(
                                     let added = app.toggle_plot_slot(&k);
                                     if added {
                                         // Fetch value directly from Redis for this key
-                                        if let Ok(value) = client.get_value(&k) {
-                                            app.update_slot_data(&k, &value);
+                                        if let Ok(loaded) =
+                                            client.get_value(&k, app.max_value_items)
+                                        {
+                                            app.update_slot_data(&k, &loaded.value);
                                         }
                                         app.plot_visible = true;
                                         app.status_message = format!(
@@ -1659,7 +1670,17 @@ mod tests {
     }
 
     #[test]
+    fn max_value_items_defaults_and_accepts_an_override() {
+        let a = Args::try_parse_from(["redis-tui"]).unwrap();
+        assert_eq!(a.max_value_items, app::DEFAULT_MAX_VALUE_ITEMS as u64);
+        let a = Args::try_parse_from(["redis-tui", "--max-value-items", "50"]).unwrap();
+        assert_eq!(a.max_value_items, 50);
+    }
+
+    #[test]
     fn numeric_ranges_are_still_enforced() {
+        // Zero would load nothing at all, which reads as an empty key.
+        assert!(Args::try_parse_from(["redis-tui", "--max-value-items", "0"]).is_err());
         assert!(Args::try_parse_from(["redis-tui", "--connect-timeout", "0"]).is_err());
         assert!(Args::try_parse_from(["redis-tui", "--rate-history", "0"]).is_err());
         assert!(Args::try_parse_from(["redis-tui", "--rate-avg-window", "0"]).is_err());
@@ -1675,6 +1696,7 @@ mod tests {
             "REDIS_TUI_DB",
             "REDIS_TUI_RATE_HISTORY",
             "REDIS_TUI_RATE_AVG_WINDOW",
+            "REDIS_TUI_MAX_VALUE_ITEMS",
             "REDIS_TUI_CONNECT_RETRIES",
             "REDIS_TUI_CONNECT_TIMEOUT",
         ] {

--- a/src/redis_client.rs
+++ b/src/redis_client.rs
@@ -20,6 +20,33 @@ pub struct StreamEntry {
 }
 
 /// The value of a Redis key, typed by its Redis data type
+/// A loaded value plus how much of it exists.
+///
+/// `total_items` is `Some(n)` for a collection, whether or not it was capped -
+/// the pane compares it against what it received to report what is hidden -
+/// and `None` for types that are not collections.
+#[derive(Debug, Clone)]
+pub struct LoadedValue {
+    pub value: RedisValue,
+    pub total_items: Option<usize>,
+}
+
+impl LoadedValue {
+    fn whole(value: RedisValue) -> Self {
+        LoadedValue {
+            value,
+            total_items: None,
+        }
+    }
+
+    fn capped(value: RedisValue, total: usize) -> Self {
+        LoadedValue {
+            value,
+            total_items: Some(total),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum RedisValue {
     String(Vec<u8>),
@@ -178,50 +205,91 @@ impl RedisClient {
         })
     }
 
-    pub fn get_value(&mut self, key: &str) -> Result<RedisValue> {
+    /// Read a key's value, fetching at most `max_items` elements of a
+    /// collection.
+    ///
+    /// Nothing here may fetch a collection whole. Arrow-key navigation
+    /// auto-loads the selected key, so an unbounded LRANGE/SMEMBERS/HGETALL
+    /// meant merely scrolling onto a large key pulled all of it onto the main
+    /// thread (#87). Sets and hashes are read through SSCAN/HSCAN and stopped
+    /// at the cap rather than fetched and trimmed, so the server never
+    /// materialises the whole reply either.
+    ///
+    /// `total_items` carries the collection's true length so the pane can say
+    /// how much is hidden. Strings are not collections: they are returned
+    /// whole, because truncating a binary payload corrupts it.
+    pub fn get_value(&mut self, key: &str, max_items: usize) -> Result<LoadedValue> {
         let key_type: String = redis::cmd("TYPE")
             .arg(key)
             .query(&mut self.connection)
             .unwrap_or_else(|_| "unknown".to_string());
 
+        // COUNT is a per-batch hint: large enough to avoid a round trip per
+        // element, small enough not to undo the cap on a huge collection.
+        let scan_hint = max_items.clamp(10, 1000);
+
         match key_type.as_str() {
             "string" => {
                 let val: Vec<u8> = self.connection.get(key).context("Failed to GET")?;
-                Ok(RedisValue::String(val))
+                Ok(LoadedValue::whole(RedisValue::String(val)))
             }
             "list" => {
+                let total: usize = self.connection.llen(key).context("Failed to LLEN")?;
                 let vals: Vec<Vec<u8>> = self
                     .connection
-                    .lrange(key, 0, -1)
+                    .lrange(key, 0, max_items as isize - 1)
                     .context("Failed to LRANGE")?;
-                Ok(RedisValue::List(vals))
+                Ok(LoadedValue::capped(RedisValue::List(vals), total))
             }
             "set" => {
-                let vals: Vec<Vec<u8>> = self
-                    .connection
-                    .smembers(key)
-                    .context("Failed to SMEMBERS")?;
-                Ok(RedisValue::Set(vals))
+                let total: usize = self.connection.scard(key).context("Failed to SCARD")?;
+                let iter: redis::Iter<Vec<u8>> = redis::cmd("SSCAN")
+                    .arg(key)
+                    .cursor_arg(0)
+                    .arg("COUNT")
+                    .arg(scan_hint)
+                    .clone()
+                    .iter(&mut self.connection)
+                    .context("Failed to SSCAN")?;
+                let mut vals = Vec::new();
+                for item in iter.take(max_items) {
+                    vals.push(item.context("Failed to read a set member")?);
+                }
+                Ok(LoadedValue::capped(RedisValue::Set(vals), total))
             }
             "zset" => {
+                let total: usize = self.connection.zcard(key).context("Failed to ZCARD")?;
                 let vals: Vec<(Vec<u8>, f64)> = self
                     .connection
-                    .zrange_withscores(key, 0, -1)
-                    .context("Failed to ZRANGEBYSCORE")?;
-                Ok(RedisValue::ZSet(vals))
+                    .zrange_withscores(key, 0, max_items as isize - 1)
+                    .context("Failed to ZRANGE")?;
+                Ok(LoadedValue::capped(RedisValue::ZSet(vals), total))
             }
             "hash" => {
-                let map: HashMap<String, Vec<u8>> =
-                    self.connection.hgetall(key).context("Failed to HGETALL")?;
-                let mut pairs: Vec<(String, Vec<u8>)> = map.into_iter().collect();
+                let total: usize = self.connection.hlen(key).context("Failed to HLEN")?;
+                let iter: redis::Iter<(String, Vec<u8>)> = redis::cmd("HSCAN")
+                    .arg(key)
+                    .cursor_arg(0)
+                    .arg("COUNT")
+                    .arg(scan_hint)
+                    .clone()
+                    .iter(&mut self.connection)
+                    .context("Failed to HSCAN")?;
+                let mut pairs: Vec<(String, Vec<u8>)> = Vec::new();
+                for item in iter.take(max_items) {
+                    pairs.push(item.context("Failed to read a hash field")?);
+                }
                 pairs.sort_by(|a, b| a.0.cmp(&b.0));
-                Ok(RedisValue::Hash(pairs))
+                Ok(LoadedValue::capped(RedisValue::Hash(pairs), total))
             }
             "stream" => {
                 let entries = self.get_stream_entries(key)?;
-                Ok(RedisValue::Stream(entries))
+                Ok(LoadedValue::whole(RedisValue::Stream(entries)))
             }
-            other => Ok(RedisValue::Unknown(format!("Unsupported type: {}", other))),
+            other => Ok(LoadedValue::whole(RedisValue::Unknown(format!(
+                "Unsupported type: {}",
+                other
+            )))),
         }
     }
 
@@ -722,8 +790,8 @@ impl MultiRedisClient {
         self.client_for_key(key).get_key_info(key)
     }
 
-    pub fn get_value(&mut self, key: &str) -> Result<RedisValue> {
-        self.client_for_key(key).get_value(key)
+    pub fn get_value(&mut self, key: &str, max_items: usize) -> Result<LoadedValue> {
+        self.client_for_key(key).get_value(key, max_items)
     }
 
     pub fn delete_key(&mut self, key: &str) -> Result<()> {
@@ -1054,7 +1122,117 @@ mod tests {
         assert_eq!(client.db, 0);
     }
 
-    /// End-to-end: the skipped count must reach the status line the user actually reads.
+    // ─── #87: collection fetches must be bounded ─────────────
+
+    /// Seed `n` members of each collection type, then read them back with a
+    /// cap far below `n`.
+    fn seed_big_collections(url: &str, n: usize) {
+        let mut c = RedisClient::connect(url).unwrap();
+        let mut lpush = redis::cmd("RPUSH");
+        lpush.arg("big:list");
+        let mut sadd = redis::cmd("SADD");
+        sadd.arg("big:set");
+        let mut zadd = redis::cmd("ZADD");
+        zadd.arg("big:zset");
+        let mut hset = redis::cmd("HSET");
+        hset.arg("big:hash");
+        for i in 0..n {
+            lpush.arg(format!("item-{:06}", i));
+            sadd.arg(format!("member-{:06}", i));
+            zadd.arg(i as f64).arg(format!("scored-{:06}", i));
+            hset.arg(format!("field-{:06}", i)).arg(i);
+        }
+        for cmd in [&lpush, &sadd, &zadd, &hset] {
+            cmd.query::<()>(&mut c.connection).unwrap();
+        }
+    }
+
+    // The reported hang: arrow-key navigation auto-loads the selected key, so
+    // merely scrolling onto a large collection pulled the whole thing into
+    // memory on the main thread. Every collection type must stop at the cap.
+    #[test]
+    #[ignore = "requires redis-server; run with: cargo test -- --ignored"]
+    fn every_collection_type_is_capped_at_max_items() {
+        let server = TestRedis::start();
+        seed_big_collections(&server.url(), 5000);
+        let mut c = RedisClient::connect(&server.url()).unwrap();
+
+        for key in ["big:list", "big:set", "big:zset", "big:hash"] {
+            let loaded = c.get_value(key, 100).unwrap();
+            let n = match &loaded.value {
+                RedisValue::List(v) | RedisValue::Set(v) => v.len(),
+                RedisValue::ZSet(v) => v.len(),
+                RedisValue::Hash(v) => v.len(),
+                other => panic!("{} loaded as {:?}", key, other),
+            };
+            assert_eq!(n, 100, "{} should stop at the cap, got {}", key, n);
+            assert_eq!(
+                loaded.total_items,
+                Some(5000),
+                "{} should report its true length",
+                key
+            );
+        }
+    }
+
+    // Under the cap nothing is hidden, and the totals still agree.
+    #[test]
+    #[ignore = "requires redis-server; run with: cargo test -- --ignored"]
+    fn a_small_collection_is_returned_whole() {
+        let server = TestRedis::start();
+        seed_big_collections(&server.url(), 7);
+        let mut c = RedisClient::connect(&server.url()).unwrap();
+
+        for key in ["big:list", "big:set", "big:zset", "big:hash"] {
+            let loaded = c.get_value(key, 100).unwrap();
+            assert_eq!(loaded.total_items, Some(7), "{}", key);
+        }
+    }
+
+    // A list keeps insertion order, so the cap must take the *first* N rather
+    // than an arbitrary N -- otherwise the pane shows different data per load.
+    #[test]
+    #[ignore = "requires redis-server; run with: cargo test -- --ignored"]
+    fn a_capped_list_keeps_its_first_items_in_order() {
+        let server = TestRedis::start();
+        seed_big_collections(&server.url(), 500);
+        let mut c = RedisClient::connect(&server.url()).unwrap();
+
+        let loaded = c.get_value("big:list", 3).unwrap();
+        match loaded.value {
+            RedisValue::List(v) => {
+                let got: Vec<String> = v
+                    .iter()
+                    .map(|b| String::from_utf8_lossy(b).into())
+                    .collect();
+                assert_eq!(got, vec!["item-000000", "item-000001", "item-000002"]);
+            }
+            other => panic!("expected a list, got {:?}", other),
+        }
+    }
+
+    // Strings are not collections: the cap must not truncate binary payloads,
+    // which would corrupt them exactly as #82 did.
+    #[test]
+    #[ignore = "requires redis-server; run with: cargo test -- --ignored"]
+    fn a_string_is_never_truncated_by_the_item_cap() {
+        let server = TestRedis::start();
+        let blob: Vec<u8> = (0..4000u32).map(|i| (i % 251) as u8).collect();
+        let mut seed = RedisClient::connect(&server.url()).unwrap();
+        redis::cmd("SET")
+            .arg("blob")
+            .arg(&blob)
+            .query::<()>(&mut seed.connection)
+            .unwrap();
+
+        let loaded = seed.get_value("blob", 10).unwrap();
+        match loaded.value {
+            RedisValue::String(b) => assert_eq!(b, blob, "the string was truncated"),
+            other => panic!("expected a string, got {:?}", other),
+        }
+        assert_eq!(loaded.total_items, None, "a string has no item count");
+    }
+
     // #82: the exact reported sequence -- select a binary key, press `s`, press
     // Enter without typing anything -- grew a 4000-byte float32 blob to 6847
     // bytes of U+FFFD. It must now leave the bytes untouched.
@@ -1245,6 +1423,7 @@ mod tests {
         );
     }
 
+    /// End-to-end: the skipped count must reach the status line the user actually reads.
     #[test]
     #[ignore = "requires redis-server; run with: cargo test -- --ignored"]
     fn refresh_keys_status_line_reports_skipped_keys() {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -245,6 +245,20 @@ fn draw_value_view(frame: &mut Frame, app: &mut App, area: Rect) {
         )));
     }
 
+    // Say so when the collection was capped. Partial data that looks complete
+    // is worse than slow data.
+    if let Some((shown, total)) = app.value_truncation() {
+        lines.push(Line::from(Span::styled(
+            format!(
+                "Showing first {} of {} — raise --max-value-items to see more",
+                shown, total
+            ),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )));
+    }
+
     // Ingestion rate summary — shown for stream keys being actively listened to
     if let Some(key) = app.selected_key_name() {
         let is_stream = app
@@ -1983,6 +1997,45 @@ impl App {
 mod tests {
     use super::*;
     use ratatui::{backend::TestBackend, Terminal};
+
+    // ─── #87: a capped collection must say so ────────────────
+
+    #[test]
+    fn the_value_view_announces_a_capped_collection() {
+        let mut app = App::new();
+        app.current_key_info = Some(crate::redis_client::KeyInfo {
+            name: "big:list".to_string(),
+            key_type: "list".to_string(),
+            ttl: -1,
+            size: 4096,
+            encoding: "quicklist".to_string(),
+        });
+        app.current_value = Some(crate::redis_client::RedisValue::List(
+            (0..5).map(|i| format!("item-{}", i).into_bytes()).collect(),
+        ));
+        app.value_total_items = Some(5000);
+
+        let backend = TestBackend::new(90, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| draw_value_view(frame, &mut app, Rect::new(0, 0, 90, 24)))
+            .unwrap();
+
+        let buf = terminal.backend().buffer().clone();
+        let text: String = (0..24)
+            .map(|y| {
+                (0..90)
+                    .map(|x| buf.cell((x, y)).unwrap().symbol().to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            text.contains("Showing first 5 of 5000"),
+            "the pane must say what is hidden:\n{}",
+            text
+        );
+    }
 
     // ─── #85: multi-byte key names must not panic ────────────
 


### PR DESCRIPTION
Fixes #87. Fixes #43.

`get_value` fetched list, set, zset and hash values in their entirety — `LRANGE 0 -1`, `SMEMBERS`, `ZRANGE WITHSCORES`, `HGETALL` — with no cap of any kind. Only the stream path was bounded.

The user never opted in: `load_selected_value` auto-loads on arrow-key navigation, so **merely scrolling the selection onto a large collection** pulled the whole thing onto the main thread. The reporter measured one Down keypress onto a 5M-element list taking the TUI from 4 MB RSS / 0% CPU to ~1.3 GB with the CPU pinned — and it stayed pinned, because `format_value` rebuilds one `String` per element on *every frame* at the 50 ms tick.

## What changed

**The fetch is bounded.** Collections load up to `--max-value-items` (default 1000), settable as `REDIS_TUI_MAX_VALUE_ITEMS` — which is #43, and the reason the two are one PR: the cap needs a number, and #43 is the request for that number to be configurable.

- **Sets and hashes** go through `SSCAN`/`HSCAN` and stop at the cap, so the *server* never assembles the whole reply either. Trimming a completed `SMEMBERS` would have fixed the client and left the stall in place.
- **Lists and sorted sets** take their first N in order, so the same elements appear on every load rather than an arbitrary sample.
- **Strings are untouched.** Truncating a binary payload corrupts it — exactly what #82 fixed — so the item cap does not apply to them. There's a test asserting that.

**Truncation is visible, not silent.** `get_value` now returns `LoadedValue`, carrying the collection's true length from `LLEN`/`SCARD`/`ZCARD`/`HLEN`, and the value pane says:

```
Showing first 1000 of 5000000 — raise --max-value-items to see more
```

This mattered enough to be part of the fix rather than a follow-up: showing 1000 of 5,000,000 items *without saying so* is the same class of quiet wrongness as the mangled values in #82. The user reads partial data as complete.

## Tests

Four `#[ignore]`d live tests against a throwaway `redis-server`, seeding 5000 members of every collection type: each type stops at the cap and reports its true total; a small collection comes back whole; a capped list keeps its *first* items in order; and a string is never truncated by the item cap.

**Verified they fail without the fix** — I reverted all four caps and re-ran: `big:list should stop at the cap, got 5000`.

Plus five unit tests: three on `App::value_truncation`, one `TestBackend` test that the notice actually renders in the pane, and one on the new flag's default and override. `REDIS_TUI_MAX_VALUE_ITEMS` was added to the existing `--help` contract test.

## Verification

`cargo build --locked --all-targets`, `--release`, `cargo test --locked` (135 passed, 17 ignored), `cargo test --locked -- --ignored` (17 passed), `cargo clippy --locked --all-targets -- -D warnings`, `cargo fmt --check` — all green. `grep` confirms no unbounded collection fetch remains.

## Notes

- **Cost:** one extra round trip per value load, for the count. `get_key_info` already does four, and this buys an honest "N of M" rather than a vague "there may be more".
- **Not addressed:** #8 (O(N) round-trips on key *refresh*) is adjacent but a different change — the ranked plan sequences it after this.
- Also reattaches a doc comment in the test module that my own #112 left describing the wrong test.

`2.0.2` -> `2.0.3`.