### PR TITLE
Start the dev nodes on free ports instead of taking over 6379/6380 (#117)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,9 @@ docker run -it --rm --network host redis-tui
 ```bash
 ./start-dev.sh    # 2 Redis instances + test data + 3 live stream devices, launches TUI in multi-host mode
 
+# Ports are OS-assigned and printed on startup; pin them only if you need to:
+REDIS_PORT_1=7001 REDIS_PORT_2=7002 ./start-dev.sh
+
 # The devices alone (start-dev.sh runs three of these and reaps them on exit):
 ./stream-device.py --port 6379 --stream device:test --rate 500 --samples 1024
 ```
@@ -156,4 +159,5 @@ There is no `tests/` directory: this is a binary-only crate with no lib target, 
 - `scan_keys` drives the SCAN cursor by hand — never `Cmd::iter`. Its errors arrive through the same `Result` as a UTF-8 decode failure and do not advance the cursor, so treating every `Err` as a skippable key name re-issues the same SCAN forever
 - Nothing reachable from `run_app` may print to stdout or stderr: raw mode owns the alternate screen. Per-host scan failures travel back as `MultiRedisClient::host_errors` and land on the status line. The `eprintln!`s in `from_entries` are fine — they run before raw mode
 - `stream-device.py` simulates an instrumentation device: continuous float32 waveforms via `XADD <key> * source device _ <blob>` plus `XTRIM MAXLEN ~`. It speaks RESP over a stdlib socket — the `redis` python package is not a dependency, and one `redis-cli` per entry cannot hold 1200 entries/s. Phase carries across entries so the waveform is continuous and the FFT view shows a signal rather than a per-entry discontinuity
+- `start-dev.sh` only ever talks to servers it started itself, on OS-assigned ports (the `TestRedis` trick: bind `127.0.0.1:0`, read the port, release it) in their own `--dir`, killed by one `trap cleanup EXIT INT TERM`. It once treated a `PING` answer on 6379/6380 as its own node and ran `FLUSHALL`, which emptied whatever system Redis or Valkey was there (#117). A `PING` reply is not proof of ownership — the readiness check compares `INFO server`'s `process_id` against the pid it spawned, because when the port is taken the child dies and the incumbent answers instead. Never reintroduce an adopt-if-running path, and never `FLUSHALL`
 - The stream drain is bounded by time, never by message count: `drained += 1` per message capped throughput at 400 messages/s regardless of entries carried, and a producer writing entries individually above that grew the channel without bound. `drain_listener` coalesces a listener's whole queue into one batch under a 10ms budget

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "redis-tui"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-tui"
-version = "2.0.5"
+version = "2.0.6"
 edition = "2021"
 description = "A Redis TUI client inspired by Redis Insight"
 license = "BSD-3-Clause"

--- a/README.md
+++ b/README.md
@@ -73,10 +73,22 @@ The included `start-dev.sh` script starts two local Redis instances, loads test 
 ./start-dev.sh
 ```
 
+Both instances run on ports the OS assigns, in their own temporary directories,
+and are shut down when the script exits. It never connects to a Redis it did not
+start, so a server already running on this machine is left alone. The ports it
+picked are printed on startup and in the summary. To pin them instead — handy for
+attaching `redis-cli` — set `REDIS_PORT_1` and `REDIS_PORT_2`; if either is
+already in use the script stops rather than using what is there:
+
+```bash
+REDIS_PORT_1=7001 REDIS_PORT_2=7002 ./start-dev.sh
+```
+
 The devices write continuously to `device:slow` (10 entries/s), `device:medium`
 (200/s) and `device:fast` (1200/s), so the stream listener (`l`), ingestion rate
 view (`i`) and live plotting have something moving to show. They are stopped
-when the TUI exits. `stream-device.py` also runs standalone:
+when the TUI exits. `stream-device.py` also runs standalone, against a server of
+your own:
 
 ```bash
 ./stream-device.py --port 6379 --stream device:test --rate 500 --samples 1024

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -1,15 +1,26 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Both nodes run with persistence off (--save '' --appendonly no).
-# Without it redis writes dump.rdb into whatever directory it was launched
-# from, which is the repo root, and the live tests then adopt that file as
-# their starting dataset - `dir` defaults to the working directory and an
-# existing dump.rdb is loaded at boot whether or not saving is enabled.
-# This is throwaway fixture data that FLUSHALL rebuilds on every run, so
-# there is nothing here worth persisting.
-REDIS_PORT_1=6379
-REDIS_PORT_2=6380
+# Both nodes are started by this script, on ports the OS hands out, into their
+# own data directories, and are killed when it exits.
+#
+# They used to be fixed at 6379/6380 and the script treated a PING answer there
+# as "our node is already up", adopted it, and ran FLUSHALL. On any machine with
+# a system redis-server or valkey on 6379 - which is what `apt install
+# redis-server` gives you, and what the missing-dependency message above tells
+# you to install - that emptied a real server, and its save points wrote the
+# loss straight to disk. See #117.
+#
+# Nothing is adopted now, so there is no FLUSHALL: a server we just started is
+# already empty. Persistence is off (--save '' --appendonly no) and each node
+# gets its own --dir, so no dump.rdb can land in the repo root, where the live
+# tests would otherwise load it as their starting dataset.
+#
+# Set REDIS_PORT_1/REDIS_PORT_2 to pin the ports - useful for attaching redis-cli
+# or a second client - but then they must be free, and anything already there is
+# a fatal error rather than something to take over.
+REDIS_PORT_1="${REDIS_PORT_1:-}"
+REDIS_PORT_2="${REDIS_PORT_2:-}"
 
 echo "=== Redis TUI Dev Environment (Multi-Host) ==="
 
@@ -38,42 +49,136 @@ if ! command -v python3 &>/dev/null; then
     exit 1
 fi
 
-# ─── Start Redis Node 1 ──────────────────────────────────
-if redis-cli -p "$REDIS_PORT_1" ping &>/dev/null; then
-    echo "[*] Redis node 1 already running on port $REDIS_PORT_1"
-else
-    echo "[*] Starting redis node 1 on port $REDIS_PORT_1..."
-    redis-server --port "$REDIS_PORT_1" --daemonize yes --loglevel warning \
-        --save '' --appendonly no
-    sleep 1
-    if ! redis-cli -p "$REDIS_PORT_1" ping &>/dev/null; then
-        echo "ERROR: Failed to start redis node 1"
-        exit 1
-    fi
-    echo "[*] Node 1 started (PID $(redis-cli -p "$REDIS_PORT_1" INFO server | grep process_id | tr -d '\r' | cut -d: -f2))"
-fi
+# ─── Server and device lifecycle ─────────────────────────
+# Everything this script starts is torn down here, however it ends: a clean
+# quit, Ctrl-C, or a failure under `set -e`. The trap is installed before the
+# first server so a failure part-way through startup cannot leak one.
+REDIS_PIDS=()
+REDIS_DIRS=()
+DEVICE_PIDS=()
 
-# ─── Start Redis Node 2 ──────────────────────────────────
-if redis-cli -p "$REDIS_PORT_2" ping &>/dev/null; then
-    echo "[*] Redis node 2 already running on port $REDIS_PORT_2"
-else
-    echo "[*] Starting redis node 2 on port $REDIS_PORT_2..."
-    redis-server --port "$REDIS_PORT_2" --daemonize yes --loglevel warning \
-        --save '' --appendonly no
-    sleep 1
-    if ! redis-cli -p "$REDIS_PORT_2" ping &>/dev/null; then
-        echo "ERROR: Failed to start redis node 2"
-        exit 1
+cleanup() {
+    if [ ${#DEVICE_PIDS[@]} -gt 0 ]; then
+        kill "${DEVICE_PIDS[@]}" 2>/dev/null || true
+        wait "${DEVICE_PIDS[@]}" 2>/dev/null || true
     fi
-    echo "[*] Node 2 started (PID $(redis-cli -p "$REDIS_PORT_2" INFO server | grep process_id | tr -d '\r' | cut -d: -f2))"
-fi
+    if [ ${#REDIS_PIDS[@]} -gt 0 ]; then
+        kill "${REDIS_PIDS[@]}" 2>/dev/null || true
+        wait "${REDIS_PIDS[@]}" 2>/dev/null || true
+    fi
+    if [ ${#REDIS_DIRS[@]} -gt 0 ]; then
+        rm -rf "${REDIS_DIRS[@]}"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+# Ask the OS for a free port by binding :0, reading what it assigned, and
+# releasing it. This is the same trick the live tests use (see TestRedis in
+# src/redis_client.rs), for the same reason: a fixed or sequential range
+# collides with whatever else is on the machine.
+free_port() {
+    python3 -c 'import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()'
+}
+
+# start_node <label> <env-var-name> <requested-port-or-empty>
+#
+# Sets STARTED_PORT and STARTED_PID, and records the pid and data directory for
+# cleanup. Deliberately not called through $(...): command substitution runs the
+# function in a subshell, where the appends to REDIS_PIDS/REDIS_DIRS would be
+# discarded and the servers would leak.
+STARTED_PORT=""
+STARTED_PID=""
+start_node() {
+    local label="$1" var="$2" pinned="$3" port dir pid waited owner info attempt=0
+
+    dir="$(mktemp -d -t redis-tui-dev.XXXXXX)"
+    REDIS_DIRS+=("$dir")
+
+    while :; do
+        if [ -n "$pinned" ]; then
+            port="$pinned"
+        else
+            port="$(free_port)"
+        fi
+
+        redis-server --port "$port" --dir "$dir" --loglevel warning \
+            --save '' --appendonly no &>"$dir/server.log" &
+        pid=$!
+
+        # Wait for it to answer, or to exit - a taken port fails almost at once.
+        #
+        # A PING answer is not enough on its own. If something else already owns
+        # the port, our child dies but the incumbent answers the ping, and we
+        # would adopt a server we did not start - the #117 bug, reintroduced
+        # through the back door. So compare the responder's process_id with the
+        # pid we spawned and only accept our own.
+        # The INFO must not run bare: under `set -e` with pipefail, redis-cli
+        # exiting non-zero while the server is still binding would abort the
+        # whole script instead of retrying. Guarding it with `if` suppresses that.
+        waited=0
+        owner=""
+        while [ "$waited" -lt 50 ]; do
+            if info="$(redis-cli -p "$port" INFO server 2>/dev/null)"; then
+                owner="$(printf '%s' "$info" | tr -d '\r' \
+                    | sed -n 's/^process_id:\(.*\)$/\1/p')"
+            else
+                owner=""
+            fi
+            if [ -n "$owner" ]; then
+                if [ "$owner" = "$pid" ]; then
+                    REDIS_PIDS+=("$pid")
+                    STARTED_PORT="$port"
+                    STARTED_PID="$pid"
+                    return 0
+                fi
+                break   # someone else's server is on this port
+            fi
+            kill -0 "$pid" 2>/dev/null || break
+            sleep 0.1
+            waited=$((waited + 1))
+        done
+
+        kill "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+
+        # A pinned port that is taken is a hard error. Taking it over is exactly
+        # the behaviour #117 removed, so there is no retry and no adoption.
+        if [ -n "$pinned" ]; then
+            echo "ERROR: $label could not start on port $port."
+            if [ -n "$owner" ] && [ "$owner" != "$pid" ]; then
+                echo "       Another server (pid $owner) is already listening there."
+                echo "       This script will not take over a server it did not start."
+            fi
+            echo "       Port $port is pinned by $var; unset it to let the OS pick a free one."
+            sed -n '1,20p' "$dir/server.log" >&2 || true
+            exit 1
+        fi
+
+        attempt=$((attempt + 1))
+        if [ "$attempt" -ge 5 ]; then
+            echo "ERROR: could not start $label after $attempt attempts on OS-assigned ports."
+            sed -n '1,20p' "$dir/server.log" >&2 || true
+            exit 1
+        fi
+    done
+}
+
+echo "[*] Starting redis node 1..."
+start_node "node 1" REDIS_PORT_1 "$REDIS_PORT_1"
+REDIS_PORT_1="$STARTED_PORT"
+echo "[*] Node 1 up on port $REDIS_PORT_1 (PID $STARTED_PID)"
+
+echo "[*] Starting redis node 2..."
+start_node "node 2" REDIS_PORT_2 "$REDIS_PORT_2"
+REDIS_PORT_2="$STARTED_PORT"
+echo "[*] Node 2 up on port $REDIS_PORT_2 (PID $STARTED_PID)"
 
 CLI1="redis-cli -p $REDIS_PORT_1"
 CLI2="redis-cli -p $REDIS_PORT_2"
-
-echo "[*] Flushing existing data on both nodes..."
-$CLI1 FLUSHALL >/dev/null
-$CLI2 FLUSHALL >/dev/null
 
 # ═══════════════════════════════════════════════════════════
 # NODE 1 DATA
@@ -283,17 +388,12 @@ $CLI2 -n 1 HSET "db1:info" description "DB 1 on node 2" purpose "collision test"
 # (~400 entries/s), so the fast channel is deliberately past it.
 DEVICE_SCRIPT="$(dirname "$0")/stream-device.py"
 DEVICE_LOG="$(mktemp -t redis-tui-devices.XXXXXX.log)"
-DEVICE_PIDS=()
 
-stop_devices() {
-    if [ ${#DEVICE_PIDS[@]} -gt 0 ]; then
-        kill "${DEVICE_PIDS[@]}" 2>/dev/null || true
-        wait "${DEVICE_PIDS[@]}" 2>/dev/null || true
-    fi
-}
-# The TUI runs in the foreground, so this fires however it ends - quit, Ctrl-C
-# or a crash. Without it the devices outlive the script and keep writing.
-trap stop_devices EXIT INT TERM
+# DEVICE_PIDS and the trap that reaps them are declared with the server
+# lifecycle above. The TUI runs in the foreground, so `cleanup` fires however
+# this ends - quit, Ctrl-C or a crash - and stops the devices before the nodes
+# they write to. Do not install a second trap here: it would replace that one
+# and leak both servers.
 
 start_device() { # name rate samples
     "$DEVICE_SCRIPT" --port "$REDIS_PORT_1" --stream "device:$1" \


### PR DESCRIPTION
Fixes #117.

`start-dev.sh` treated a `PING` answer on 6379 or 6380 as "our node is already up", adopted that server, and ran `FLUSHALL` against it. The `--save '' --appendonly no` flags that make the data throwaway only ever applied to the branch that starts a server itself, so the file header's claim that both nodes run without persistence was false on exactly the path that mattered.

On Debian and Ubuntu that was the default path: the script's own missing-dependency message says to `sudo apt install redis-server`, which installs a systemd unit on 6379 carrying the distro save points. Running the script emptied a real server, and the save points wrote the loss to disk. It had already happened on a developer machine here.

## What changed

Both nodes are started by the script on ports the OS assigns, in their own temporary directories, and are killed when it exits. Nothing is adopted, so `FLUSHALL` is gone entirely rather than made conditional: a server we just started is already empty.

`REDIS_PORT_1` / `REDIS_PORT_2` pin the ports when that is useful, for attaching `redis-cli` or a second client. A pinned port already in use is a fatal error naming the incumbent pid, never something to take over.

One `trap cleanup EXIT INT TERM` reaps devices, then servers, then the temp directories. The later `trap stop_devices` is deleted; it would have replaced this one and leaked both servers.

## A PING reply is not proof of ownership

Worth calling out because it bit the first version of this fix. When the port is taken, our child dies and the *incumbent* answers the ping, so a naive readiness check adopts a foreign server through the pinned-port path — the same bug by another route. Caught in testing: with `REDIS_PORT_1=6379` the script cheerfully reported "Node 1 up on port 6379 (PID …)" and wrote fixture data into the system valkey.

The check now compares `INFO server`'s `process_id` against the pid we spawned and accepts only its own. The `INFO` runs inside an `if`, because under `set -e` with `pipefail` a bare assignment would abort the script when `redis-cli` fails during the moment the server is still binding.

## Verification

Run against this machine, which has a system valkey on 6379 with save points, using a canary key to prove it is untouched:

| Case | Result |
|---|---|
| Auto ports | Nodes on 41663/57281, 21 and 17 keys loaded, both reaped, temp dirs removed, valkey untouched |
| `REDIS_PORT_1`/`2` pinned to free ports | Nodes come up on exactly those ports, data loads |
| `REDIS_PORT_1=6379` (occupied) | Refuses: names incumbent pid 2016, exits 1, valkey and canary untouched |

`cargo test` 149 passed, `cargo test -- --ignored` 19 passed, clippy clean, `cargo fmt --check` clean, `shellcheck start-dev.sh` clean.

## Docs

README gains the port behaviour and the pinning example. CLAUDE.md gains the same under Dev environment, plus a Conventions entry recording the invariant and why a `PING` reply cannot stand in for ownership.